### PR TITLE
Map additions

### DIFF
--- a/client/src/components/Map/MapMarkerPopup.js
+++ b/client/src/components/Map/MapMarkerPopup.js
@@ -34,7 +34,7 @@ class MapMarkerPopup extends PureComponent {
                                         top: -0.75rem;
                                         text-align: center; 
                                         color: white" >
-                                        ${this.props.index}
+                            ${this.props.index}
                         </div>
                     </div>`,
         });

--- a/client/src/components/Map/MapMarkerPopup.js
+++ b/client/src/components/Map/MapMarkerPopup.js
@@ -15,7 +15,7 @@ class MapMarkerPopup extends PureComponent {
             labelAnchor: [-3.5, 0],
             popupAnchor: [0, -21],
             className: '',
-            html:   `<div style="position:relative;
+            html: `<div style="position:relative;
                                     left: -1rem;
                                     top: -1rem;">
                         <span style="background-color: ${color};
@@ -24,16 +24,19 @@ class MapMarkerPopup extends PureComponent {
                                         display: block;
                                         left: -1rem;
                                         top: -1rem;
-                                        position: relative;
+                                        position: absolute;
                                         border-radius: 1.9rem 1.9rem 0;
                                         transform: rotate(45deg);
-                                        border: 1px solid #FFFFFF" />
+                                        border: 1px solid #FFFFFF">
+                        </span>
                         <div style="position: absolute;
                                         width: 1.75rem;
                                         height: 1.75rem;
-                                        top: 0.25rem
-                                        text-align: center" >
-                                        ${index}
+                                        left: -1rem;
+                                        top: -0.75rem;
+                                        text-align: center" 
+                                        text-color: "white" >
+                                        ${this.props.index}
                         </div>
                     </div>`,
         });

--- a/client/src/components/Map/MapMarkerPopup.js
+++ b/client/src/components/Map/MapMarkerPopup.js
@@ -15,9 +15,7 @@ class MapMarkerPopup extends PureComponent {
             labelAnchor: [-3.5, 0],
             popupAnchor: [0, -21],
             className: '',
-            html: `<div style="position:relative;
-                                    left: -1rem;
-                                    top: -1rem;">
+            html: `<div style="position:relative;">
                         <span style="background-color: ${color};
                                         width: 1.75rem;
                                         height: 1.75rem;
@@ -34,8 +32,8 @@ class MapMarkerPopup extends PureComponent {
                                         height: 1.75rem;
                                         left: -1rem;
                                         top: -0.75rem;
-                                        text-align: center" 
-                                        text-color: "white" >
+                                        text-align: center; 
+                                        color: white" >
                                         ${this.props.index}
                         </div>
                     </div>`,

--- a/client/src/components/Map/MapMarkerPopup.js
+++ b/client/src/components/Map/MapMarkerPopup.js
@@ -15,16 +15,27 @@ class MapMarkerPopup extends PureComponent {
             labelAnchor: [-3.5, 0],
             popupAnchor: [0, -21],
             className: '',
-            html: `<span style="background-color: ${color};
-                            width: 1.75rem;
-                            height: 1.75rem;
-                            display: block;
-                            left: -1rem;
-                            top: -1rem;
-                            position: relative;
-                            border-radius: 1.9rem 1.9rem 0;
-                            transform: rotate(45deg);
-                            border: 1px solid #FFFFFF" />`,
+            html:   `<div style="position:relative;
+                                    left: -1rem;
+                                    top: -1rem;">
+                        <span style="background-color: ${color};
+                                        width: 1.75rem;
+                                        height: 1.75rem;
+                                        display: block;
+                                        left: -1rem;
+                                        top: -1rem;
+                                        position: relative;
+                                        border-radius: 1.9rem 1.9rem 0;
+                                        transform: rotate(45deg);
+                                        border: 1px solid #FFFFFF" />
+                        <div style="position: absolute;
+                                        width: 1.75rem;
+                                        height: 1.75rem;
+                                        top: 0.25rem
+                                        text-align: center" >
+                                        ${index}
+                        </div>
+                    </div>`,
         });
     };
 

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -55,7 +55,7 @@ export default class UCIMap extends PureComponent {
     getRoute = (day) => {
         // Clear any existing route on the map
         this.setState({ poly: [], info_marker: null });
-        
+
         if (day) {
             let index = 0;
             let coords = ''; // lat and lng of markers to be passed to api
@@ -129,6 +129,35 @@ export default class UCIMap extends PureComponent {
                             ) {
                                 path.push([[lng, lat]]);
                                 if (waypointIndex !== 0) {
+                                    function setInfoMarker(event) {
+                                        let [position, color, duration, miles] = this.options.map.state.info_markers[
+                                            this.options.index - 1
+                                        ];
+                                        this.options.map.setState({
+                                            info_marker: (
+                                                <Marker
+                                                    position={event.latlng}
+                                                    opacity={1.0}
+                                                    icon={Leaflet.divIcon({
+                                                        iconAnchor: [0, 14],
+                                                        labelAnchor: [-3.5, 0],
+                                                        popupAnchor: [0, -21],
+                                                        className: '',
+                                                        iconSize: [1000, 14],
+                                                        html: `<div style="position:relative; top:-200%; left:5px; pointer-events: none; background-color: white; border-left-color: ${color}; border-left-style: solid; width: fit-content; border-left-width: 5px; padding-left: 10px; padding-right: 10px; padding-top: 4px; padding-bottom: 4px;">
+                                                            <span style="color:${color}">
+                                                            ${duration} 
+                                                            </span>
+                                                            <br>
+                                                            <span style="color:#888888">
+                                                            ${miles}
+                                                            </span>
+                                                        </div>`,
+                                                    })}
+                                                ></Marker>
+                                            ),
+                                        });
+                                    }
                                     poly.push(
                                         <Polyline
                                             zIndexOffset={100}
@@ -136,41 +165,11 @@ export default class UCIMap extends PureComponent {
                                             positions={path[waypointIndex]}
                                             index={waypointIndex}
                                             map={this}
-                                            onmouseover={function () {
-                                                let [
-                                                    position,
-                                                    color,
-                                                    duration,
-                                                    miles,
-                                                ] = this.options.map.state.info_markers[this.options.index - 1];
-                                                this.options.map.setState({
-                                                    info_marker: (
-                                                        <Marker
-                                                            position={position}
-                                                            opacity={1.0}
-                                                            icon={Leaflet.divIcon({
-                                                                iconAnchor: [0, 14],
-                                                                labelAnchor: [-3.5, 0],
-                                                                popupAnchor: [0, -21],
-                                                                className: '',
-                                                                iconSize: [1000, 14],
-                                                                html: `<div style="background-color: white;border-left-color: ${color};border-left-style: solid;width: fit-content;border-left-width: 5px;padding-left: 10px;padding-right: 10px;padding-top: 4px;padding-bottom: 4px;">
-                                                                    <span style="color:${color}">
-                                                                    ${duration} 
-                                                                    </span>
-                                                                    <br>
-                                                                    <span style="color:#888888">
-                                                                    ${miles}
-                                                                    </span>
-                                                                </div>`,
-                                                            })}
-                                                        ></Marker>
-                                                    ),
-                                                });
-                                            }}
+                                            onmouseover={setInfoMarker}
                                             onmouseout={function () {
                                                 this.options.map.setState({ info_marker: null });
                                             }}
+                                            onmousemove={setInfoMarker}
                                         />
                                     ); // Draw path from last waypoint to next waypoint
 

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -144,7 +144,7 @@ export default class UCIMap extends PureComponent {
                                                         popupAnchor: [0, -21],
                                                         className: '',
                                                         iconSize: [1000, 14],
-                                                        html: `<div style="position:relative; top:-200%; left:5px; pointer-events: none; background-color: white; border-left-color: ${color}; border-left-style: solid; width: fit-content; border-left-width: 5px; padding-left: 10px; padding-right: 10px; padding-top: 4px; padding-bottom: 4px;">
+                                                        html: `<div style="position:relative; top:-200%; left:2px; pointer-events: none; background-color: white; border-left-color: ${color}; border-left-style: solid; width: fit-content; border-left-width: 5px; padding-left: 10px; padding-right: 10px; padding-top: 4px; padding-bottom: 4px;">
                                                             <span style="color:${color}">
                                                             ${duration} 
                                                             </span>

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -121,7 +121,7 @@ export default class UCIMap extends PureComponent {
                                 lng === waypoints[waypointIndex]['location'][1]
                             ) {
                                 path.push([[lng, lat]]);
-                                if (waypointIndex != 0) {
+                                if (waypointIndex !== 0) {
                                     poly.push(
                                         <Polyline color={colors[waypointIndex - 1]} positions={path[waypointIndex]} />
                                     ); // Draw path from last waypoint to next waypoint

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -51,118 +51,133 @@ export default class UCIMap extends PureComponent {
     };
 
     getRoute = (day) => {
-        let index = 0;
-        let coords = '';
-        let coords_array = [];
-        let colors = [];
-        this.state.eventsInCalendar
-            .sort((event, event2) => event.start - event2.start)
-            .forEach((event) => {
-                // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-                if (
-                    event.isCustomEvent ||
-                    !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
-                    !event.start.toString().includes(DAYS[day])
+        if (day) {
+            let index = 0;
+            let coords = '';
+            let coords_array = [];
+            let colors = [];
+
+            // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
+            this.state.eventsInCalendar
+                .filter(
+                    (event) =>
+                        !(
+                            event.isCustomEvent ||
+                            !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
+                            !event.start.toString().includes(DAYS[day])
+                        )
                 )
-                    return;
+                .sort((event, event2) => event.start - event2.start)
+                .forEach((event) => {
+                    // Get building code, get id of building code, which will get us the building data from buildingCatalogue
+                    const buildingCode = event.bldg.split(' ').slice(0, -1).join(' ');
+                    const id = locations[buildingCode];
+                    const locationData = buildingCatalogue[id];
 
-                // Get building code, get id of building code, which will get us the building data from buildingCatalogue
-                const buildingCode = event.bldg.split(' ')[0];
-                const id = locations[buildingCode];
-                const locationData = buildingCatalogue[id];
+                    if (locationData === undefined) return;
 
-                if (locationData === undefined) return;
+                    colors.push(event.color);
 
-                colors.push(event.color);
-
-                if (day) {
-                    if (coords) coords += ';';
-                    coords += locationData.lng + ',' + locationData.lat;
-                    coords_array.push([locationData.lat, locationData.lng]);
-                }
-                index++;
-            });
-        if (day && index > 1) {
-            var url = new URL(DIRECTIONS_ENDPOINT + encodeURIComponent(coords));
-
-            url.search = new URLSearchParams({
-                alternatives: false,
-                geometries: 'geojson',
-                steps: false,
-                access_token: ACCESS_TOKEN,
-            }).toString();
-
-            fetch(url, {
-                method: 'GET',
-                headers: { 'Content-Type': 'application/json' },
-            }).then((response) => {
-                response.json().then((obj) => {
-                    let latlng = obj['routes'][0]['geometry']['coordinates'];
-                    let waypoint = 0;
-                    let path = [
-                        [[obj['waypoints'][waypoint]['location'][1], obj['waypoints'][waypoint]['location'][0]]],
-                    ];
-                    let poly = [];
-                    poly.push(<Polyline color={colors[0]} positions={[path[0][0], coords_array[0]]} dashArray="4" />);
-
-                    for (let i of latlng) {
-                        path[waypoint].push([i[1], i[0]]);
-                        if (
-                            i[0] === obj['waypoints'][waypoint]['location'][0] &&
-                            i[1] === obj['waypoints'][waypoint]['location'][1]
-                        ) {
-                            path.push([[i[1], i[0]]]);
-                            if (waypoint != 0) {
-                                poly.push(<Polyline color={colors[waypoint - 1]} positions={path[waypoint]} />);
-                                poly.push(
-                                    <Polyline
-                                        color={colors[waypoint - 1]}
-                                        positions={[path[waypoint][path[waypoint].length - 1], coords_array[waypoint]]}
-                                        dashArray="4"
-                                    />
-                                );
-                                poly.push(
-                                    <Marker
-                                        position={path[waypoint][Math.floor(path[waypoint].length / 2)]}
-                                        icon={Leaflet.divIcon({
-                                            iconAnchor: [0, 14],
-                                            labelAnchor: [-3.5, 0],
-                                            popupAnchor: [0, -21],
-                                            className: '',
-                                            iconSize: [1000, 14],
-                                            html: `<div style="background-color: white;border-left-color: ${
-                                                colors[waypoint - 1]
-                                            };border-left-style: solid;width: fit-content;border-left-width: 5px;padding-left: 10px;padding-right: 10px;padding-top: 4px;padding-bottom: 4px;">
-                                    <span style="color:${colors[waypoint - 1]}"> ${
-                                                obj['routes'][0]['legs'][waypoint - 1]['duration'] > 30
-                                                    ? Math.round(
-                                                          obj['routes'][0]['legs'][waypoint - 1]['duration'] / 60
-                                                      ).toString() + ' min'
-                                                    : '<1 min'
-                                            } </span>
-                                    <br>
-                                    <span style="color:#888888">
-                                                ${
-                                                    (
-                                                        Math.floor(
-                                                            obj['routes'][0]['legs'][waypoint - 1]['distance'] /
-                                                                1.609 /
-                                                                10
-                                                        ) / 100
-                                                    ).toString() + ' mi'
-                                                }
-                                                </span>
-                                            </div>`,
-                                        })}
-                                    ></Marker>
-                                );
-                            }
-                            waypoint++;
+                    if (day) {
+                        if (coords) {
+                            coords += ';';
                         }
+                        coords += locationData.lng + ',' + locationData.lat;
+                        coords_array.push([locationData.lat, locationData.lng]);
                     }
-                    this.setState({ poly: poly });
+                    index++;
                 });
-            });
+            if (index > 1) {
+                var url = new URL(DIRECTIONS_ENDPOINT + encodeURIComponent(coords));
+
+                url.search = new URLSearchParams({
+                    alternatives: false,
+                    geometries: 'geojson',
+                    steps: false,
+                    access_token: ACCESS_TOKEN,
+                }).toString();
+
+                fetch(url, {
+                    method: 'GET',
+                    headers: { 'Content-Type': 'application/json' },
+                }).then((response) => {
+                    response.json().then((obj) => {
+                        let coordinates = obj['routes'][0]['geometry']['coordinates']; // The coordinates for the lines of the routes
+                        let waypoints = obj['waypoints']; // The waypoints we specified in the request
+                        let waypointIndex = 0; // The current waypoint we are building a path from
+                        let path = [
+                            [[waypoints[waypointIndex]['location'][1], waypoints[waypointIndex]['location'][0]]],
+                        ]; // Path is a list of paths for each waypoint. For example, path[0] is the path to waypoint 0, path[1] is the path from 0 to 1... etc.
+
+                        let poly = []; // Arrays of polyline to be added to map
+                        poly.push(
+                            <Polyline color={colors[0]} positions={[path[0][0], coords_array[0]]} dashArray="4" />
+                        ); // Draw a dashline from waypoint 0 to start of route
+
+                        for (let [lat, lng] of coordinates) {
+                            path[waypointIndex].push([lng, lat]); // Creates a path using lat and lng of coordinates until lat and lng matches one of the waypoint's coordinates
+                            if (
+                                lat === waypoints[waypointIndex]['location'][0] &&
+                                lng === waypoints[waypointIndex]['location'][1]
+                            ) {
+                                path.push([[lng, lat]]);
+                                if (waypointIndex != 0) {
+                                    poly.push(
+                                        <Polyline color={colors[waypointIndex - 1]} positions={path[waypointIndex]} />
+                                    ); // Draw path from last waypoint to next waypoint
+                                    let duration =
+                                        obj['routes'][0]['legs'][waypointIndex - 1]['duration'] > 30
+                                            ? Math.round(
+                                                  obj['routes'][0]['legs'][waypointIndex - 1]['duration'] / 60
+                                              ).toString() + ' min'
+                                            : '<1 min';
+                                    let miles =
+                                        (
+                                            Math.floor(
+                                                obj['routes'][0]['legs'][waypointIndex - 1]['distance'] / 1.609 / 10
+                                            ) / 100
+                                        ).toString() + ' mi';
+                                    poly.push(
+                                        <Polyline
+                                            color={colors[waypointIndex - 1]}
+                                            positions={[
+                                                path[waypointIndex][path[waypointIndex].length - 1],
+                                                coords_array[waypointIndex],
+                                            ]}
+                                            dashArray="4"
+                                        />
+                                    ); // Draw a dashed line directly to waypoint
+                                    poly.push(
+                                        <Marker
+                                            position={path[waypointIndex][Math.floor(path[waypointIndex].length / 2)]}
+                                            icon={Leaflet.divIcon({
+                                                iconAnchor: [0, 14],
+                                                labelAnchor: [-3.5, 0],
+                                                popupAnchor: [0, -21],
+                                                className: '',
+                                                iconSize: [1000, 14],
+                                                html: `<div style="background-color: white;border-left-color: ${
+                                                    colors[waypointIndex - 1]
+                                                };border-left-style: solid;width: fit-content;border-left-width: 5px;padding-left: 10px;padding-right: 10px;padding-top: 4px;padding-bottom: 4px;">
+                                                            <span style="color:${colors[waypointIndex - 1]}">
+                                                            ${duration} 
+                                                            </span>
+                                                            <br>
+                                                            <span style="color:#888888">
+                                                            ${miles}
+                                                            </span>
+                                                        </div>`,
+                                            })}
+                                        ></Marker>
+                                    ); // Draw a marker in the middle (roughly) of the path with miles and walk time
+                                }
+                                waypointIndex++;
+                            }
+                        }
+                        this.setState({ poly: poly });
+                    });
+                });
+            }
         } else {
             this.setState({ poly: [] });
         }
@@ -195,19 +210,20 @@ export default class UCIMap extends PureComponent {
         let pinnedCourses = new Set();
         let index = 0;
 
+        // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
         this.state.eventsInCalendar
+            .filter(
+                (event) =>
+                    !(
+                        event.isCustomEvent ||
+                        !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
+                        !event.start.toString().includes(DAYS[this.state.day])
+                    )
+            )
             .sort((event, event2) => event.start - event2.start)
             .forEach((event) => {
-                // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-                if (
-                    event.isCustomEvent ||
-                    !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
-                    !event.start.toString().includes(DAYS[this.state.day])
-                )
-                    return;
-
                 // Get building code, get id of building code, which will get us the building data from buildingCatalogue
-                const buildingCode = event.bldg.split(' ')[0];
+                const buildingCode = event.bldg.split(' ').slice(0, -1).join(' ');
                 const id = locations[buildingCode];
                 const locationData = buildingCatalogue[id];
                 const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -129,7 +129,7 @@ export default class UCIMap extends PureComponent {
                                 path.push([[lng, lat]]);
                                 if (waypointIndex !== 0) {
                                     function setInfoMarker(event) {
-                                        let [position, color, duration, miles] = this.options.map.state.info_markers[
+                                        let [color, duration, miles] = this.options.map.state.info_markers[
                                             this.options.index - 1
                                         ];
                                         this.options.map.setState({
@@ -195,13 +195,7 @@ export default class UCIMap extends PureComponent {
                                             ) / 100
                                         ).toString() + ' mi';
                                     // Add a marker in the middle (roughly) of the path with miles and walk time
-                                    info_markers.push([
-                                        path[waypointIndex][Math.floor(path[waypointIndex].length / 2)],
-                                        colors[waypointIndex - 1],
-                                        duration,
-                                        miles,
-                                        0.0,
-                                    ]);
+                                    info_markers.push([colors[waypointIndex - 1], duration, miles, 0.0]);
                                 }
                                 waypointIndex++;
                             }

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -170,6 +170,17 @@ export default class UCIMap extends PureComponent {
                                             }}
                                         />
                                     ); // Draw path from last waypoint to next waypoint
+
+                                    poly.push(
+                                        <Polyline
+                                            color={colors[waypointIndex - 1]}
+                                            positions={[
+                                                path[waypointIndex][path[waypointIndex].length - 1],
+                                                coords_array[waypointIndex],
+                                            ]}
+                                            dashArray="4"
+                                        />
+                                    ); // Draw a dashed line directly to waypoint
                                     let duration =
                                         obj['routes'][0]['legs'][waypointIndex - 1]['duration'] > 30
                                             ? Math.round(
@@ -182,17 +193,6 @@ export default class UCIMap extends PureComponent {
                                                 obj['routes'][0]['legs'][waypointIndex - 1]['distance'] / 1.609 / 10
                                             ) / 100
                                         ).toString() + ' mi';
-                                    poly.push(
-                                        <Polyline
-                                            color={colors[waypointIndex - 1]}
-                                            positions={[
-                                                path[waypointIndex][path[waypointIndex].length - 1],
-                                                coords_array[waypointIndex],
-                                            ]}
-                                            dashArray="4"
-                                        />
-                                    ); // Draw a dashed line directly to waypoint
-
                                     // Add a marker in the middle (roughly) of the path with miles and walk time
                                     info_markers.push([
                                         path[waypointIndex][Math.floor(path[waypointIndex].length / 2)],

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent, createRef } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { Map, TileLayer, withLeaflet, Polyline } from 'react-leaflet';
 import buildingCatalogue from './static/buildingCatalogue';
 import locations from '../SectionTable/static/locations.json';
@@ -49,36 +49,36 @@ export default class UCIMap extends PureComponent {
         poly: [],
     };
 
-    refPolyline = createRef();
-
     getRoute = (day) => {
         let index = 0;
         let coords = '';
         let colors = [];
-        this.state.eventsInCalendar.forEach((event) => {
-            // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-            if (
-                event.isCustomEvent ||
-                !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
-                !event.start.toString().includes(DAYS[day])
-            )
-                return;
+        this.state.eventsInCalendar
+            .sort((event, event2) => event.start - event2.start)
+            .forEach((event) => {
+                // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
+                if (
+                    event.isCustomEvent ||
+                    !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
+                    !event.start.toString().includes(DAYS[day])
+                )
+                    return;
 
-            // Get building code, get id of building code, which will get us the building data from buildingCatalogue
-            const buildingCode = event.bldg.split(' ')[0];
-            const id = locations[buildingCode];
-            const locationData = buildingCatalogue[id];
+                // Get building code, get id of building code, which will get us the building data from buildingCatalogue
+                const buildingCode = event.bldg.split(' ')[0];
+                const id = locations[buildingCode];
+                const locationData = buildingCatalogue[id];
 
-            if (locationData === undefined) return;
+                if (locationData === undefined) return;
 
-            colors.push(event.color);
+                colors.push(event.color);
 
-            if (day) {
-                if (coords) coords += ';';
-                coords += locationData.lng + ',' + locationData.lat;
-            }
-            index++;
-        });
+                if (day) {
+                    if (coords) coords += ';';
+                    coords += locationData.lng + ',' + locationData.lat;
+                }
+                index++;
+            });
         if (day && index > 1) {
             var url = new URL(DIRECTIONS_ENDPOINT + encodeURIComponent(coords));
 
@@ -144,51 +144,53 @@ export default class UCIMap extends PureComponent {
         let pinnedCourses = new Set();
         let index = 0;
 
-        this.state.eventsInCalendar.forEach((event) => {
-            // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-            if (
-                event.isCustomEvent ||
-                !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
-                !event.start.toString().includes(DAYS[this.state.day])
-            )
-                return;
+        this.state.eventsInCalendar
+            .sort((event, event2) => event.start - event2.start)
+            .forEach((event) => {
+                // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
+                if (
+                    event.isCustomEvent ||
+                    !event.scheduleIndices.includes(this.state.currentScheduleIndex) ||
+                    !event.start.toString().includes(DAYS[this.state.day])
+                )
+                    return;
 
-            // Get building code, get id of building code, which will get us the building data from buildingCatalogue
-            const buildingCode = event.bldg.split(' ')[0];
-            const id = locations[buildingCode];
-            const locationData = buildingCatalogue[id];
-            const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;
+                // Get building code, get id of building code, which will get us the building data from buildingCatalogue
+                const buildingCode = event.bldg.split(' ')[0];
+                const id = locations[buildingCode];
+                const locationData = buildingCatalogue[id];
+                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;
 
-            if (locationData === undefined || pinnedCourses.has(courseString)) return;
+                if (locationData === undefined || pinnedCourses.has(courseString)) return;
 
-            // Acronym, if it exists, is in between parentheses
-            const acronym = locationData.name.substring(
-                locationData.name.indexOf('(') + 1,
-                locationData.name.indexOf(')')
-            );
+                // Acronym, if it exists, is in between parentheses
+                const acronym = locationData.name.substring(
+                    locationData.name.indexOf('(') + 1,
+                    locationData.name.indexOf(')')
+                );
 
-            pinnedCourses.add(courseString);
+                pinnedCourses.add(courseString);
 
-            markers.push(
-                <MapMarkerPopup
-                    image={locationData.imageURLs[0]}
-                    markerColor={event.color}
-                    location={locationData.name}
-                    lat={locationData.lat}
-                    lng={locationData.lng}
-                    acronym={acronym}
-                    index={this.state.day ? (index + 1).toString() : ''}
-                >
-                    <Fragment>
-                        <hr />
-                        Class: {`${event.title} ${event.sectionType}`}
-                        <br />
-                        Room: {event.bldg.split(' ')[1]}
-                    </Fragment>
-                </MapMarkerPopup>
-            );
-            index++;
-        });
+                markers.push(
+                    <MapMarkerPopup
+                        image={locationData.imageURLs[0]}
+                        markerColor={event.color}
+                        location={locationData.name}
+                        lat={locationData.lat}
+                        lng={locationData.lng}
+                        acronym={acronym}
+                        index={this.state.day ? (index + 1).toString() : ''}
+                    >
+                        <Fragment>
+                            <hr />
+                            Class: {`${event.title} ${event.sectionType}`}
+                            <br />
+                            Room: {event.bldg.split(' ')[1]}
+                        </Fragment>
+                    </MapMarkerPopup>
+                );
+                index++;
+            });
 
         return markers;
     };

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -283,7 +283,7 @@ export default class UCIMap extends PureComponent {
                             <hr />
                             Class: {`${event.title} ${event.sectionType}`}
                             <br />
-                            Room: {event.bldg.split(' ')[1]}
+                            Room: {event.bldg.split(' ').slice(-1)}
                         </Fragment>
                     </MapMarkerPopup>
                 );

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -73,7 +73,7 @@ export default class UCIMap extends PureComponent {
         // Tracks courses that have already been pinned on the map, so there are no duplicates
         let pinnedCourses = new Set();
 
-        this.state.eventsInCalendar.forEach((event) => {
+        this.state.eventsInCalendar.forEach((event, index) => {
             // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
             if (
                 event.isCustomEvent ||
@@ -106,6 +106,7 @@ export default class UCIMap extends PureComponent {
                     lat={locationData.lat}
                     lng={locationData.lng}
                     acronym={acronym}
+                    index={this.state.day ? (index + 1).toString() : ""}
                 >
                     <Fragment>
                         <hr />

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -195,7 +195,7 @@ export default class UCIMap extends PureComponent {
                                             ) / 100
                                         ).toString() + ' mi';
                                     // Add a marker in the middle (roughly) of the path with miles and walk time
-                                    info_markers.push([colors[waypointIndex - 1], duration, miles, 0.0]);
+                                    info_markers.push([colors[waypointIndex - 1], duration, miles]);
                                 }
                                 waypointIndex++;
                             }

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -7,7 +7,6 @@ import DayTabs from './MapTabsAndSearchBar';
 import MapMarkerPopup from './MapMarkerPopup';
 import Locate from 'leaflet.locatecontrol';
 import Leaflet from 'leaflet';
-import { duration } from '@material-ui/core';
 
 class LocateControl extends PureComponent {
     componentDidMount() {
@@ -54,6 +53,9 @@ export default class UCIMap extends PureComponent {
     };
 
     getRoute = (day) => {
+        // Clear any existing route on the map
+        this.setState({ poly: [], info_marker: null });
+        
         if (day) {
             let index = 0;
             let coords = ''; // lat and lng of markers to be passed to api
@@ -129,6 +131,7 @@ export default class UCIMap extends PureComponent {
                                 if (waypointIndex !== 0) {
                                     poly.push(
                                         <Polyline
+                                            zIndexOffset={100}
                                             color={colors[waypointIndex - 1]}
                                             positions={path[waypointIndex]}
                                             index={waypointIndex}
@@ -209,8 +212,6 @@ export default class UCIMap extends PureComponent {
                     });
                 });
             }
-        } else {
-            this.setState({ poly: [], info_marker: null });
         }
     };
 
@@ -259,7 +260,7 @@ export default class UCIMap extends PureComponent {
                 const locationData = buildingCatalogue[id];
                 const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;
 
-                index++; // index temp fix for courses in same building
+                index++; // always increment index to account for courses within the same building
                 if (locationData === undefined || pinnedCourses.has(courseString)) return;
 
                 // Acronym, if it exists, is in between parentheses
@@ -278,7 +279,7 @@ export default class UCIMap extends PureComponent {
                         lat={locationData.lat}
                         lng={locationData.lng}
                         acronym={acronym}
-                        index={this.state.day ? (index + 1).toString() : ''}
+                        index={this.state.day ? index.toString() : ''}
                     >
                         <Fragment>
                             <hr />

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -52,7 +52,7 @@ export default class UCIMap extends PureComponent {
         info_marker: null,
     };
 
-    getRoute = (day) => {
+    generateRoute = (day) => {
         // Clear any existing route on the map
         this.setState({ poly: [], info_marker: null });
 
@@ -323,7 +323,7 @@ export default class UCIMap extends PureComponent {
                         day={this.state.day}
                         setDay={(day) => {
                             this.setState({ day: day });
-                            this.getRoute(day);
+                            this.generateRoute(day);
                         }}
                         handleSearch={this.handleSearch}
                     />

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -83,13 +83,12 @@ export default class UCIMap extends PureComponent {
 
                     colors.push(event.color);
 
-                    if (day) {
-                        if (coords) {
-                            coords += ';';
-                        }
-                        coords += locationData.lng + ',' + locationData.lat;
-                        coords_array.push([locationData.lat, locationData.lng]);
+                    if (coords) {
+                        coords += ';';
                     }
+                    coords += locationData.lng + ',' + locationData.lat;
+                    coords_array.push([locationData.lat, locationData.lng]);
+
                     index++;
                 });
             if (index > 1) {

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -259,6 +259,7 @@ export default class UCIMap extends PureComponent {
                 const locationData = buildingCatalogue[id];
                 const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;
 
+                index++; // index temp fix for courses in same building
                 if (locationData === undefined || pinnedCourses.has(courseString)) return;
 
                 // Acronym, if it exists, is in between parentheses
@@ -287,7 +288,6 @@ export default class UCIMap extends PureComponent {
                         </Fragment>
                     </MapMarkerPopup>
                 );
-                index++;
             });
         return markers;
     };

--- a/client/src/components/Map/UCIMap.js
+++ b/client/src/components/Map/UCIMap.js
@@ -194,7 +194,7 @@ export default class UCIMap extends PureComponent {
                                                 obj['routes'][0]['legs'][waypointIndex - 1]['distance'] / 1.609 / 10
                                             ) / 100
                                         ).toString() + ' mi';
-                                    // Add a marker in the middle (roughly) of the path with miles and walk time
+                                    // Add marker info (colors, duration, mile)
                                     info_markers.push([colors[waypointIndex - 1], duration, miles]);
                                 }
                                 waypointIndex++;

--- a/client/src/stores/AppStore.js
+++ b/client/src/stores/AppStore.js
@@ -19,6 +19,7 @@ class AppStore extends EventEmitter {
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
+        this.setMaxListeners(100);
 
         let darkMode = null;
         if (typeof Storage !== 'undefined') darkMode = window.localStorage.getItem('DarkMode');
@@ -128,6 +129,7 @@ class AppStore extends EventEmitter {
                 this.emit('addedCoursesChange');
                 break;
             case 'CHANGE_CURRENT_SCHEDULE':
+                console.log('change current schedule');
                 this.currentScheduleIndex = action.newScheduleIndex;
                 this.emit('currentScheduleIndexChange');
                 break;

--- a/client/src/stores/AppStore.js
+++ b/client/src/stores/AppStore.js
@@ -19,7 +19,6 @@ class AppStore extends EventEmitter {
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
-        this.setMaxListeners(100);
 
         let darkMode = null;
         if (typeof Storage !== 'undefined') darkMode = window.localStorage.getItem('DarkMode');
@@ -129,7 +128,6 @@ class AppStore extends EventEmitter {
                 this.emit('addedCoursesChange');
                 break;
             case 'CHANGE_CURRENT_SCHEDULE':
-                console.log('change current schedule');
                 this.currentScheduleIndex = action.newScheduleIndex;
                 this.emit('currentScheduleIndexChange');
                 break;


### PR DESCRIPTION
## Summary
Added indexes to map (was retroactively taken out from the repo after the new merge) 
Added routing to map 
Uses Directions API and not the Static Tile API, which allows for 100,000 requests for free https://www.mapbox.com/pricing/#navigation so it should not be a problem. The fetches are cached so it should not use many API requests.
This is only used to give rough estimates for a schedule. It is not suppose to show exactly where the classes are. The direction API are given coordinates that were already included in AntAlmanac's json file.

https://user-images.githubusercontent.com/8692395/126052532-0535e80c-a9f3-4eb5-95c1-1ead409a44b9.mp4

## Test Plan
Tested when there is only 2 courses are less and added checks for these cases

## Future Followup (Optional)

Add the markers to show up on hover on path? This may cause the user to not know about this feature.
Possibly lookup the exactly location of classes. (Not sure if mapbox has this but it would be nice if we have map.uci.edu access) 