### PR TITLE
fix unintended trigger of undo GA event

### DIFF
--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -291,11 +291,6 @@ export const addCustomEvent = (customEvent) => {
 export const undoDelete = (event) => {
     const deletedCourses = AppStore.getDeletedCourses();
 
-    ReactGA.event({
-        category: 'antalmanac-rewrite',
-        action: 'Click Undo button',
-    });
-
     if (deletedCourses.length > 0 && (event == null || (event.keyCode === 90 && (event.ctrlKey || event.metaKey)))) {
         const lastDeleted = deletedCourses[deletedCourses.length - 1];
 
@@ -314,6 +309,11 @@ export const undoDelete = (event) => {
                 }.`
             );
         }
+
+        ReactGA.event({
+            category: 'antalmanac-rewrite',
+            action: 'Click Undo button',
+        });
     }
 };
 


### PR DESCRIPTION
## Summary
An unintended Google Analytics event was being sent on every keypress. Moved the event inside the if statement checking that they key is actually pressed, and that there was a valid delete that can be undone. 

## Test Plan
1. Open devtools
2. Press multiple random keys, no event should be sent.
3. Confirm GA event is sent when undo button or ctrl+z pressed and there is a class to undo deletion.

## Issues
Resolves #178 

## Future Followup:
From [Chase's comment](https://github.com/icssc-projects/AntAlmanac/issues/178#issue-971282055):

Having undoButton fire on every keydown is pretty poor design. We should probably have some sort of helper function called keyPressed that is inbetween. It would check if the keys were ctr+z before calling the undoButton function.