### PR TITLE
Added warning when multiple terms detected and added term info to tooltip

### DIFF
--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -39,9 +39,12 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
     const addedCourses = AppStore.getAddedCourses();
 
     let existingCourse;
+    let multipleTerms = false;
 
     for (const course of addedCourses) {
-        if (course.section.sectionCode === section.sectionCode && term === course.term) {
+        if (term !== course.term) {
+            multipleTerms = true;
+        } else if (course.section.sectionCode === section.sectionCode) {
             existingCourse = course;
             if (course.scheduleIndices.includes(scheduleIndex)) {
                 return;
@@ -50,6 +53,8 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
             }
         }
     }
+
+    if (multipleTerms) openSnackbar('warning', 'Course added from different term');
 
     if (color === undefined) {
         const setOfUsedColors = new Set(addedCourses.map((course) => course.color));

--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -59,7 +59,7 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
             'warning',
             `Course added from different term.\nSchedule now contains courses from ${[...multipleTerms]
                 .sort()
-                .join(', ')}`,
+                .join(', ')}.`,
             null,
             null,
             { whiteSpace: 'pre-line' }

--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -39,12 +39,12 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
     const addedCourses = AppStore.getAddedCourses();
 
     let existingCourse;
-    let multipleTerms = false;
+    let multipleTerms = new Set([term]);
 
     for (const course of addedCourses) {
-        if (term !== course.term) {
-            multipleTerms = true;
-        } else if (course.section.sectionCode === section.sectionCode) {
+        multipleTerms.add(course.term);
+
+        if (course.section.sectionCode === section.sectionCode && term === course.term) {
             existingCourse = course;
             if (course.scheduleIndices.includes(scheduleIndex)) {
                 return;
@@ -54,7 +54,16 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
         }
     }
 
-    if (multipleTerms) openSnackbar('warning', 'Course added from different term');
+    if (multipleTerms.size > 1)
+        openSnackbar(
+            'warning',
+            `Course added from different term.\nSchedule now contains courses from ${[...multipleTerms]
+                .sort()
+                .join(', ')}`,
+            null,
+            null,
+            { whiteSpace: 'pre-line' }
+        );
 
     if (color === undefined) {
         const setOfUsedColors = new Set(addedCourses.map((course) => course.color));
@@ -89,13 +98,14 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
     }
 };
 
-export const openSnackbar = (variant, message, duration, position) => {
+export const openSnackbar = (variant, message, duration, position, style) => {
     dispatcher.dispatch({
         type: 'OPEN_SNACKBAR',
         variant: variant,
         message: message,
         duration: duration,
         position: position,
+        style: style,
     });
 };
 

--- a/client/src/components/App/NotificationSnackbar.js
+++ b/client/src/components/App/NotificationSnackbar.js
@@ -1,11 +1,7 @@
 import React, { PureComponent } from 'react';
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import ErrorIcon from '@material-ui/icons/Error';
-import InfoIcon from '@material-ui/icons/Info';
 import CloseIcon from '@material-ui/icons/Close';
 import { amber, green } from '@material-ui/core/colors';
 import IconButton from '@material-ui/core/IconButton';
-import WarningIcon from '@material-ui/icons/Warning';
 import AppStore from '../../stores/AppStore';
 import { withStyles } from '@material-ui/core/styles';
 import { withSnackbar } from 'notistack';
@@ -49,6 +45,7 @@ class NotificationSnackbar extends PureComponent {
             duration: AppStore.getSnackbarDuration(),
             position: AppStore.getSnackbarPosition(),
             action: this.snackbarAction,
+            style: AppStore.getSnackbarStyle(),
         });
     };
 

--- a/client/src/components/Calendar/CourseCalendarEvent.js
+++ b/client/src/components/Calendar/CourseCalendarEvent.js
@@ -110,6 +110,10 @@ const CourseCalendarEvent = (props) => {
                             </Tooltip>
                         </tr>
                         <tr>
+                            <td className={classes.alignToTop}>Term</td>
+                            <td className={classes.rightCells}>{term}</td>
+                        </tr>
+                        <tr>
                             <td className={classes.alignToTop}>Instructors</td>
                             <td className={`${classes.multiline} ${classes.rightCells}`}>{instructors.join('\n')}</td>
                         </tr>

--- a/client/src/stores/AppStore.js
+++ b/client/src/stores/AppStore.js
@@ -15,6 +15,7 @@ class AppStore extends EventEmitter {
         this.snackbarVariant = 'info';
         this.snackbarDuration = 3000;
         this.snackbarPosition = { vertical: 'bottom', horizontal: 'left' };
+        this.snackbarStyle = {};
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
@@ -69,6 +70,10 @@ class AppStore extends EventEmitter {
 
     getSnackbarDuration() {
         return this.snackbarDuration;
+    }
+
+    getSnackbarStyle() {
+        return this.snackbarStyle;
     }
 
     getDarkMode() {
@@ -187,6 +192,7 @@ class AppStore extends EventEmitter {
                 this.snackbarMessage = action.message;
                 this.snackbarDuration = action.duration ? action.duration : this.snackbarDuration;
                 this.snackbarPosition = action.position ? action.position : this.snackbarPosition;
+                this.snackbarStyle = action.style ? action.style : this.snackbarStyle;
                 this.emit('openSnackbar');
                 break;
             case 'EDIT_CUSTOM_EVENTS':


### PR DESCRIPTION
## Summary
Previously, users could add courses from multiple terms, but after being added, there would be no indication of these terms. This change adds a warning snackbar every time the user adds a course and multiple terms are present.
![warning](https://user-images.githubusercontent.com/25188285/117520962-0d500000-af60-11eb-9273-bfee736de9f5.gif)

It also adds a row in the event tooltips indicating the term.
![tooltip_term](https://user-images.githubusercontent.com/25188285/117520968-1771fe80-af60-11eb-858f-82c39716b372.png)

## Test Plan
* Verify that adding courses from two different terms produces a warning snackbar
* Verify that adding courses from the same term does not produce a warning
* Verify that calendar event tooltips display a term and that it's correct
* Make sure the placement of the term in the tooltip is sensible (i.e. should it be listed second?)
* Make sure that displaying the warning after every class is not excessive (i.e. should it only appear once a new term is added?)

## Issues
#156

## Future Followup (Optional)
* Add term for each course in Added Classes page