### PR TITLE
Use PeterPortal API Websoc endpoint instead of AntAlmanac's

### DIFF
--- a/client/src/api/endpoints.js
+++ b/client/src/api/endpoints.js
@@ -14,5 +14,6 @@ export const ENROLLMENT_DATA_ENDPOINT = endpointTransform('/api/enrollmentData')
 export const NEWS_ENDPOINT = endpointTransform('/api/news');
 
 // PeterPortal API
-export const PETERPORTAL_REST_ENDPOINT = 'https://api.peterportal.org/rest/v0';
 export const PETERPORTAL_GRAPHQL_ENDPOINT = 'https://api.peterportal.org/graphql';
+export const PETERPORTAL_REST_ENDPOINT = 'https://api.peterportal.org/rest/v0';
+export const PETERPORTAL_WEBSOC_ENDPOINT = `${PETERPORTAL_REST_ENDPOINT}/schedule/soc`;

--- a/client/src/components/CoursePane/CourseRenderPane.js
+++ b/client/src/components/CoursePane/CourseRenderPane.js
@@ -9,9 +9,10 @@ import RightPaneStore from '../../stores/RightPaneStore';
 import loadingGif from '../SearchForm/Gifs/loading.gif';
 import darkModeLoadingGif from '../SearchForm/Gifs/dark-loading.gif';
 import AdBanner from '../AdBanner/AdBanner';
-import { RANDOM_AD_ENDPOINT, WEBSOC_ENDPOINT } from '../../api/endpoints';
+import { RANDOM_AD_ENDPOINT } from '../../api/endpoints';
 import GeDataFetchProvider from '../SectionTable/GEDataFetchProvider';
 import LazyLoad from 'react-lazyload';
+import { queryWebsoc } from '../../helpers';
 
 const styles = (theme) => ({
     course: {
@@ -142,11 +143,7 @@ class CourseRenderPane extends PureComponent {
             };
 
             try {
-                const response = await fetch(WEBSOC_ENDPOINT, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(params),
-                });
+                const response = await queryWebsoc(params);
 
                 if (response.ok) {
                     const jsonResp = await response.json();

--- a/client/src/components/EnrollmentGraph/GraphModalContent.js
+++ b/client/src/components/EnrollmentGraph/GraphModalContent.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { FormControl, InputLabel, MenuItem, Paper, Select, Typography } from '@material-ui/core';
 import GraphRenderPane from './GraphRenderPane';
-import { WEBSOC_ENDPOINT } from '../../api/endpoints';
+import { queryWebsoc } from '../../helpers';
 
 const styles = {
     paper: {
@@ -43,11 +43,7 @@ class GraphModalContent extends PureComponent {
             courseNumber: this.props.courseDetails.courseNumber,
         };
 
-        const response = await fetch(WEBSOC_ENDPOINT, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(params),
-        });
+        const response = await queryWebsoc(params);
 
         const jsonResp = await response.json();
 

--- a/client/src/components/SectionTable/GEDataFetchProvider.js
+++ b/client/src/components/SectionTable/GEDataFetchProvider.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import SectionTable from './SectionTable';
 import RightPaneStore from '../../stores/RightPaneStore';
-import { WEBSOC_ENDPOINT } from '../../api/endpoints';
+import { queryWebsoc } from '../../helpers';
 
 class GeDataFetchProvider extends PureComponent {
     state = {
@@ -20,11 +20,7 @@ class GeDataFetchProvider extends PureComponent {
             courseTitle: this.props.courseDetails.courseTitle,
         };
 
-        const response = await fetch(WEBSOC_ENDPOINT, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(params),
-        });
+        const response = await queryWebsoc(params);
 
         const jsonResp = await response.json();
 

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -1,5 +1,5 @@
 import { openSnackbar } from './actions/AppStoreActions';
-import { WEBSOC_ENDPOINT } from './api/endpoints';
+import { PETERPORTAL_WEBSOC_ENDPOINT, WEBSOC_ENDPOINT } from './api/endpoints';
 
 export async function getCoursesData(userData) {
     const dataToSend = {};
@@ -34,12 +34,7 @@ export async function getCoursesData(userData) {
                 sectionCodes: sectionArray.join(','),
             };
 
-            const response = await fetch(WEBSOC_ENDPOINT, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(params),
-            });
-
+            const response = await queryWebsoc(params);
             const jsonResp = await response.json();
 
             for (const school of jsonResp.schools) {
@@ -66,6 +61,28 @@ export async function getCoursesData(userData) {
         addedCourses: addedCourses,
         customEvents: userData.customEvents,
     };
+}
+
+export async function queryWebsoc(params) {
+    // Construct a request to PeterPortal with the params as a query string
+    const url = new URL(PETERPORTAL_WEBSOC_ENDPOINT);
+    url.search = new URLSearchParams(params).toString();
+    const response = await fetch(url);
+
+    if (response.ok || response.status === 400) {
+        // Return the PeterPortal API response if the status is ok
+        // or if the status is 400 (means the paramaters were invalid)
+        return response;
+    } else {
+        // If the PeterPortal API is down,
+        // attempt to use the former AntAlamanc websoc endpoint
+        const backupResponse = await fetch(WEBSOC_ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(params),
+        });
+        return backupResponse;
+    }
 }
 
 export function clickToCopy(event, sectionCode) {


### PR DESCRIPTION
## Summary
Created a new helper function to fetch websoc data.
This helper will now query the PeterPortal API for websoc data.
If the API is down, it will use the old AntAlmanac endpoint as a backup.

Reasons for doing this
- PeterPortal API does not have CORS restrictions. Any open source developer would be able to work on the frontend without the AntAlmanac backend.
- No duplicate code. The logic is the same between PP API endpoint and AntAlmanac's.
- GraphQL support (if we want to use that in the future)
- PP API is working on caching old catalogues
- PP API will have a copy of the current term's courses, which will automatically be used if Websoc implements rate limiting again.

## Test Plan
- Monitor network requests and verify that websoc requests are going to PeterPortal, not our backend
- Intentionally fail a request to PeterPortal API and verify that the frontend falls back to using the original backend endpoint

## Issues
Closes #181 
Relates to #183 

## Future Followup
Consider using graphql instead of rest endpoint