### PR TITLE
URL encode Course Description API requests

### DIFF
--- a/client/src/components/SectionTable/CourseInfoBar.js
+++ b/client/src/components/SectionTable/CourseInfoBar.js
@@ -44,7 +44,9 @@ class CourseInfoBar extends PureComponent {
             if (this.state.loading === true) {
                 const { courseNumber, deptCode } = this.props;
                 try {
-                    const courseId = `${deptCode.replace(/\s/g, '')}${courseNumber.replace(/\s/g, '')}`;
+                    const courseId = encodeURIComponent(
+                        `${deptCode.replace(/\s/g, '')}${courseNumber.replace(/\s/g, '')}`
+                    );
                     const response = await fetch(`${PETERPORTAL_REST_ENDPOINT}/courses/${courseId}`);
 
                     if (response.ok) {


### PR DESCRIPTION
## Summary
Previously the department wasn't encoded, so ones like "CHC/LAT" would 404.
This encodes the course id so that the API can parse it correctly.

## Test Plan
- Search or CHC/LAT courses
- Click on the course info button
- Verify that request succeeds

- Search for a normal course (e.g. COMPSCI)
- Click on the course info button
- Verify that request succeeds

## Issues
Closes #200 