### PR TITLE
Fix .ics download safari bug

### DIFF
--- a/client/src/components/Calendar/ExportCalendar.js
+++ b/client/src/components/Calendar/ExportCalendar.js
@@ -37,7 +37,7 @@ const getByDays = (days) => {
 //  Ex: ("2021 Spring", 'Tu') -> [2021, 3, 30]
 const getClassStartDate = (term, bydays) => {
     // Get the start date of the quarter (Monday)
-    const quarterStartDate = new Date(quarterStartDates[term]);
+    const quarterStartDate = new Date(...quarterStartDates[term]);
 
     // dayOffset represents the number of days since the start of the quarter
     var dayOffset;


### PR DESCRIPTION
## Summary
Safari needs `new Date` objects to provides year, month, and day as args, not as a list.
By destucturing the term, we are able to download for both safari and chrome.

## Test Plan
Verify that you can download a schedule as .ics on Safari, FireFox, and Chrome

## Issues
Closes #191 
