### PR TITLE
Add news component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9426,6 +9426,14 @@
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
             "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
         },
+        "moment-timezone": {
+            "version": "0.5.33",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+            "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+            "requires": {
+                "moment": ">= 2.9.0"
+            }
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
         "leaflet.locatecontrol": "^0.72.0",
         "material-ui-popup-state": "^1.6.1",
         "moment": "^2.27.0",
+        "moment-timezone": "^0.5.33",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-big-calendar": "^0.24.6",

--- a/client/src/api/endpoints.js
+++ b/client/src/api/endpoints.js
@@ -12,3 +12,4 @@ export const LOAD_DATA_ENDPOINT = endpointTransform('/api/users/loadUserData');
 export const SAVE_DATA_ENDPOINT = endpointTransform('/api/users/saveUserData');
 export const ENROLLMENT_DATA_ENDPOINT = endpointTransform('/api/enrollmentData');
 export const PETERPORTAL_DATA_ENDPOINT = endpointTransform('/api/peterportalapi');
+export const NEWS_ENDPOINT = endpointTransform('/api/news');

--- a/client/src/components/App/CustomAppBar.js
+++ b/client/src/components/App/CustomAppBar.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import { AppBar, Button, Toolbar, Tooltip } from '@material-ui/core';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
-import { Assignment, Info } from '@material-ui/icons';
+import { Assignment } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
 import NotificationHub from './NotificationHub';
 import SettingsMenu from './SettingsMenu';
 import { ReactComponent as Logo } from './logo.svg';
+import News from './News';
 
 const styles = {
     appBar: {
@@ -47,6 +48,8 @@ class CustomAppBar extends PureComponent {
                             Feedback
                         </Button>
                     </Tooltip>
+
+                    <News />
 
                     {/*<Tooltip title="Info Page">*/}
                     {/*<Button*/}

--- a/client/src/components/App/News.js
+++ b/client/src/components/App/News.js
@@ -39,7 +39,7 @@ class News extends PureComponent {
         anchorEl: null,
         newsItems: null,
         loading: true,
-        showDot: true,
+        showDot: false,
     };
 
     componentDidMount = async () => {
@@ -53,51 +53,41 @@ class News extends PureComponent {
                 const idOfLatestNewsItem = sortedNewsItems[0]['_id'];
                 const idOfLatestCheckedNewsItem = window.localStorage.getItem('idOfLatestCheckedNewsItem');
 
-                if (idOfLatestCheckedNewsItem !== null && idOfLatestNewsItem === idOfLatestCheckedNewsItem)
-                    this.setState({ showDot: false });
+                if (idOfLatestCheckedNewsItem === null || idOfLatestNewsItem !== idOfLatestCheckedNewsItem)
+                    this.setState({ showDot: true });
             }
         } catch (e) {
             console.error('Error loading news items:', e);
-            this.setState({ newsItems: null, loading: false, showDot: true });
+            this.setState({ newsItems: null, loading: false });
         }
     };
 
     getNewsItems = () => {
         const { classes } = this.props;
-        if (this.state.loading === false && this.state.newsItems !== null) {
-            if (this.state.newsItems.length === 0) {
+        if (this.state.loading === false && this.state.newsItems !== null && this.state.newsItems.length !== 0) {
+            return this.state.newsItems.map((newsItem, index) => {
                 return (
-                    <ListItem alignItems="flex-start" className={classes.listItem} dense>
-                        <Typography variant="body2" gutterBottom>
-                            No news items found
-                        </Typography>
-                    </ListItem>
+                    <Fragment key={newsItem['_id']}>
+                        <ListItem alignItems="flex-start" className={classes.listItem} dense>
+                            <Typography variant="body1" gutterBottom>
+                                {newsItem.title}
+                            </Typography>
+                            <Typography variant="body2" gutterBottom>
+                                {newsItem.body}
+                            </Typography>
+                            <Typography variant="caption" gutterBottom color="textSecondary">
+                                {moment(newsItem.date).tz('America/Los_Angeles').format('MMMM Do YYYY')}
+                            </Typography>
+                        </ListItem>
+                        {index !== this.state.newsItems.length - 1 ? <Divider /> : null}
+                    </Fragment>
                 );
-            } else {
-                return this.state.newsItems.map((newsItem, index) => {
-                    return (
-                        <Fragment key={newsItem['_id']}>
-                            <ListItem alignItems="flex-start" className={classes.listItem} dense>
-                                <Typography variant="body1" gutterBottom>
-                                    {newsItem.title}
-                                </Typography>
-                                <Typography variant="body2" gutterBottom>
-                                    {newsItem.body}
-                                </Typography>
-                                <Typography variant="caption" gutterBottom color="textSecondary">
-                                    {moment(newsItem.date).tz('America/Los_Angeles').format('MMMM Do YYYY')}
-                                </Typography>
-                            </ListItem>
-                            {index !== this.state.newsItems.length - 1 ? <Divider /> : null}
-                        </Fragment>
-                    );
-                });
-            }
-        } else if (this.state.loading === false && this.state.newsItems === null) {
+            });
+        } else if (this.state.loading === false) {
             return (
                 <ListItem alignItems="flex-start" className={classes.listItem} dense>
-                    <Typography variant="caption" gutterBottom>
-                        {'Error loading news items'}
+                    <Typography variant="body2" gutterBottom>
+                        No new announcements!
                     </Typography>
                 </ListItem>
             );

--- a/client/src/components/App/News.js
+++ b/client/src/components/App/News.js
@@ -31,7 +31,7 @@ class News extends PureComponent {
         try {
             const data = await fetch(NEWS_ENDPOINT);
             const json = await data.json();
-            this.setState({ newsItems: json.news, loading: false });
+            this.setState({ newsItems: json.news.sort((a, b) => (a.date > b.date ? -1 : 1)), loading: false });
         } catch (e) {
             console.error('Error loading news items:', e);
             this.setState({ newsItems: null, loading: false });
@@ -41,24 +41,34 @@ class News extends PureComponent {
     getNewsItems = () => {
         const { classes } = this.props;
         if (this.state.loading === false && this.state.newsItems !== null) {
-            return this.state.newsItems.map((newsItem, index) => {
+            if (this.state.newsItems.length === 0) {
                 return (
-                    <Fragment key={newsItem['_id']}>
-                        <ListItem alignItems="flex-start" className={classes.listItem} dense>
-                            <Typography variant="body1" gutterBottom>
-                                {newsItem.title}
-                            </Typography>
-                            <Typography variant="body2" gutterBottom>
-                                {newsItem.body}
-                            </Typography>
-                            <Typography variant="caption" gutterBottom color="textSecondary">
-                                {moment(newsItem.date).tz('America/Los_Angeles').format('MMMM Do YYYY')}
-                            </Typography>
-                        </ListItem>
-                        {index !== this.state.newsItems.length - 1 ? <Divider /> : null}
-                    </Fragment>
+                    <ListItem alignItems="flex-start" className={classes.listItem} dense>
+                        <Typography variant="body2" gutterBottom>
+                            No news items found
+                        </Typography>
+                    </ListItem>
                 );
-            });
+            } else {
+                return this.state.newsItems.map((newsItem, index) => {
+                    return (
+                        <Fragment key={newsItem['_id']}>
+                            <ListItem alignItems="flex-start" className={classes.listItem} dense>
+                                <Typography variant="body1" gutterBottom>
+                                    {newsItem.title}
+                                </Typography>
+                                <Typography variant="body2" gutterBottom>
+                                    {newsItem.body}
+                                </Typography>
+                                <Typography variant="caption" gutterBottom color="textSecondary">
+                                    {moment(newsItem.date).tz('America/Los_Angeles').format('MMMM Do YYYY')}
+                                </Typography>
+                            </ListItem>
+                            {index !== this.state.newsItems.length - 1 ? <Divider /> : null}
+                        </Fragment>
+                    );
+                });
+            }
         } else if (this.state.loading === false && this.state.newsItems === null) {
             return (
                 <ListItem alignItems="flex-start" className={classes.listItem} dense>

--- a/client/src/components/App/News.js
+++ b/client/src/components/App/News.js
@@ -1,0 +1,126 @@
+import React, { PureComponent, Fragment } from 'react';
+import { Button, Divider, List, ListItem, Paper, Popover, Tooltip, Typography, withStyles } from '@material-ui/core';
+import { RssFeed } from '@material-ui/icons';
+import { NEWS_ENDPOINT } from '../../api/endpoints';
+import { Skeleton } from '@material-ui/lab';
+import moment from 'moment-timezone';
+
+const styles = (theme) => ({
+    list: {
+        width: theme.spacing(40),
+        maxHeight: theme.spacing(40),
+        overflow: 'auto',
+    },
+    listItem: {
+        display: 'flex',
+        flexDirection: 'column',
+    },
+    skeleton: {
+        padding: '4px',
+    },
+});
+
+class News extends PureComponent {
+    state = {
+        anchorEl: null,
+        newsItems: null,
+        loading: true,
+    };
+
+    componentDidMount = async () => {
+        try {
+            const data = await fetch(NEWS_ENDPOINT);
+            const json = await data.json();
+            this.setState({ newsItems: json.news, loading: false });
+        } catch (e) {
+            console.error('Error loading news items:', e);
+            this.setState({ newsItems: null, loading: false });
+        }
+    };
+
+    getNewsItems = () => {
+        const { classes } = this.props;
+        if (this.state.loading === false && this.state.newsItems !== null) {
+            return this.state.newsItems.map((newsItem, index) => {
+                return (
+                    <Fragment key={newsItem['_id']}>
+                        <ListItem alignItems="flex-start" className={classes.listItem} dense>
+                            <Typography variant="body1" gutterBottom>
+                                {newsItem.title}
+                            </Typography>
+                            <Typography variant="body2" gutterBottom>
+                                {newsItem.body}
+                            </Typography>
+                            <Typography variant="caption" gutterBottom color="textSecondary">
+                                {moment(newsItem.date).tz('America/Los_Angeles').format('MMMM Do YYYY')}
+                            </Typography>
+                        </ListItem>
+                        {index !== this.state.newsItems.length - 1 ? <Divider /> : null}
+                    </Fragment>
+                );
+            });
+        } else if (this.state.loading === false && this.state.newsItems === null) {
+            return (
+                <ListItem alignItems="flex-start" className={classes.listItem} dense>
+                    <Typography variant="caption" gutterBottom>
+                        {'Error loading news items'}
+                    </Typography>
+                </ListItem>
+            );
+        } else {
+            return (
+                <div className={this.props.classes.skeleton}>
+                    <div>
+                        <Skeleton variant="text" animation="wave" height={30} width="50%" />
+                    </div>
+                    <div>
+                        <Skeleton variant="text" animation="wave" />
+                    </div>
+                    <div>
+                        <Skeleton variant="text" animation="wave" width="20%" />
+                    </div>
+                </div>
+            );
+        }
+    };
+
+    render() {
+        const { classes } = this.props;
+
+        return (
+            <div>
+                <Tooltip title="Toggle news panel">
+                    <Button
+                        onClick={(e) => this.setState({ anchorEl: e.currentTarget })}
+                        color="inherit"
+                        startIcon={<RssFeed />}
+                    >
+                        News
+                    </Button>
+                </Tooltip>
+                <Popover
+                    placement="bottom-end"
+                    open={Boolean(this.state.anchorEl)}
+                    anchorEl={this.state.anchorEl}
+                    onClose={() => this.setState({ anchorEl: null })}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'center',
+                    }}
+                    transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'center',
+                    }}
+                >
+                    <Paper>
+                        <List className={classes.list} disablePadding dense>
+                            {this.getNewsItems()}
+                        </List>
+                    </Paper>
+                </Popover>
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(News);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,11 +1258,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
-        "react-lazyload": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.1.0.tgz",
-            "integrity": "sha512-WNkWS2jlLnAud2uEqi/Ud4TEjzOQzsN97NzbeRodB9k0TepnoadXDU2bee3PvfP3vpbepsZ716FjSb+xS1W4UQ=="
-        },
         "read-pkg": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",


### PR DESCRIPTION
## Summary
The news section basically lets us put up notifications or messages for our users by simply adding documents to the MongoDB. [An endpoint /api/news has been added to antalmanac-backend ](https://github.com/icssc-projects/antalmanac-backend/commit/f0a59d9246d383cba093a9d13d03a91973d1f466). 

![image](https://user-images.githubusercontent.com/30539874/109630945-5320c000-7afa-11eb-8d2f-d8ffc482caa0.png)

## Test Plan
- Error message when endpoint responds with non 200 code
- Skeleton shows up during load
- Dates are parsed properly
- Too many news items triggers scroll
- Editing DB results in instantaneous changes on frontend

## Issues
#110 

## Future Followup
Implement notification dot when the user has not viewed the latest news item. PR should be merged after this is complete.