### PR TITLE
Fixed search bug caused by auto light/dark mode

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -10,17 +10,18 @@ import DesktopTabs from '../CoursePane/DesktopTabs';
 import AppStore from '../../stores/AppStore';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
+import { isDarkMode } from '../../helpers';
 
 class App extends PureComponent {
     state = {
-        darkMode: this.isDarkMode(),
+        darkMode: isDarkMode(),
     };
 
     componentDidMount = () => {
         document.addEventListener('keydown', undoDelete, false);
 
         AppStore.on('themeToggle', () => {
-            this.setState({ darkMode: this.isDarkMode() });
+            this.setState({ darkMode: isDarkMode() });
         });
 
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
@@ -35,17 +36,6 @@ class App extends PureComponent {
 
     componentWillUnmount() {
         document.removeEventListener('keydown', undoDelete, false);
-    }
-
-    isDarkMode() {
-        switch (AppStore.getTheme()) {
-            case 'light':
-                return false;
-            case 'dark':
-                return true;
-            default:
-                return window.matchMedia('(prefers-color-scheme: dark)').matches;
-        }
     }
 
     render() {

--- a/client/src/components/CoursePane/CourseRenderPane.js
+++ b/client/src/components/CoursePane/CourseRenderPane.js
@@ -12,7 +12,7 @@ import AdBanner from '../AdBanner/AdBanner';
 import { RANDOM_AD_ENDPOINT } from '../../api/endpoints';
 import GeDataFetchProvider from '../SectionTable/GEDataFetchProvider';
 import LazyLoad from 'react-lazyload';
-import { queryWebsoc } from '../../helpers';
+import { queryWebsoc, isDarkMode } from '../../helpers';
 
 const styles = (theme) => ({
     course: {
@@ -191,7 +191,7 @@ class CourseRenderPane extends PureComponent {
         if (this.state.loading) {
             currentView = (
                 <div className={classes.loadingGifStyle}>
-                    <img src={AppStore.getDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
+                    <img src={isDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
                 </div>
             );
         } else if (!this.state.error) {
@@ -205,7 +205,7 @@ class CourseRenderPane extends PureComponent {
                 <div className={classes.root}>
                     {this.state.courseData.length === 0 ? (
                         <div className={classes.noResultsDiv}>
-                            <img src={AppStore.getDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
+                            <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
                         </div>
                     ) : (
                         this.state.courseData.map((_, index) => {
@@ -226,7 +226,7 @@ class CourseRenderPane extends PureComponent {
             currentView = (
                 <div className={classes.root}>
                     <div className={classes.noResultsDiv}>
-                        <img src={AppStore.getDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
+                        <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
                     </div>
                 </div>
             );

--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -12,7 +12,7 @@ import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
 import ColorAndDelete from '../AddedCourses/ColorAndDelete';
 import classNames from 'classnames';
-import { clickToCopy } from '../../helpers';
+import { clickToCopy, isDarkMode } from '../../helpers';
 
 const styles = (theme) => ({
     popover: {
@@ -33,7 +33,7 @@ const styles = (theme) => ({
     },
     tr: {
         '&.addedCourse': {
-            backgroundColor: AppStore.getDarkMode() ? '#b0b04f' : '#fcfc97',
+            backgroundColor: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
     },
     cell: {
@@ -41,7 +41,7 @@ const styles = (theme) => ({
     },
     link: {
         textDecoration: 'underline',
-        color: AppStore.getDarkMode() ? 'dodgerblue' : 'blue',
+        color: isDarkMode() ? 'dodgerblue' : 'blue',
         cursor: 'pointer',
     },
     paper: {

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -1,5 +1,6 @@
 import { openSnackbar } from './actions/AppStoreActions';
 import { PETERPORTAL_WEBSOC_ENDPOINT, WEBSOC_ENDPOINT } from './api/endpoints';
+import AppStore from './stores/AppStore';
 
 export async function getCoursesData(userData) {
     const dataToSend = {};
@@ -95,4 +96,15 @@ export function clickToCopy(event, sectionCode) {
     document.execCommand('copy');
     document.body.removeChild(tempEventTarget);
     openSnackbar('success', 'Section code copied to clipboard');
+}
+
+export function isDarkMode() {
+    switch (AppStore.getTheme()) {
+        case 'light':
+            return false;
+        case 'dark':
+            return true;
+        default:
+            return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
 }


### PR DESCRIPTION
## Summary
In my previous PR (#211), I changed the storage variable `darkMode` to `theme` to better reflect its now three possible states (light, dark, and auto). Accordingly, I changed its getter method `getDarkMode` to `getTheme`, but forgot to change all occurrences of it in the codebase. The crash was caused by attempting to call the old `getDarkMode` function which no longer existed.

Now, I’ve changed all occurrences of `getDarkMode` with a helper function `isDarkMode`, which calls `getTheme` internally and determines from its value — along with the OS’s dark mode state if in automatic mode — if the user is currently in dark or light mode.

## Test Plan
I tried searching for classes and that works as expected now. I also tried switching my OS’s setting while loading the search results to see if the loading GIF would switch between light and dark mode versions, but it loaded too fast for me to test that which makes me think that it is very rare that a user would encounter this issue (and even if they did, it wouldn’t crash the site, they just wouldn’t be able to see the loading GIF)