### PR TITLE
Query PeterPortal API directly for CourseInfoBar

### DIFF
--- a/client/src/api/endpoints.js
+++ b/client/src/api/endpoints.js
@@ -11,5 +11,8 @@ export const AD_IMAGE_ENDPOINT = endpointTransform('/api/banners/getAdImage');
 export const LOAD_DATA_ENDPOINT = endpointTransform('/api/users/loadUserData');
 export const SAVE_DATA_ENDPOINT = endpointTransform('/api/users/saveUserData');
 export const ENROLLMENT_DATA_ENDPOINT = endpointTransform('/api/enrollmentData');
-export const PETERPORTAL_DATA_ENDPOINT = endpointTransform('/api/peterportalapi');
 export const NEWS_ENDPOINT = endpointTransform('/api/news');
+
+// PeterPortal API
+export const PETERPORTAL_REST_ENDPOINT = 'https://api.peterportal.org/rest/v0';
+export const PETERPORTAL_GRAPHQL_ENDPOINT = 'https://api.peterportal.org/graphql';

--- a/client/src/components/SectionTable/CourseInfoBar.js
+++ b/client/src/components/SectionTable/CourseInfoBar.js
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { Button, Popover } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { MoreVert } from '@material-ui/icons';
-import { PETERPORTAL_DATA_ENDPOINT } from '../../api/endpoints';
+import { PETERPORTAL_REST_ENDPOINT } from '../../api/endpoints';
 
 const styles = () => ({
     rightSpace: {
@@ -44,7 +44,8 @@ class CourseInfoBar extends PureComponent {
             if (this.state.loading === true) {
                 const { courseNumber, deptCode } = this.props;
                 try {
-                    const response = await fetch(`${PETERPORTAL_DATA_ENDPOINT}/courses/${deptCode}/${courseNumber}`);
+                    const courseId = `${deptCode.replace(/\s/g, '')}${courseNumber.replace(/\s/g, '')}`;
+                    const response = await fetch(`${PETERPORTAL_REST_ENDPOINT}/courses/${courseId}`);
 
                     if (response.ok) {
                         const jsonResp = await response.json();


### PR DESCRIPTION
## Summary
This sends a request directly to the PeterPortal Rest API for course information. It's unnecessary (and slower) to go through our own backend as a proxy.

## Test Plan
- Go to any course and click on the course title.  
- Verify that course information is displayed in the CourseInfoBar (no "No description available" error)

## Issues
Closes #177

## Future Followup 
Use graphql instead of REST to fetch course info. 