### PR TITLE
Update feedback form link, and create /feedback route

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6512,6 +6512,14 @@
             "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
             "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
         },
+        "history": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+            "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+            "requires": {
+                "@babel/runtime": "^7.7.6"
+            }
+        },
         "hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -11918,6 +11926,23 @@
                 "lodash.throttle": "^4.1.1",
                 "prop-types": "^15.6.0",
                 "resize-observer-polyfill": "^1.5.0"
+            }
+        },
+        "react-router": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+            "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+            "requires": {
+                "history": "^5.2.0"
+            }
+        },
+        "react-router-dom": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+            "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+            "requires": {
+                "history": "^5.2.0",
+                "react-router": "6.2.1"
             }
         },
         "react-scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,8 +18,8 @@
         "leaflet.locatecontrol": "^0.72.0",
         "material-ui-popup-state": "^1.6.1",
         "moment": "^2.27.0",
-        "notistack": "^1.0.2",
         "moment-timezone": "^0.5.33",
+        "notistack": "^1.0.2",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-big-calendar": "^0.24.6",
@@ -29,6 +29,7 @@
         "react-input-mask": "^2.0.4",
         "react-lazyload": "^3.1.0",
         "react-leaflet": "^2.7.0",
+        "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5"
     },

--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Single Page Apps for GitHub Pages</title>
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // MIT License
+            // https://github.com/rafgraph/spa-github-pages
+            // This script takes the current url and converts the path and query
+            // string into just a query string, and then redirects the browser
+            // to the new url with only a query string and hash fragment,
+            // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+            // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+            // Note: this 404.html file must be at least 512 bytes for it to work
+            // with Internet Explorer (it is currently > 512 bytes)
+
+            // If you're creating a Project Pages site and NOT using a custom domain,
+            // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+            // This way the code will only replace the route part of the path, and not
+            // the real directory in which the app resides, for example:
+            // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+            // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+            // Otherwise, leave pathSegmentsToKeep as 0.
+            var pathSegmentsToKeep = 0;
+
+            var l = window.location;
+            l.replace(
+                l.protocol +
+                    '//' +
+                    l.hostname +
+                    (l.port ? ':' + l.port : '') +
+                    l.pathname
+                        .split('/')
+                        .slice(0, 1 + pathSegmentsToKeep)
+                        .join('/') +
+                    '/?/' +
+                    l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+                    (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+                    l.hash
+            );
+        </script>
+    </head>
+    <body></body>
+</html>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -52,6 +52,33 @@
     -->
         <title>AntAlmanac</title>
         <!-- Global site tag (gtag.js) - Google Analytics -->
+
+        <!-- Start Single Page Apps for GitHub Pages -->
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // MIT License
+            // https://github.com/rafgraph/spa-github-pages
+            // This script checks to see if a redirect is present in the query string,
+            // converts it back into the correct url and adds it to the
+            // browser's history using window.history.replaceState(...),
+            // which won't cause the browser to attempt to load the new url.
+            // When the single page app is loaded further down in this file,
+            // the correct url will be waiting in the browser's history for
+            // the single page app to route accordingly.
+            (function (l) {
+                if (l.search[1] === '/') {
+                    var decoded = l.search
+                        .slice(1)
+                        .split('&')
+                        .map(function (s) {
+                            return s.replace(/~and~/g, '&');
+                        })
+                        .join('?');
+                    window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+                }
+            })(window.location);
+        </script>
+        <!-- End Single Page Apps for GitHub Pages -->
     </head>
     <body style="overflow: hidden">
         <noscript> You need to enable JavaScript to run this app. </noscript>

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -10,6 +10,8 @@ import DesktopTabs from '../CoursePane/DesktopTabs';
 import AppStore from '../../stores/AppStore';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Feedback from './Feedback';
 
 class App extends PureComponent {
     state = {
@@ -51,37 +53,42 @@ class App extends PureComponent {
         });
 
         return (
-            <ThemeProvider theme={theme}>
-                <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                    <CssBaseline />
-                    <Bar />
-                    <Grid container alignItems={'stretch'} style={{ flexGrow: '1' }}>
-                        <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
-                            <Calendar />
+            <BrowserRouter>
+                <Routes>
+                    <Route exact path="/feedback" element={<Feedback />} />
+                </Routes>
+                <ThemeProvider theme={theme}>
+                    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                        <CssBaseline />
+                        <Bar />
+                        <Grid container alignItems={'stretch'} style={{ flexGrow: '1' }}>
+                            <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
+                                <Calendar />
+                            </Grid>
+
+                            <DesktopTabs />
+
+                            {/*<Hidden mdUp>*/}
+                            {/*    <Grid item xs={12}>*/}
+                            {/*        <div>*/}
+                            {/*            <Tabs*/}
+                            {/*                value={this.state.activeTab}*/}
+                            {/*                onChange={this.handleTabChange}*/}
+                            {/*                variant="fullWidth"*/}
+                            {/*                indicatorColor="primary"*/}
+                            {/*                textColor="primary"*/}
+                            {/*            >*/}
+                            {/*                <Tab icon={<CalendarToday />} />*/}
+                            {/*                <Tab icon={<Search />} />*/}
+                            {/*            </Tabs>*/}
+                            {/*        </div>*/}
+                            {/*    </Grid>*/}
+                            {/*</Hidden>*/}
                         </Grid>
-
-                        <DesktopTabs />
-
-                        {/*<Hidden mdUp>*/}
-                        {/*    <Grid item xs={12}>*/}
-                        {/*        <div>*/}
-                        {/*            <Tabs*/}
-                        {/*                value={this.state.activeTab}*/}
-                        {/*                onChange={this.handleTabChange}*/}
-                        {/*                variant="fullWidth"*/}
-                        {/*                indicatorColor="primary"*/}
-                        {/*                textColor="primary"*/}
-                        {/*            >*/}
-                        {/*                <Tab icon={<CalendarToday />} />*/}
-                        {/*                <Tab icon={<Search />} />*/}
-                        {/*            </Tabs>*/}
-                        {/*        </div>*/}
-                        {/*    </Grid>*/}
-                        {/*</Hidden>*/}
-                    </Grid>
-                    <NotificationSnackbar />
-                </MuiPickersUtilsProvider>
-            </ThemeProvider>
+                        <NotificationSnackbar />
+                    </MuiPickersUtilsProvider>
+                </ThemeProvider>
+            </BrowserRouter>
         );
     }
 }

--- a/client/src/components/App/CustomAppBar.js
+++ b/client/src/components/App/CustomAppBar.js
@@ -67,7 +67,7 @@ const CustomAppBar = (props) => {
                         <Tooltip title="Give Us Feedback!">
                             <Button
                                 onClick={() => {
-                                    window.open('https://goo.gl/forms/eIHy4kp56pZKP9fK2', '_blank');
+                                    window.open('https://forms.gle/k81f2aNdpdQYeKK8A', '_blank');
                                 }}
                                 color="inherit"
                                 startIcon={<Assignment />}

--- a/client/src/components/App/Feedback.js
+++ b/client/src/components/App/Feedback.js
@@ -2,7 +2,7 @@ import { PureComponent } from 'react';
 
 class Feedback extends PureComponent {
     constructor() {
-        window.location = 'https://forms.gle/k81f2aNdpdQYeKK8A';
+        window.location.replace('https://forms.gle/k81f2aNdpdQYeKK8A');
     }
 }
 

--- a/client/src/components/App/Feedback.js
+++ b/client/src/components/App/Feedback.js
@@ -1,0 +1,9 @@
+import { PureComponent } from 'react';
+
+class Feedback extends PureComponent {
+    constructor() {
+        window.location = 'https://forms.gle/k81f2aNdpdQYeKK8A';
+    }
+}
+
+export default Feedback;


### PR DESCRIPTION
## Summary
- The Feedback button in the upper-right corner now links to the new AntAlmanac feedback form (https://forms.gle/k81f2aNdpdQYeKK8A) in a new tab.
- A new /feedback route was created; the URL antalmanac.com/feedback will now redirect to the Google Form. This was done by using React Router.

## Test Plan
- If the user enters antalmanac.com/feedback, they will be successfully redirected to the Google Form.
- If the user presses the back button, it will go back to their original page.
- If the user presses the back button and then goes forward, they will still be directed to the Google Form.
- This works on Chrome, Firefox, and Microsoft Edge.

Simple Demo:

https://user-images.githubusercontent.com/78244965/150243553-31cd371a-dff6-4a5a-9aaa-0ff905cdaa5d.mp4


## Issues
- Maybe double-check if this works on other browsers?
