### PR TITLE
Change schedule selector to dropdown

### DIFF
--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -302,12 +302,7 @@ export const undoDelete = (event) => {
     }
 };
 
-export const changeCurrentSchedule = (direction) => {
-    let newScheduleIndex;
-
-    if (direction === 0) newScheduleIndex = (AppStore.getCurrentScheduleIndex() - 1 + 4) % 4;
-    else if (direction === 1) newScheduleIndex = (AppStore.getCurrentScheduleIndex() + 1) % 4;
-
+export const changeCurrentSchedule = (newScheduleIndex) => {
     dispatcher.dispatch({ type: 'CHANGE_CURRENT_SCHEDULE', newScheduleIndex });
 };
 

--- a/client/src/components/Calendar/CalendarPaneToolbar.js
+++ b/client/src/components/Calendar/CalendarPaneToolbar.js
@@ -48,7 +48,6 @@ class CalendarPaneToolbar extends PureComponent {
                     <MenuItem value={1}>Schedule 2</MenuItem>
                     <MenuItem value={2}>Schedule 3</MenuItem>
                     <MenuItem value={3}>Schedule 4</MenuItem>
-                    <MenuItem value={4}>Schedule 5</MenuItem>
                 </Select>
 
                 <div className={classes.spacer} />

--- a/client/src/components/Calendar/CalendarPaneToolbar.js
+++ b/client/src/components/Calendar/CalendarPaneToolbar.js
@@ -1,13 +1,15 @@
 import React, { PureComponent } from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { IconButton, Tooltip, Typography, Paper, Button } from '@material-ui/core';
-import { ChevronLeft, ChevronRight, Delete, Undo } from '@material-ui/icons';
+import { IconButton, Tooltip, Paper, Button } from '@material-ui/core';
+import { Delete, Undo } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import { clearSchedules, undoDelete } from '../../actions/AppStoreActions';
 import CustomEventsDialog from '../CustomEvents/CustomEventDialog';
 import { changeCurrentSchedule } from '../../actions/AppStoreActions';
 import ScreenshotButton from './ScreenshotButton';
 import ExportCalendar from './ExportCalendar';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
 
 const styles = {
@@ -21,6 +23,7 @@ const styles = {
         '& button': {
             marginRight: '4px',
         },
+        padding: '4px',
     },
     inline: {
         display: 'inline',
@@ -31,22 +34,22 @@ const styles = {
 };
 
 class CalendarPaneToolbar extends PureComponent {
+    handleScheduleChange(event) {
+        changeCurrentSchedule(event.target.value);
+    }
+
     render() {
         const { classes } = this.props;
 
         return (
             <Paper elevation={0} variant="outlined" square className={classes.toolbar}>
-                <IconButton onClick={() => changeCurrentSchedule(0)}>
-                    <ChevronLeft fontSize="small" />
-                </IconButton>
-
-                <Typography variant="body2" className={classes.inline}>
-                    {'Schedule ' + (this.props.currentScheduleIndex + 1)}
-                </Typography>
-
-                <IconButton onClick={() => changeCurrentSchedule(1)}>
-                    <ChevronRight fontSize="small" />
-                </IconButton>
+                <Select value={this.props.currentScheduleIndex} onChange={this.handleScheduleChange}>
+                    <MenuItem value={0}>Schedule 1</MenuItem>
+                    <MenuItem value={1}>Schedule 2</MenuItem>
+                    <MenuItem value={2}>Schedule 3</MenuItem>
+                    <MenuItem value={3}>Schedule 4</MenuItem>
+                    <MenuItem value={4}>Schedule 5</MenuItem>
+                </Select>
 
                 <div className={classes.spacer} />
 


### PR DESCRIPTION
## Summary
Change schedule switcher to a dropdown menu.
![schedule-dropdown](https://user-images.githubusercontent.com/29494270/118051491-fc273a80-b335-11eb-9afc-2f8f8cd69ca7.gif)

## Test Plan
- Add a class to each schedule, verify they appear correctly
- Add a custom event to each schedule, verify they appear correctly
- Save and reload the schedules, verify the events persist

## Issues

## Future Followup (Optional)
Later on, we'll probably swap "Schedule {1-4}" out for named schedules associated with an account.