### PR TITLE
Remove past enrollment button (temporarily)

### DIFF
--- a/client/src/components/SectionTable/SectionTable.js
+++ b/client/src/components/SectionTable/SectionTable.js
@@ -78,7 +78,8 @@ class SectionTable extends PureComponent {
                         courseNumber={courseDetails.courseNumber}
                     />
 
-                    <AlmanacGraph courseDetails={courseDetails} />
+                    {/* Temporarily remove "Past Enrollment" until data on PeterPortal API */}
+                    {/* <AlmanacGraph courseDetails={courseDetails} />  */}
 
                     {courseDetails.prerequisiteLink ? (
                         <Typography variant="h6" style={{ flexGrow: '2', marginTop: 9 }}>


### PR DESCRIPTION
## Summary
Removed past enrollment button

## Test Plan
Ran local version and manually checked to see if button gone.
Before:
![Before](https://user-images.githubusercontent.com/53128285/150198714-1fce78c8-44ba-4c36-8d71-317ae968751e.png)
After:
![After](https://user-images.githubusercontent.com/53128285/150199211-d1349094-f7df-4ec0-896b-c285b3aa5f3d.png)

## Issues
Closes #212 