### PR TITLE
Add postinstall script, remove unused npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 2. Navigate to the root directory and install the dependencies  
 `cd AntAlmanac`  
 `npm install`  
-`npm run dependency-install`
 
 3. Start the development server  
 `npm start`

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2139,15 +2139,6 @@
                 "@xtuc/long": "4.2.2"
             }
         },
-        "@welldone-software/why-did-you-render": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-4.2.5.tgz",
-            "integrity": "sha512-Uq4Gmi14bHDfWPGu1EuZKkdxlihXIyyfhAoP0nkA3qHTu8yit0iL1KO6Ldyno55otnjL3GHUY/MswMVvB5Ro8g==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4"
-            }
-        },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -11695,21 +11686,6 @@
                     "requires": {
                         "isexe": "^2.0.0"
                     }
-                }
-            }
-        },
-        "react-device-detect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.13.1.tgz",
-            "integrity": "sha512-XTPgAMsUVHC5lMNUGiAeO2UfAfhMfjq0CBUM67eHnc9XfO7iESh6h/cffKV8VGgrZBX+dyuqJl23bLLHoav5Ig==",
-            "requires": {
-                "ua-parser-js": "^0.7.21"
-            },
-            "dependencies": {
-                "ua-parser-js": {
-                    "version": "0.7.21",
-                    "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-                    "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
                 }
             }
         },

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,6 @@
         "react": "^16.13.1",
         "react-big-calendar": "^0.24.6",
         "react-color": "^2.18.1",
-        "react-device-detect": "^1.13.1",
         "react-dom": "^16.13.1",
         "react-ga": "^2.7.0",
         "react-input-mask": "^2.0.4",
@@ -38,9 +37,6 @@
         "nodemon": "^1.14.6",
         "test": "react-scripts test --env=jsdom",
         "eject": "react-scripts eject"
-    },
-    "devDependencies": {
-        "@welldone-software/why-did-you-render": "^4.2.5"
     },
     "browserslist": [
         ">0.2%",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "client-install": "cd ./client && npm install",
         "server-install": "cd ./antalmanac-backend && npm install",
         "dependency-install": "concurrently \"npm run client-install\" \"npm run server-install\"",
+        "postinstall": "npm run dependency-install",
         "server": "cd antalmanac-backend && sls offline --stage development --noPrependStageInUrl",
         "client": "npm run start --prefix ./client",
         "start": "concurrently \"npm run server\" \"npm run client\""

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "scripts": {
         "client-install": "cd ./client && npm install",
         "server-install": "cd ./antalmanac-backend && npm install",
-        "dependency-install": "concurrently \"npm run client-install\" \"npm run server-install\"",
+        "dependency-install": "concurrently -n \"BACKEND,FRONTEND\" \"npm run server-install\" \"npm run client-install\"",
         "postinstall": "npm run dependency-install",
         "server": "cd antalmanac-backend && sls offline --stage development --noPrependStageInUrl",
         "client": "npm run start --prefix ./client",
-        "start": "concurrently \"npm run server\" \"npm run client\""
+        "start": "concurrently -n \"BACKEND,FRONTEND\" \"npm run server\" \"npm run client\""
     },
     "devDependencies": {
         "concurrently": "^5.3.0",


### PR DESCRIPTION
## Summary
After running `npm install`, this will automatically trigger `npm run dependency-install`. This simplifies the setup process, since a new dev now only needs to run `npm install`.

This PR also removes unnecessary npm packages.

concurrently processes are now named `FRONTEND` and `BACKEND` to be more descriptive (before it was `0` and `1`).

## Test Plan
npm install script
- clear node modules from ./, ./client, and ./antalmanac-backend
- run `npm install` or `npm i`
- verify that the postinstall script triggered `npm run dependency-install` and added the node-modules to client and backened
- verify that running `npm install <random package>` in `./` or `./` client doesn't trigger the postinstall script

unnecessary npm packages
- run `npx depcheck` in ./ and ./client
- verify there are no unused dependencies or devDependencies

## Issues
Related to #183 