### PR TITLE
Section Code cell now show pointer on hover

### DIFF
--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -76,6 +76,11 @@ const styles = (theme) => ({
     multiline: {
         whiteSpace: 'pre',
     },
+    sectionCode: {
+        '&:hover': {
+            cursor: 'pointer',
+        },
+    },
     Act: { color: '#c87137' },
     Col: { color: '#ff40b5' },
     Dis: { color: '#8d63f0' },


### PR DESCRIPTION
## Summary
When hovering on a Section Code cell, the cursor while change to a pointer to indicate that it can be clicked.
![image](https://user-images.githubusercontent.com/29494270/118753662-4b7bd800-b81a-11eb-9b64-fe1708bc43cf.png)
_I couldn't figure out how to screenshot with the cursor, so I took a pic of the screen lol_
## Test Plan
- Search for a class and hover over the course code
- Add the course to schedule
- Navigate to "Added Classes" tab and hover over a course code
- Verify that both display the pointer cursor as shown above