### PR TITLE
Add about page

### DIFF
--- a/client/src/components/App/AboutPage.js
+++ b/client/src/components/App/AboutPage.js
@@ -26,15 +26,28 @@ class AboutPage extends PureComponent {
                 <Dialog open={this.state.isOpen}>
                     <DialogTitle>About</DialogTitle>
                     <DialogContent>
-                        <DialogContentText>This is the about page.</DialogContentText>
-
-                        <Link
-                            href="#"
-                            onClick={() => window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ', '_blank')}
-                            color="primary"
-                        >
-                            Check out the ICSSC Website!
-                        </Link>
+                        <DialogContentText>
+                            AntAlmanac is a schedule planning tool for UCI students.
+                            <br />
+                            <br />
+                            The website is maintained by the{' '}
+                            <Link target="_blank" href="https://studentcouncil.ics.uci.edu/">
+                                ICS Student Council
+                            </Link>{' '}
+                            Projects Committee.
+                            <br />
+                            <br />
+                            Interested in helping out? Join our{' '}
+                            <Link target="_blank" href="https://discord.gg/GzF76D7UhY">
+                                Discord
+                            </Link>{' '}
+                            or checkout the{' '}
+                            <Link target="_blank" href="https://github.com/icssc-projects/AntAlmanac">
+                                code on GitHub
+                            </Link>
+                            .<br />
+                            <br />
+                        </DialogContentText>
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={() => this.setState({ isOpen: false })} color="primary">

--- a/client/src/components/App/AboutPage.js
+++ b/client/src/components/App/AboutPage.js
@@ -1,0 +1,50 @@
+import React, { Fragment, PureComponent } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Link } from '@material-ui/core';
+import { Info } from '@material-ui/icons';
+import ReactGA from 'react-ga';
+
+class AboutPage extends PureComponent {
+    state = {
+        isOpen: false,
+    };
+    render() {
+        return (
+            <Fragment>
+                <Button
+                    onClick={(event) => {
+                        this.setState({ isOpen: true });
+                        ReactGA.event({
+                            category: 'antalmanac-rewrite',
+                            action: 'Click "About"',
+                        });
+                    }}
+                    color="inherit"
+                    startIcon={<Info />}
+                >
+                    About
+                </Button>
+                <Dialog open={this.state.isOpen}>
+                    <DialogTitle>About</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText>This is the about page.</DialogContentText>
+
+                        <Link
+                            href="#"
+                            onClick={() => window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ', '_blank')}
+                            color="primary"
+                        >
+                            Check out the ICSSC Website!
+                        </Link>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={() => this.setState({ isOpen: false })} color="primary">
+                            Close
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            </Fragment>
+        );
+    }
+}
+
+export default AboutPage;

--- a/client/src/components/App/CustomAppBar.js
+++ b/client/src/components/App/CustomAppBar.js
@@ -10,6 +10,7 @@ import SettingsMenu from './SettingsMenu';
 import { ReactComponent as Logo } from './logo.svg';
 import { ReactComponent as MobileLogo } from './mobile-logo.svg';
 import News from './News';
+import AboutPage from './AboutPage';
 
 const styles = {
     appBar: {
@@ -76,6 +77,7 @@ const CustomAppBar = (props) => {
                             </Button>
                         </Tooltip>,
                         <News />,
+                        <AboutPage />,
                     ].map((element) => (
                         <ConditionalWrapper
                             condition={isMobileScreen}


### PR DESCRIPTION
## Summary
Added an about page.
![image](https://user-images.githubusercontent.com/48658337/150631544-9155399a-6981-4361-9475-b930bd55f013.png)

## Test Plan
- Clicked on the About menu item, which displays a popup with about information.
- Clicked on all the links in the popup and verified they open the correct websites on a new page.
- Clicked on the close button and it closes the popup.
## Issues
Closes #130