### PR TITLE
Fix ics export bug for classes with TBA times

### DIFF
--- a/client/src/components/Calendar/ExportCalendar.js
+++ b/client/src/components/Calendar/ExportCalendar.js
@@ -68,6 +68,7 @@ const dateToIcs = (date) => {
 // Note(chase): We currently don't use this function because timezones are too annoying.
 //  If you want to use this function, you also need to set the VEvent's
 //  startInputType/endInputType to 'utc'
+// eslint-disable-next-line
 const toUTC = (times, offsetHours) => {
     return times.map((time) => {
         // Construct a Date object
@@ -156,6 +157,11 @@ class ExportCalendarButton extends PureComponent {
 
             // Create a VEvent for each meeting
             for (const meeting of meetings) {
+                if (meeting.time == 'TBA') {
+                    // Skip this meeting if there is no meeting time
+                    continue;
+                }
+
                 const bydays = getByDays(meeting.days);
                 const classStartDate = getClassStartDate(term, bydays[0]);
                 const [firstClassStart, firstClassEnd] = getFirstClass(classStartDate, meeting.time);


### PR DESCRIPTION
## Summary
Download ics would fail when a class's time was TBA.
This commit now skips classes with TBA times, since it doesn't make sense to include those classes on a calendar.

## Test Plan
- Add classes to a schedule
- Add a class with a "TBA" time
- Verify that download .ics file works

## Issues
Close #151 