### PR TITLE
Rename start script to "npm start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 `npm run dependency-install`
 
 3. Start the development server  
-`npm run dev`
+`npm start`
 
 4. The site should load on http://localhost:3000  
 As you make changes to the React application in `client/src`, those changes will be automatically reflected on the site.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dependency-install": "concurrently \"npm run client-install\" \"npm run server-install\"",
         "server": "cd antalmanac-backend && sls offline --stage development --noPrependStageInUrl",
         "client": "npm run start --prefix ./client",
-        "dev": "concurrently \"npm run server\" \"npm run client\""
+        "start": "concurrently \"npm run server\" \"npm run client\""
     },
     "devDependencies": {
         "concurrently": "^5.3.0",


### PR DESCRIPTION
## Summary
Previously the command to start the application was "npm run dev".
This starts the backend and frontend concurrently.

Now that trigger has been renamed to "npm start" to match most other react projects.

## Test Plan
Run `npm start` and verify that the projects starts like normal.
