### PR TITLE
Implemented basic notistack functionality

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
         "leaflet.locatecontrol": "^0.72.0",
         "material-ui-popup-state": "^1.6.1",
         "moment": "^2.27.0",
+        "notistack": "^1.0.2",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-big-calendar": "^0.24.6",

--- a/client/src/components/App/NotificationSnackbar.js
+++ b/client/src/components/App/NotificationSnackbar.js
@@ -11,13 +11,6 @@ import { withStyles } from '@material-ui/core/styles';
 import { withSnackbar } from 'notistack';
 import { Fragment } from 'react';
 
-const variantIcon = {
-    success: CheckCircleIcon,
-    warning: WarningIcon,
-    error: ErrorIcon,
-    info: InfoIcon,
-};
-
 const styles = (theme) => ({
     success: {
         backgroundColor: green[600],

--- a/client/src/components/App/NotificationSnackbar.js
+++ b/client/src/components/App/NotificationSnackbar.js
@@ -5,11 +5,11 @@ import InfoIcon from '@material-ui/icons/Info';
 import CloseIcon from '@material-ui/icons/Close';
 import { amber, green } from '@material-ui/core/colors';
 import IconButton from '@material-ui/core/IconButton';
-import Snackbar from '@material-ui/core/Snackbar';
-import SnackbarContent from '@material-ui/core/SnackbarContent';
 import WarningIcon from '@material-ui/icons/Warning';
 import AppStore from '../../stores/AppStore';
 import { withStyles } from '@material-ui/core/styles';
+import { withSnackbar } from 'notistack';
+import { Fragment } from 'react';
 
 const variantIcon = {
     success: CheckCircleIcon,
@@ -45,66 +45,44 @@ const styles = (theme) => ({
 
 class NotificationSnackbar extends PureComponent {
     state = {
-        open: false,
         message: '',
         variant: 'info',
         duration: 3000,
     };
 
     openSnackbar = () => {
-        this.setState({
-            open: true,
-            message: AppStore.getSnackbarMessage(),
+        this.props.enqueueSnackbar(AppStore.getSnackbarMessage(), {
             variant: AppStore.getSnackbarVariant(),
             duration: AppStore.getSnackbarDuration(),
             position: AppStore.getSnackbarPosition(),
+            action: this.snackbarAction,
         });
     };
 
-    closeSnackbar = () => {
-        this.setState({ open: false });
+    snackbarAction = (key) => {
+        const { classes } = this.props;
+        return (
+            <Fragment>
+                <IconButton
+                    key="close"
+                    color="inherit"
+                    onClick={() => {
+                        this.props.closeSnackbar(key);
+                    }}
+                >
+                    <CloseIcon className={classes.icon} />
+                </IconButton>
+            </Fragment>
+        );
     };
 
     componentDidMount = () => {
         AppStore.on('openSnackbar', this.openSnackbar);
     };
 
-    handleClose = (event, reason) => {
-        if (reason === 'clickaway') {
-            return;
-        }
-
-        this.closeSnackbar();
-    };
-
     render() {
-        const { classes } = this.props;
-        const Icon = variantIcon[this.state.variant];
-
-        return (
-            <Snackbar
-                anchorOrigin={this.state.position}
-                open={this.state.open}
-                autoHideDuration={this.state.duration}
-                onClose={this.handleClose}
-            >
-                <SnackbarContent
-                    className={classes[this.state.variant]}
-                    message={
-                        <span className={classes.message}>
-                            <Icon className={classes.icon} />
-                            {this.state.message}
-                        </span>
-                    }
-                    action={[
-                        <IconButton key="close" color="inherit" onClick={this.closeSnackbar}>
-                            <CloseIcon className={classes.icon} />
-                        </IconButton>,
-                    ]}
-                />
-            </Snackbar>
-        );
+        return null;
     }
 }
 
-export default withStyles(styles)(NotificationSnackbar);
+export default withStyles(styles)(withSnackbar(NotificationSnackbar));

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import App from './components/App/App';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { unregister } from './registerServiceWorker';
+import { SnackbarProvider } from 'notistack';
 // import whyDidYouRender from '@welldone-software/why-did-you-render';
 // if (process.env.NODE_ENV === 'development') {
 // const whyDidYouRender = require('@welldone-software/why-did-you-render/dist/no-classes-transpile/umd/whyDidYouRender.min.js');
@@ -42,7 +43,9 @@ const theme = createMuiTheme({
 const rootElement = document.getElementById('root');
 render(
     <MuiThemeProvider theme={theme}>
-        <App style={{ height: '100%' }} />
+        <SnackbarProvider>
+            <App style={{ height: '100%' }} />
+        </SnackbarProvider>
     </MuiThemeProvider>,
     rootElement
 );

--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
             "prettier --write",
             "git add"
         ]
-    },
-    "dependencies": {
-        "notistack": "^1.0.2"
     }
 }


### PR DESCRIPTION
## Summary
Previously, notifications would only appear one at a time. New ones would replace the current one. Now, up to 3 will be displayed, with newer ones replacing older ones if needed.
![notistack](https://user-images.githubusercontent.com/25188285/109843856-65852180-7c00-11eb-93b5-012db39bda83.gif)

## Test Plan
- Click a course's code 4 times to display 4 notifications (forcing 1 to be cycled out)
- Test the notification's delete button
- Try saving/loading valid schedules, undoing calendar delete's, adding courses to watch list, and adding online classes to see success notifications
- Try saving/loading invalid schedules to see error notifications

## Issues
#123 

## Future Followup (Optional)
* Handle the case of long save names (currently has the potential to make the snackbar take up the entire screen)
* Prevent duplicates from appearing