### PR TITLE
Fix clearing a schedule would clear courses/events that appear only in one schedule

### DIFF
--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -256,25 +256,15 @@ export const clearSchedules = (scheduleIndicesToClear) => {
     const addedCourses = AppStore.getAddedCourses();
     const customEvents = AppStore.getCustomEvents();
     const addedCoursesAfterClear = addedCourses.filter((course) => {
-        if (course.scheduleIndices.length === 1) {
-            return false;
-        } else {
-            course.scheduleIndices = course.scheduleIndices.filter((index) => !scheduleIndicesToClear.includes(index));
-
-            return course.scheduleIndices.length !== 0;
-        }
+        course.scheduleIndices = course.scheduleIndices.filter((index) => !scheduleIndicesToClear.includes(index));
+        return course.scheduleIndices.length !== 0;
     });
 
     const customEventsAfterClear = customEvents.filter((customEvent) => {
-        if (customEvent.scheduleIndices.length === 1) {
-            return false;
-        } else {
-            customEvent.scheduleIndices = customEvent.scheduleIndices.filter(
-                (index) => !scheduleIndicesToClear.includes(index)
-            );
-
-            return customEvent.scheduleIndices.length !== 0;
-        }
+        customEvent.scheduleIndices = customEvent.scheduleIndices.filter(
+            (index) => !scheduleIndicesToClear.includes(index)
+        );
+        return customEvent.scheduleIndices.length !== 0;
     });
 
     dispatcher.dispatch({


### PR DESCRIPTION
## Summary
This bug is caused by an extra check that would cause courses and events to not be included if they only appeared in one schedule.
I am not sure why this is here besides potentially speeding the course deletion up if the course was only in one schedule, but it doesn't check if the one schedule is the current schedule. It seems to be unnecessary anyways.
## Test Plan
1. Add courses into a schedule
2. Go to a different schedule
3. Clear schedule
4. Examine that courses in the original schedule are also deleted
## Issues
Fixes #190 
## Future Followup (Optional)
