### PR TITLE
Saturday and Sunday columns are visible if there's a weekend course/event

### DIFF
--- a/client/src/components/Calendar/ScheduleCalendar.js
+++ b/client/src/components/Calendar/ScheduleCalendar.js
@@ -213,6 +213,13 @@ class ScheduleCalendar extends PureComponent {
         const events = this.getEventsForCalendar();
         const hasWeekendCourse = events.some((event) => event.start.getDay() == 0 || event.start.getDay() == 6);
 
+        // If a final is on a Saturday or Sunday, let the calendar start on Saturday
+        moment.locale('es-us', {
+            week: {
+                dow: hasWeekendCourse && this.state.showFinalsSchedule ? 6 : 0,
+            },
+        });
+
         return (
             <div className={classes.container} onClick={this.handleClosePopover}>
                 <CalendarPaneToolbar

--- a/client/src/components/Calendar/ScheduleCalendar.js
+++ b/client/src/components/Calendar/ScheduleCalendar.js
@@ -262,8 +262,8 @@ class ScheduleCalendar extends PureComponent {
                                 date.getMinutes() > 0 ? '' : localizer.format(date, 'h A', culture),
                             dayFormat: 'ddd',
                         }}
-                        defaultView={Views.WORK_WEEK}
-                        views={[Views.WORK_WEEK]}
+                        defaultView={Views.WEEK}
+                        views={[Views.WEEK, Views.WORK_WEEK]}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}

--- a/client/src/components/Calendar/ScheduleCalendar.js
+++ b/client/src/components/Calendar/ScheduleCalendar.js
@@ -210,6 +210,9 @@ class ScheduleCalendar extends PureComponent {
 
     render() {
         const { classes } = this.props;
+        const events = this.getEventsForCalendar();
+        const hasWeekendCourse = events.some((event) => event.start.getDay() == 0 || event.start.getDay() == 6);
+
         return (
             <div className={classes.container} onClick={this.handleClosePopover}>
                 <CalendarPaneToolbar
@@ -262,14 +265,15 @@ class ScheduleCalendar extends PureComponent {
                                 date.getMinutes() > 0 ? '' : localizer.format(date, 'h A', culture),
                             dayFormat: 'ddd',
                         }}
-                        defaultView={Views.WEEK}
+                        defaultView={Views.WORK_WEEK}
                         views={[Views.WEEK, Views.WORK_WEEK]}
+                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}
                         min={new Date(2018, 0, 1, 7)}
                         max={new Date(2018, 0, 1, 23)}
-                        events={this.getEventsForCalendar()}
+                        events={events}
                         eventPropGetter={ScheduleCalendar.eventStyleGetter}
                         showMultiDayTimes={false}
                         components={{ event: CustomEvent({ classes }) }}

--- a/client/src/components/CustomEvents/DaySelector.js
+++ b/client/src/components/CustomEvents/DaySelector.js
@@ -5,7 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 
 class DaySelector extends PureComponent {
     state = {
-        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false],
+        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false, false, false],
     };
 
     handleChange = (dayIndex) => (event) => {
@@ -29,6 +29,18 @@ class DaySelector extends PureComponent {
                         <Checkbox
                             checked={this.state.days[0]}
                             onChange={this.handleChange(0)}
+                            value="0"
+                            color="primary"
+                        />
+                    }
+                    label="Sunday"
+                />
+
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={this.state.days[1]}
+                            onChange={this.handleChange(1)}
                             value="1"
                             color="primary"
                         />
@@ -39,8 +51,8 @@ class DaySelector extends PureComponent {
                 <FormControlLabel
                     control={
                         <Checkbox
-                            checked={this.state.days[1]}
-                            onChange={this.handleChange(1)}
+                            checked={this.state.days[2]}
+                            onChange={this.handleChange(2)}
                             value="2"
                             color="primary"
                         />
@@ -51,8 +63,8 @@ class DaySelector extends PureComponent {
                 <FormControlLabel
                     control={
                         <Checkbox
-                            checked={this.state.days[2]}
-                            onChange={this.handleChange(2)}
+                            checked={this.state.days[3]}
+                            onChange={this.handleChange(3)}
                             value="3"
                             color="primary"
                         />
@@ -63,8 +75,8 @@ class DaySelector extends PureComponent {
                 <FormControlLabel
                     control={
                         <Checkbox
-                            checked={this.state.days[3]}
-                            onChange={this.handleChange(3)}
+                            checked={this.state.days[4]}
+                            onChange={this.handleChange(4)}
                             value="4"
                             color="primary"
                         />
@@ -75,13 +87,25 @@ class DaySelector extends PureComponent {
                 <FormControlLabel
                     control={
                         <Checkbox
-                            checked={this.state.days[4]}
-                            onChange={this.handleChange(4)}
+                            checked={this.state.days[5]}
+                            onChange={this.handleChange(5)}
                             value="5"
                             color="primary"
                         />
                     }
                     label="Friday"
+                />
+
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={this.state.days[6]}
+                            onChange={this.handleChange(6)}
+                            value="6"
+                            color="primary"
+                        />
+                    }
+                    label="Saturday"
                 />
             </FormGroup>
         );

--- a/client/src/stores/calenderizeHelpers.js
+++ b/client/src/stores/calenderizeHelpers.js
@@ -18,12 +18,15 @@ export const calendarizeCourseEvents = () => {
                 endHr = parseInt(endHr, 10);
                 endMin = parseInt(endMin, 10);
 
+                // Note: There may be Saturday (Sa) or Sunday (Su) courses
                 let dates = [
+                    meeting.days.includes('Su'),
                     meeting.days.includes('M'),
                     meeting.days.includes('Tu'),
                     meeting.days.includes('W'),
                     meeting.days.includes('Th'),
                     meeting.days.includes('F'),
+                    meeting.days.includes('Sa'),
                 ];
 
                 if (ampm === 'p' && endHr !== 12) {
@@ -43,9 +46,9 @@ export const calendarizeCourseEvents = () => {
                             instructors: course.section.instructors,
                             sectionCode: course.section.sectionCode,
                             sectionType: course.section.sectionType,
-                            start: new Date(2018, 0, index + 1, startHr, startMin),
+                            start: new Date(2018, 0, index, startHr, startMin),
                             finalExam: course.section.finalExam,
-                            end: new Date(2018, 0, index + 1, endHr, endMin),
+                            end: new Date(2018, 0, index, endHr, endMin),
                             isCustomEvent: false,
                             scheduleIndices: course.scheduleIndices,
                         };

--- a/client/src/stores/calenderizeHelpers.js
+++ b/client/src/stores/calenderizeHelpers.js
@@ -18,7 +18,6 @@ export const calendarizeCourseEvents = () => {
                 endHr = parseInt(endHr, 10);
                 endMin = parseInt(endMin, 10);
 
-                // Note: There may be Saturday (Sa) or Sunday (Su) courses
                 let dates = [
                     meeting.days.includes('Su'),
                     meeting.days.includes('M'),
@@ -114,7 +113,7 @@ export const calendarizeCustomEvents = () => {
     const customEventsInCalendar = [];
 
     for (const customEvent of customEvents) {
-        for (let dayIndex = 0; dayIndex < 5; dayIndex++) {
+        for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
             if (customEvent.days[dayIndex] === true) {
                 const startHour = parseInt(customEvent.start.slice(0, 2), 10);
                 const startMin = parseInt(customEvent.start.slice(3, 5), 10);
@@ -124,9 +123,9 @@ export const calendarizeCustomEvents = () => {
                 customEventsInCalendar.push({
                     customEventID: customEvent.customEventID,
                     color: customEvent.color,
-                    start: new Date(2018, 0, dayIndex + 1, startHour, startMin),
+                    start: new Date(2018, 0, dayIndex, startHour, startMin),
                     isCustomEvent: true,
-                    end: new Date(2018, 0, dayIndex + 1, endHour, endMin),
+                    end: new Date(2018, 0, dayIndex, endHour, endMin),
                     scheduleIndices: customEvent.scheduleIndices,
                     title: customEvent.title,
                 });

--- a/client/src/stores/calenderizeHelpers.js
+++ b/client/src/stores/calenderizeHelpers.js
@@ -77,6 +77,8 @@ export const calendarizeFinals = () => {
             end = parseInt(end, 10);
             endMin = parseInt(endMin, 10);
             date = [
+                date.includes('Sat'),
+                date.includes('Sun'),
                 date.includes('Mon'),
                 date.includes('Tue'),
                 date.includes('Wed'),
@@ -98,8 +100,8 @@ export const calendarizeFinals = () => {
                         bldg: course.section.meetings[0].bldg,
                         color: course.color,
                         scheduleIndices: course.scheduleIndices,
-                        start: new Date(2018, 0, index + 1, start, startMin),
-                        end: new Date(2018, 0, index + 1, end, endMin),
+                        start: new Date(2018, 0, index - 1, start, startMin),
+                        end: new Date(2018, 0, index - 1, end, endMin),
                     });
             });
         }


### PR DESCRIPTION
## Summary
- If a course is on a Saturday or Sunday, the calendar will expand so that all seven days are visible (Sunday to Saturday).
- If a weekend course is removed, the calendar will revert back to the standard view (Monday to Friday).
- If a course has a final on a Saturday or Sunday, the calendar that shows the finals will also expand to show all seven days; however, it will start on Saturday instead of Sunday because Saturday finals are earlier.
- Just to be consistent, users can have custom events on Saturdays/Sundays.

## Test Plan
- Screenshotting works properly if the calendar has a weekend course, final, and/or custom event.
- Downloading an .ics file still works if there's something on the weekend.
- Adding non-weekend courses still works and are in the correct position on the calendar.
- The calendar properly expands/contracts when you add/remove weekend events.
- Saving/loading a schedule with a weekend event works; the weekend event will still appear.

Demo:

https://user-images.githubusercontent.com/78244965/152706517-49bd1194-32b5-4746-b024-a91afa42ffae.mp4




## Issues
- Since the columns get smaller when the calendar expands, the styling for each event is a little off.
- Closes #141 
