### PR TITLE
Custom events box

### DIFF
--- a/client/src/components/CustomEvents/CustomEventDialog.js
+++ b/client/src/components/CustomEvents/CustomEventDialog.js
@@ -41,7 +41,7 @@ class CustomEventDialog extends PureComponent {
     };
 
     handleOpen = () => {
-        this.setState({ open: true })
+        this.setState({ open: true });
         ReactGA.event({
             category: 'antalmanac-rewrite',
             action: 'Click Custom Event button',
@@ -165,7 +165,12 @@ class CustomEventDialog extends PureComponent {
                             Cancel
                         </Button>
 
-                        <Button onClick={() => this.handleClose(false)} variant="contained" color="primary">
+                        <Button
+                            onClick={() => this.handleClose(false)}
+                            variant="contained"
+                            color="primary"
+                            disabled={!(this.state.scheduleIndices.length && this.state.days.some(Boolean))}
+                        >
                             {this.props.customEvent ? 'Save Changes' : 'Add Event'}
                         </Button>
                     </DialogActions>

--- a/client/src/components/CustomEvents/CustomEventDialog.js
+++ b/client/src/components/CustomEvents/CustomEventDialog.js
@@ -164,15 +164,21 @@ class CustomEventDialog extends PureComponent {
                         <Button onClick={() => this.handleClose(true)} color="primary">
                             Cancel
                         </Button>
-
-                        <Button
-                            onClick={() => this.handleClose(false)}
-                            variant="contained"
-                            color="primary"
-                            disabled={!(this.state.scheduleIndices.length && this.state.days.some(Boolean))}
+                        <Tooltip
+                            title="Schedule and day must be checked"
+                            disableHoverListener={this.state.scheduleIndices.length && this.state.days.some(Boolean)}
                         >
-                            {this.props.customEvent ? 'Save Changes' : 'Add Event'}
-                        </Button>
+                            <span>
+                                <Button
+                                    onClick={() => this.handleClose(false)}
+                                    variant="contained"
+                                    color="primary"
+                                    disabled={!(this.state.scheduleIndices.length && this.state.days.some(Boolean))}
+                                >
+                                    {this.props.customEvent ? 'Save Changes' : 'Add Event'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                     </DialogActions>
                 </Dialog>
             </Fragment>

--- a/client/src/components/CustomEvents/CustomEventDialog.js
+++ b/client/src/components/CustomEvents/CustomEventDialog.js
@@ -54,7 +54,7 @@ class CustomEventDialog extends PureComponent {
             this.handleAddToCalendar();
         }
 
-        this.setState({ open: false, eventName: '' });
+        this.setState({ open: false, eventName: '', days: [false, false, false, false, false], scheduleIndices: [] });
     };
 
     handleEventNameChange = (event) => {
@@ -92,6 +92,10 @@ class CustomEventDialog extends PureComponent {
 
     handleSelectScheduleIndices = (scheduleIndices) => {
         this.setState({ scheduleIndices: scheduleIndices });
+    };
+
+    isAddDisabled = () => {
+        return !(this.state.scheduleIndices.length && this.state.days.some(Boolean));
     };
 
     render() {
@@ -164,16 +168,13 @@ class CustomEventDialog extends PureComponent {
                         <Button onClick={() => this.handleClose(true)} color="primary">
                             Cancel
                         </Button>
-                        <Tooltip
-                            title="Schedule and day must be checked"
-                            disableHoverListener={this.state.scheduleIndices.length && this.state.days.some(Boolean)}
-                        >
+                        <Tooltip title="Schedule and day must be checked" disableHoverListener={!this.isAddDisabled()}>
                             <span>
                                 <Button
                                     onClick={() => this.handleClose(false)}
                                     variant="contained"
                                     color="primary"
-                                    disabled={!(this.state.scheduleIndices.length && this.state.days.some(Boolean))}
+                                    disabled={this.isAddDisabled()}
                                 >
                                     {this.props.customEvent ? 'Save Changes' : 'Add Event'}
                                 </Button>

--- a/client/src/components/CustomEvents/CustomEventDialog.js
+++ b/client/src/components/CustomEvents/CustomEventDialog.js
@@ -54,7 +54,7 @@ class CustomEventDialog extends PureComponent {
             this.handleAddToCalendar();
         }
 
-        this.setState({ open: false });
+        this.setState({ open: false, eventName: '' });
     };
 
     handleEventNameChange = (event) => {


### PR DESCRIPTION
## Summary
Three improvements to the custom events box:
- Disable "Add Event" button in modal until boxes have been checked to select both the day(s) and the selected schedule(s)
 
![output](https://user-images.githubusercontent.com/30458137/112889711-dc3ffe00-908a-11eb-8f6a-63643a8ca1ab.gif)

- There is a tool tip message when the "Add Event" button is disabled, indicating that the days and schedule boxes need to be checked.

![image](https://user-images.githubusercontent.com/30458137/112887360-ee6c6d00-9087-11eb-9179-54d8101f13cc.png)
- Cancel button now clears the event name

## Test Plan
1. Button is disabled without anything clicked, tooltip active
2. Button is still disabled with only one of each section (day or schedule) selected
3. Button is enabled when one or more boxes from both sections are selected, tooltip not present on hover
4. Event name is cleared when cancel is pressed
## Issues
#111 