### PR TITLE
Add GDIM to the Dept Search Bar

### DIFF
--- a/client/src/components/SearchForm/DeptSearchBar/depts.js
+++ b/client/src/components/SearchForm/DeptSearchBar/depts.js
@@ -55,6 +55,7 @@ export default [
     { deptLabel: 'FIN: Finance', deptValue: 'FIN' },
     { deptLabel: 'FLM&MDA: Film and Media Studies', deptValue: 'FLM&MDA' },
     { deptLabel: 'FRENCH: French', deptValue: 'FRENCH' },
+    { deptLabel: 'GDIM: Game Design and Interactive Media', deptValue: 'GDIM' },
     { deptLabel: 'GEN&SEX: Gender and Sexuality Studies', deptValue: 'GEN&SEX' },
     { deptLabel: 'GERMAN: German', deptValue: 'GERMAN' },
     { deptLabel: 'GLBL ME: Global Middle East Studies', deptValue: 'GLBL ME' },


### PR DESCRIPTION
## Summary
GDIM (Game Design and Interactive Media) is a new department, added for Fall 2021. 
Before this PR, users were unable to add any GDIM courses to their schedule.

## Test Plan
Verify that GDIM appears in the dept search bar and that users can add a class to their schedule.
