### PR TITLE
Automatic light/dark mode

### DIFF
--- a/client/src/actions/AppStoreActions.js
+++ b/client/src/actions/AppStoreActions.js
@@ -387,13 +387,13 @@ export const copySchedule = (from, to) => {
     });
 };
 
-export const toggleDarkMode = (switchEvent) => {
+export const toggleTheme = (radioGroupEvent) => {
     dispatcher.dispatch({
-        type: 'TOGGLE_DARK_MODE',
-        darkMode: switchEvent.target.checked,
+        type: 'TOGGLE_THEME',
+        theme: radioGroupEvent.target.value,
     });
     ReactGA.event({
         category: 'antalmanac-rewrite',
-        action: 'toggle dark mode',
+        action: 'toggle theme',
     });
 };

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -13,14 +13,14 @@ import DateFnsUtils from '@date-io/date-fns';
 
 class App extends PureComponent {
     state = {
-        darkMode: AppStore.getDarkMode(),
+        theme: AppStore.getTheme(),
     };
 
     componentDidMount = () => {
         document.addEventListener('keydown', undoDelete, false);
 
-        AppStore.on('darkModeToggle', () => {
-            this.setState({ darkMode: AppStore.getDarkMode() });
+        AppStore.on('themeToggle', () => {
+            this.setState({ theme: AppStore.getTheme() });
         });
 
         ReactGA.initialize('UA-133683751-1');
@@ -37,13 +37,13 @@ class App extends PureComponent {
                 MuiCssBaseline: {
                     '@global': {
                         a: {
-                            color: this.state.darkMode ? 'dodgerblue' : 'blue',
+                            color: this.state.theme === 'dark' ? 'dodgerblue' : 'blue',
                         },
                     },
                 },
             },
             palette: {
-                type: this.state.darkMode ? 'dark' : 'light',
+                type: this.state.theme === 'dark' ? 'dark' : 'light',
                 primary: {
                     main: '#305db7',
                 },

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -13,14 +13,20 @@ import DateFnsUtils from '@date-io/date-fns';
 
 class App extends PureComponent {
     state = {
-        theme: AppStore.getTheme(),
+        darkMode: this.isDarkMode(),
     };
 
     componentDidMount = () => {
         document.addEventListener('keydown', undoDelete, false);
 
         AppStore.on('themeToggle', () => {
-            this.setState({ theme: AppStore.getTheme() });
+            this.setState({ darkMode: this.isDarkMode() });
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+            if (AppStore.getTheme() === 'auto') {
+                this.setState({ darkMode: e.matches });
+            }
         });
 
         ReactGA.initialize('UA-133683751-1');
@@ -31,19 +37,30 @@ class App extends PureComponent {
         document.removeEventListener('keydown', undoDelete, false);
     }
 
+    isDarkMode() {
+        switch (AppStore.getTheme()) {
+            case 'light':
+                return false;
+            case 'dark':
+                return true;
+            default:
+                return window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+    }
+
     render() {
         const theme = createMuiTheme({
             overrides: {
                 MuiCssBaseline: {
                     '@global': {
                         a: {
-                            color: this.state.theme === 'dark' ? 'dodgerblue' : 'blue',
+                            color: this.state.darkMode ? 'dodgerblue' : 'blue',
                         },
                     },
                 },
             },
             palette: {
-                type: this.state.theme === 'dark' ? 'dark' : 'light',
+                type: this.state.darkMode ? 'dark' : 'light',
                 primary: {
                     main: '#305db7',
                 },

--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -1,15 +1,5 @@
 import React, { Fragment, PureComponent } from 'react';
-import {
-    Button,
-    FormControl,
-    FormControlLabel,
-    FormLabel,
-    Popover,
-    RadioGroup,
-    Radio,
-    Switch,
-    Paper,
-} from '@material-ui/core';
+import { Button, FormControl, FormControlLabel, FormLabel, Popover, RadioGroup, Radio, Paper } from '@material-ui/core';
 import { Settings } from '@material-ui/icons';
 import AppStore from '../../stores/AppStore';
 import { toggleTheme } from '../../actions/AppStoreActions';
@@ -72,12 +62,7 @@ class SettingsMenu extends PureComponent {
                     <Paper className={classes.container}>
                         <FormControl>
                             <FormLabel>Theme</FormLabel>
-                            <RadioGroup
-                                aria-label="theme"
-                                name="theme"
-                                defaultValue={this.state.theme}
-                                onChange={toggleTheme}
-                            >
+                            <RadioGroup aria-label="theme" name="theme" value={this.state.theme} onChange={toggleTheme}>
                                 <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
                                 <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
                                 <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />

--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -12,7 +12,7 @@ import {
 } from '@material-ui/core';
 import { Settings } from '@material-ui/icons';
 import AppStore from '../../stores/AppStore';
-import { toggleDarkMode } from '../../actions/AppStoreActions';
+import { toggleTheme } from '../../actions/AppStoreActions';
 import { withStyles } from '@material-ui/core/styles';
 import ReactGA from 'react-ga';
 
@@ -27,12 +27,12 @@ const styles = {
 class SettingsMenu extends PureComponent {
     state = {
         anchorEl: null,
-        darkMode: AppStore.getDarkMode(),
+        theme: AppStore.getTheme(),
     };
 
     componentDidMount = () => {
-        AppStore.on('darkModeToggle', () => {
-            this.setState({ darkMode: AppStore.getDarkMode() });
+        AppStore.on('themeToggle', () => {
+            this.setState({ theme: AppStore.getTheme() });
         });
     };
 
@@ -72,25 +72,16 @@ class SettingsMenu extends PureComponent {
                     <Paper className={classes.container}>
                         <FormControl>
                             <FormLabel>Theme</FormLabel>
-                            <RadioGroup aria-label="theme" name="theme" defaultValue="auto">
+                            <RadioGroup
+                                aria-label="theme"
+                                name="theme"
+                                defaultValue={this.state.theme}
+                                onChange={toggleTheme}
+                            >
                                 <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
                                 <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
                                 <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
                             </RadioGroup>
-                        </FormControl>
-
-                        <FormControl>
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        checked={this.state.darkMode}
-                                        onChange={toggleDarkMode}
-                                        value="darkMode"
-                                        color="primary"
-                                    />
-                                }
-                                label={'Dark Mode'}
-                            />
                         </FormControl>
                     </Paper>
                 </Popover>

--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -1,5 +1,15 @@
 import React, { Fragment, PureComponent } from 'react';
-import { Button, FormControl, FormControlLabel, Popover, Switch, Paper } from '@material-ui/core';
+import {
+    Button,
+    FormControl,
+    FormControlLabel,
+    FormLabel,
+    Popover,
+    RadioGroup,
+    Radio,
+    Switch,
+    Paper,
+} from '@material-ui/core';
 import { Settings } from '@material-ui/icons';
 import AppStore from '../../stores/AppStore';
 import { toggleDarkMode } from '../../actions/AppStoreActions';
@@ -60,6 +70,15 @@ class SettingsMenu extends PureComponent {
                     }}
                 >
                     <Paper className={classes.container}>
+                        <FormControl>
+                            <FormLabel>Theme</FormLabel>
+                            <RadioGroup aria-label="theme" name="theme" defaultValue="auto">
+                                <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
+                                <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
+                                <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
+                            </RadioGroup>
+                        </FormControl>
+
                         <FormControl>
                             <FormControlLabel
                                 control={

--- a/client/src/stores/AppStore.js
+++ b/client/src/stores/AppStore.js
@@ -19,17 +19,17 @@ class AppStore extends EventEmitter {
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
-
-        let darkMode = null;
-        if (typeof Storage !== 'undefined') darkMode = window.localStorage.getItem('DarkMode');
+        this.theme = (() => {
+            // either 'light', 'dark', or 'auto'
+            const theme = typeof Storage === 'undefined' ? 'auto' : window.localStorage.getItem('theme');
+            return theme === null ? 'auto' : theme;
+        })();
 
         window.addEventListener('beforeunload', (event) => {
             if (this.unsavedChanges) {
                 event.returnValue = `Are you sure you want to leave? You have unsaved changes!`;
             }
         });
-
-        this.darkMode = darkMode === null ? false : darkMode === 'true';
     }
 
     getCurrentScheduleIndex() {
@@ -76,8 +76,8 @@ class AppStore extends EventEmitter {
         return this.snackbarStyle;
     }
 
-    getDarkMode() {
-        return this.darkMode;
+    getTheme() {
+        return this.theme;
     }
 
     getAddedSectionCodes() {
@@ -212,10 +212,10 @@ class AppStore extends EventEmitter {
                 this.emit('addedCoursesChange');
                 this.emit('customEventsChange');
                 break;
-            case 'TOGGLE_DARK_MODE':
-                this.darkMode = action.darkMode;
-                this.emit('darkModeToggle');
-                window.localStorage.setItem('DarkMode', action.darkMode);
+            case 'TOGGLE_THEME':
+                this.theme = action.theme;
+                this.emit('themeToggle');
+                window.localStorage.setItem('theme', action.theme);
                 break;
             default:
                 console.log(`[Warning] AppStore invalid action type: ${action.type}`);


### PR DESCRIPTION
Here’s automatic dark mode for the people like me who use light mode in the day and dark mode in the night. I swapped out the toggle switch for a radio button selection, where “automatic” aligns with the user’s system settings. Automatic will be the default for new users, but their selection will be saved in local storage.

https://user-images.githubusercontent.com/19882060/148345503-f2cf5916-3227-46f3-9d29-74902819f991.mov

I tested this feature by switching between all combinations of light/dark/auto mode and switching my system settings. I also refreshed the page in between to ensure that the local storage and startup worked also. Feel free to test it yourself though in case I missed anything!