### PR TITLE
Download ICS: Add quarterStartDates from Fall 2019 - Fall 2021

### DIFF
--- a/client/src/components/Calendar/ExportCalendar.js
+++ b/client/src/components/Calendar/ExportCalendar.js
@@ -7,9 +7,16 @@ import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
 
 // Hardcoded first mondays
-// Note(chase): doesn't account for week 0 in fall quarters
+// TODO(chase): account for week 0 in fall quarters
+// TODO(chase): support summer sessions
 const quarterStartDates = {
+    '2019 Fall': [2019, 9, 30],
+    '2020 Winter': [2020, 1, 6],
+    '2020 Spring': [2020, 3, 30],
+    '2020 Fall': [2020, 10, 5],
+    '2021 Winter': [2021, 1, 4],
     '2021 Spring': [2021, 3, 29],
+    '2021 Fall': [2021, 9, 27],
 };
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];


### PR DESCRIPTION
## Summary
Download ICS didn't work for any other quarters besides Spring 2021. This adds the previous quarter start dates back to Fall 2019.
Note: this doesn't include summer sessions. I will add those later

## Test Plan
Create and download a schedule from Winter 2021.

## Issues
Previously #109 
Update to #137 

## Future Followup (Optional)
- Support Summer Sessions #143 
- Account for Th/Fr classes in Fall Quarter's Week 0 #144 