### PR TITLE
Enable notifications button for Winter 2022

### DIFF
--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -294,7 +294,7 @@ const DayAndTimeCell = withStyles(styles)((props) => {
 const StatusCell = withStyles(styles)((props) => {
     const { sectionCode, term, courseTitle, courseNumber, status, classes } = props;
 
-    if (term === '2021 Fall' && (status === 'NewOnly' || status === 'FULL')) {
+    if (term === '2022 Winter' && (status === 'NewOnly' || status === 'FULL')) {
         return (
             <NoPaddingTableCell className={`${classes[status.toLowerCase()]} ${classes.cell}`}>
                 <OpenSpotAlertPopover


### PR DESCRIPTION
## Summary
Enable the button on the frontend to signup for notifications during winter 2022.

## Test Plan
Find a full class and verify that you can click the button to enroll in notifications.

## Issues
Closes #206 