### PR TITLE
Add Winter 2022 Class Schedule

### DIFF
--- a/client/src/components/Calendar/ExportCalendar.js
+++ b/client/src/components/Calendar/ExportCalendar.js
@@ -8,15 +8,17 @@ import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
 
 // Hardcoded first mondays
+// Note: months are 0-indexed
 // TODO(chase): support summer sessions
 const quarterStartDates = {
-    '2019 Fall': [2019, 9, 26],
-    '2020 Winter': [2020, 1, 6],
-    '2020 Spring': [2020, 3, 30],
-    '2020 Fall': [2020, 10, 1],
-    '2021 Winter': [2021, 1, 4],
-    '2021 Spring': [2021, 3, 29],
-    '2021 Fall': [2021, 9, 23],
+    '2019 Fall': [2019, 8, 26],
+    '2020 Winter': [2020, 0, 6],
+    '2020 Spring': [2020, 2, 30],
+    '2020 Fall': [2020, 9, 1],
+    '2021 Winter': [2021, 0, 4],
+    '2021 Spring': [2021, 2, 29],
+    '2021 Fall': [2021, 8, 23],
+    '2022 Winter': [2022, 0, 3],
 };
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];

--- a/client/src/components/EnrollmentGraph/GraphModalContent.js
+++ b/client/src/components/EnrollmentGraph/GraphModalContent.js
@@ -27,7 +27,7 @@ const styles = {
 
 class GraphModalContent extends PureComponent {
     state = {
-        pastTerm: '2021 Winter',
+        pastTerm: '2021 Fall',
         pastSections: null,
     };
 

--- a/client/src/components/SearchForm/TermSelector.js
+++ b/client/src/components/SearchForm/TermSelector.js
@@ -34,6 +34,7 @@ class TermSelector extends PureComponent {
             <FormControl fullWidth>
                 <InputLabel>Term</InputLabel>
                 <Select value={this.state.term} onChange={this.handleChange}>
+                    <MenuItem value={'2022 Winter'}>2022 Winter Quarter</MenuItem>
                     <MenuItem value={'2021 Fall'}>2021 Fall Quarter</MenuItem>
                     <MenuItem value={'2021 Spring'}>2021 Spring Quarter</MenuItem>
                     <MenuItem value={'2021 Winter'}>2021 Winter Quarter</MenuItem>

--- a/client/src/stores/RightPaneStore.js
+++ b/client/src/stores/RightPaneStore.js
@@ -5,7 +5,7 @@ const defaultFormValues = {
     deptValue: 'ALL',
     deptLabel: 'ALL: Include All Departments',
     ge: 'ANY',
-    term: '2021 Fall',
+    term: '2022 Winter',
     courseNumber: '',
     sectionCode: '',
     instructor: '',


### PR DESCRIPTION
## Summary
Add dropdown option for Winter 2022.
Fix bug in calendar export, where months were 1 off. Apparently #193 changed the months to be 0-indexed.

## Test Plan
- Load site, verify that "Winter 2022" is the default term option
- Search for a class under "Winter 2022", verify that classes show up
- Save Winter 2022 schedule as .ics, verify that the start/end dates are correct

## Issues
Closes #202 
