### PR TITLE
Add backend instructions to readme, fix potential recursive install bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@
 
 4. The site should load on http://localhost:3000  
 As you make changes to the React application in `client/src`, those changes will be automatically reflected on the site.
+
+### Running the Backend
+The backend server **isn't necessary for frontend development**.
+
+However if you do want to run the backend, you must do the following:
+- Make sure the antalamanac-backened submodule exists.  
+_You should already have this if you ran `git clone --recursive`. Otherwise you can install it with `git submodule update --init --recursive`._
+- Add the `.env` file.  
+_Only ICSSC Project Committee Members will have access to the `.env` file necessary to run the backend locally._
+- Install Serverless on your machine: `npm install -g serverless`
+
+More information can be found in the [antalmanac-backend README](https://github.com/icssc-projects/antalmanac-backend#readme).

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ _You should already have this if you ran `git clone --recursive`. Otherwise you 
 _Only ICSSC Project Committee Members will have access to the `.env` file necessary to run the backend locally._
 - Install Serverless on your machine: `npm install -g serverless`
 
-More information can be found in the [antalmanac-backend README](https://github.com/icssc-projects/antalmanac-backend#readme).
+More information can be found in the [antalmanac-backend README](https://github.com/icssc-projects/antalmanac-backend#readme).  
+_Note:_ The backend currently does not work with Node v16 ([Issue #209](https://github.com/icssc-projects/AntAlmanac/issues/209)). We recommend using Node v12 or v14 until that issue is resolved.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "antalmanac.com",
     "scripts": {
         "client-install": "cd ./client && npm install",
-        "server-install": "cd ./antalmanac-backend && npm install",
+        "server-install": "cd ./antalmanac-backend && if test -f package.json; then npm install; fi",
         "dependency-install": "concurrently -n \"BACKEND,FRONTEND\" \"npm run server-install\" \"npm run client-install\"",
         "postinstall": "npm run dependency-install",
         "server": "cd antalmanac-backend && sls offline --stage development --noPrependStageInUrl",


### PR DESCRIPTION
## Summary
This PR does 2 things:
1. Adds a section to the README explaining how to get the backend up and running.

2. Fixs a recursive install bug that happens when the backend submodule was not cloned.
If the submodule didn't exist, `npm run server-install` would actually just call `npm install` in the root directory, which calls server-install again, resulting in an infinite loop.

## Test Plan
Run `npm install` with and without the backend submodule. Verify that it works both times.