### PR TITLE
Add Spring 2022 Class Schedule

### DIFF
--- a/client/src/components/Calendar/ExportCalendar.js
+++ b/client/src/components/Calendar/ExportCalendar.js
@@ -8,6 +8,7 @@ import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
 
 // Hardcoded first mondays
+// You can find the start dates here: https://www.reg.uci.edu/calendars/academic/tenyr-19-29.html
 // Note: months are 0-indexed
 // TODO(chase): support summer sessions
 const quarterStartDates = {
@@ -19,6 +20,7 @@ const quarterStartDates = {
     '2021 Spring': [2021, 2, 29],
     '2021 Fall': [2021, 8, 23],
     '2022 Winter': [2022, 0, 3],
+    '2022 Spring': [2022, 2, 28],
 };
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];

--- a/client/src/components/EnrollmentGraph/GraphModalContent.js
+++ b/client/src/components/EnrollmentGraph/GraphModalContent.js
@@ -27,7 +27,7 @@ const styles = {
 
 class GraphModalContent extends PureComponent {
     state = {
-        pastTerm: '2021 Fall',
+        pastTerm: '2022 Winter',
         pastSections: null,
     };
 

--- a/client/src/components/SearchForm/TermSelector.js
+++ b/client/src/components/SearchForm/TermSelector.js
@@ -34,6 +34,7 @@ class TermSelector extends PureComponent {
             <FormControl fullWidth>
                 <InputLabel>Term</InputLabel>
                 <Select value={this.state.term} onChange={this.handleChange}>
+                    <MenuItem value={'2022 Spring'}>2022 Spring Quarter</MenuItem>
                     <MenuItem value={'2022 Winter'}>2022 Winter Quarter</MenuItem>
                     <MenuItem value={'2021 Fall'}>2021 Fall Quarter</MenuItem>
                     <MenuItem value={'2021 Spring'}>2021 Spring Quarter</MenuItem>

--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -294,7 +294,7 @@ const DayAndTimeCell = withStyles(styles)((props) => {
 const StatusCell = withStyles(styles)((props) => {
     const { sectionCode, term, courseTitle, courseNumber, status, classes } = props;
 
-    if (term === '2022 Winter' && (status === 'NewOnly' || status === 'FULL')) {
+    if (term === '2022 Spring' && (status === 'NewOnly' || status === 'FULL')) {
         return (
             <NoPaddingTableCell className={`${classes[status.toLowerCase()]} ${classes.cell}`}>
                 <OpenSpotAlertPopover

--- a/client/src/stores/RightPaneStore.js
+++ b/client/src/stores/RightPaneStore.js
@@ -5,7 +5,7 @@ const defaultFormValues = {
     deptValue: 'ALL',
     deptLabel: 'ALL: Include All Departments',
     ge: 'ANY',
-    term: '2022 Winter',
+    term: '2022 Spring',
     courseNumber: '',
     sectionCode: '',
     instructor: '',


### PR DESCRIPTION
## Summary
Add Spring 2022 class schedule to AntAlmanac!

## Test Plan
- Verify "Spring 2022" is the default selection on the course searcher
- Verify that a full class has the option to enroll in notifications
- Verify that calendar download button exports the correct date range

## Issues
Closes #226 

## Future Followup
#227

