### PR TITLE
Add mobile tab bar to switch between views

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -82,6 +82,6 @@
     </head>
     <body style="overflow: hidden">
         <noscript> You need to enable JavaScript to run this app. </noscript>
-        <div id="root"></div>
+        <div id="root" style="height: 100vh"></div>
     </body>
 </html>

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,17 +1,12 @@
 import React, { PureComponent } from 'react';
-import { Grid, CssBaseline, createMuiTheme } from '@material-ui/core';
+import { createMuiTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
-import Calendar from '../Calendar/ScheduleCalendar';
 import ReactGA from 'react-ga';
-import NotificationSnackbar from './NotificationSnackbar';
 import { undoDelete } from '../../actions/AppStoreActions';
-import Bar from './CustomAppBar';
-import DesktopTabs from '../CoursePane/DesktopTabs';
 import AppStore from '../../stores/AppStore';
-import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import DateFnsUtils from '@date-io/date-fns';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Feedback from './Feedback';
+import Home from './Home';
 import { isDarkMode } from '../../helpers';
 
 class App extends PureComponent {
@@ -66,35 +61,7 @@ class App extends PureComponent {
                         path="/"
                         element={
                             <ThemeProvider theme={theme}>
-                                <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                                    <CssBaseline />
-                                    <Bar />
-                                    <Grid container alignItems={'stretch'} style={{ flexGrow: '1' }}>
-                                        <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
-                                            <Calendar />
-                                        </Grid>
-
-                                        <DesktopTabs />
-
-                                        {/*<Hidden mdUp>*/}
-                                        {/*    <Grid item xs={12}>*/}
-                                        {/*        <div>*/}
-                                        {/*            <Tabs*/}
-                                        {/*                value={this.state.activeTab}*/}
-                                        {/*                onChange={this.handleTabChange}*/}
-                                        {/*                variant="fullWidth"*/}
-                                        {/*                indicatorColor="primary"*/}
-                                        {/*                textColor="primary"*/}
-                                        {/*            >*/}
-                                        {/*                <Tab icon={<CalendarToday />} />*/}
-                                        {/*                <Tab icon={<Search />} />*/}
-                                        {/*            </Tabs>*/}
-                                        {/*        </div>*/}
-                                        {/*    </Grid>*/}
-                                        {/*</Hidden>*/}
-                                    </Grid>
-                                    <NotificationSnackbar />
-                                </MuiPickersUtilsProvider>
+                                <Home />
                             </ThemeProvider>
                         }
                     />

--- a/client/src/components/App/CustomAppBar.js
+++ b/client/src/components/App/CustomAppBar.js
@@ -18,6 +18,7 @@ const styles = {
         marginBottom: '4px',
         boxShadow: 'none',
         minHeight: 0,
+        height: '50px',
     },
     buttonMargin: {
         marginRight: '4px',

--- a/client/src/components/App/Home.js
+++ b/client/src/components/App/Home.js
@@ -23,7 +23,7 @@ const Home = () => {
                         <Calendar />
                     </Grid>
                     <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
-                        <DesktopTabs style={{ height: 'calc(100% - 8px)' }} />
+                        <DesktopTabs style={{ height: 'calc(100vh - 58px)' }} />
                     </Grid>
                 </Grid>
             )}

--- a/client/src/components/App/Home.js
+++ b/client/src/components/App/Home.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Grid, CssBaseline, useMediaQuery } from '@material-ui/core';
+import Calendar from '../Calendar/ScheduleCalendar';
+import Bar from './CustomAppBar';
+import DesktopTabs from '../CoursePane/DesktopTabs';
+import NotificationSnackbar from './NotificationSnackbar';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
+import MobileHome from './MobileHome';
+import DateFnsUtils from '@date-io/date-fns';
+
+const Home = () => {
+    const isMobileScreen = useMediaQuery('(max-width:750px)');
+
+    return (
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <CssBaseline />
+            <Bar />
+            {isMobileScreen ? (
+                <MobileHome />
+            ) : (
+                <Grid container alignItems={'stretch'} style={{ flexGrow: '1' }}>
+                    <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
+                        <Calendar />
+                    </Grid>
+                    <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
+                        <DesktopTabs style={{ height: 'calc(100% - 8px)' }} />
+                    </Grid>
+                </Grid>
+            )}
+            <NotificationSnackbar />
+        </MuiPickersUtilsProvider>
+    );
+};
+
+export default Home;

--- a/client/src/components/App/MobileHome.js
+++ b/client/src/components/App/MobileHome.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Tab, Tabs, Paper } from '@material-ui/core';
+import DesktopTabs from '../CoursePane/DesktopTabs';
+import Calendar from '../Calendar/ScheduleCalendar';
+
+const MobileHome = () => {
+    const [selectedTab, setSelectedTab] = useState(0);
+
+    const components = [<Calendar isMobile={true} />, <DesktopTabs style={{ height: 'calc(100% - 50px' }} />];
+
+    return (
+        <div style={{ height: 'calc(100% - 60px' }}>
+            {components[selectedTab]}
+            <Paper elevation={0} variant="outlined" square style={{ margin: '4px', height: '50px' }}>
+                <Tabs
+                    value={selectedTab}
+                    onChange={(_, value) => {
+                        setSelectedTab(value);
+                    }}
+                    indicatorColor="primary"
+                    variant="fullWidth"
+                    centered
+                    style={{
+                        height: '100%',
+                    }}
+                >
+                    <Tab label={<div>Calendar</div>} />
+                    <Tab label={<div>Search</div>} />
+                </Tabs>
+            </Paper>
+        </div>
+    );
+};
+
+export default MobileHome;

--- a/client/src/components/App/PrivacyPolicyBanner.js
+++ b/client/src/components/App/PrivacyPolicyBanner.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core';
 const styles = {
     container: {
         padding: 12,
-        marginTop: 'auto',
+        marginTop: '10%',
     },
 };
 

--- a/client/src/components/Calendar/ScheduleCalendar.js
+++ b/client/src/components/Calendar/ScheduleCalendar.js
@@ -209,9 +209,10 @@ class ScheduleCalendar extends PureComponent {
     };
 
     render() {
-        const { classes } = this.props;
+        const { classes, isMobile } = this.props;
         const events = this.getEventsForCalendar();
         const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
+        const calStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
 
         // If a final is on a Saturday or Sunday, let the calendar start on Saturday
         moment.updateLocale('es-us', {
@@ -221,7 +222,11 @@ class ScheduleCalendar extends PureComponent {
         });
 
         return (
-            <div className={classes.container} onClick={this.handleClosePopover}>
+            <div
+                className={classes.container}
+                style={isMobile && { height: 'calc(100% - 50px' }}
+                onClick={this.handleClosePopover}
+            >
                 <CalendarPaneToolbar
                     onTakeScreenshot={this.handleTakeScreenshot}
                     currentScheduleIndex={this.state.currentScheduleIndex}
@@ -232,7 +237,7 @@ class ScheduleCalendar extends PureComponent {
                     id="screenshot"
                     style={
                         !this.state.screenshotting
-                            ? { height: `calc(100vh - 104px)` }
+                            ? calStyling
                             : {
                                   height: '100%',
                                   width: '1000px',

--- a/client/src/components/CoursePane/CourseRenderPane.js
+++ b/client/src/components/CoursePane/CourseRenderPane.js
@@ -39,7 +39,7 @@ const styles = (theme) => ({
         marginLeft: theme.spacing(),
     },
     root: {
-        height: 'calc(100% - 68px)',
+        height: 'calc(100% - 50px)',
         overflowY: 'scroll',
         position: 'relative',
     },

--- a/client/src/components/CoursePane/DesktopTabs.js
+++ b/client/src/components/CoursePane/DesktopTabs.js
@@ -114,7 +114,7 @@ class DesktopTabs extends PureComponent {
                 </Paper>
                 <div
                     style={{
-                        padding: RightPaneStore.getActiveTab() === 2 ? '0px' : '8px',
+                        padding: RightPaneStore.getActiveTab() === 2 ? '0px' : '8px 8px 0 8px',
                         height: `calc(100% - 54px)`,
                         overflowY: RightPaneStore.getActiveTab() === 1 ? 'auto' : 'hidden',
                     }}

--- a/client/src/components/CoursePane/DesktopTabs.js
+++ b/client/src/components/CoursePane/DesktopTabs.js
@@ -18,6 +18,7 @@ class DesktopTabs extends PureComponent {
 
     componentDidMount() {
         RightPaneStore.on('tabChange', this.changeTab);
+        this.setState({ activeTab: RightPaneStore.getActiveTab() });
     }
 
     componentWillUnmount() {
@@ -25,6 +26,7 @@ class DesktopTabs extends PureComponent {
     }
 
     render() {
+        const { style } = this.props;
         let currentTab;
 
         if (RightPaneStore.getActiveTab() === 0) {
@@ -36,93 +38,90 @@ class DesktopTabs extends PureComponent {
         }
 
         return (
-            <Grid item xs={12} s={6} md={6} lg={6} xl={6}>
-                <div>
-                    <Paper
-                        elevation={0}
-                        variant="outlined"
-                        square
-                        style={{
-                            overflow: 'hidden',
-                            marginBottom: '4px',
-                            marginRight: '4px',
-                        }}
+            <div style={style}>
+                <Paper
+                    elevation={0}
+                    variant="outlined"
+                    square
+                    style={{
+                        overflow: 'hidden',
+                        margin: '0 4px 4px 4px',
+                    }}
+                >
+                    <Tabs
+                        value={this.state.activeTab}
+                        onChange={handleTabChange}
+                        indicatorColor="primary"
+                        variant="fullWidth"
+                        centered
+                        style={{ height: '48px' }}
                     >
-                        <Tabs
-                            value={this.state.activeTab}
-                            onChange={handleTabChange}
-                            indicatorColor="primary"
-                            variant="fullWidth"
-                            centered
-                            style={{ height: '48px' }}
-                        >
-                            <Tab
-                                label={
-                                    <div
-                                        style={{
-                                            display: 'inline-flex',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        <Search style={{ height: 16 }} />
-                                        <Typography variant="body2">Class Search</Typography>
-                                    </div>
-                                }
-                                style={{
-                                    minHeight: 'auto',
-                                    height: '44px',
-                                    padding: 3,
-                                }}
-                            />
-                            <Tab
-                                label={
-                                    <div
-                                        style={{
-                                            display: 'inline-flex',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        <FormatListBulleted style={{ height: 16 }} />
-                                        <Typography variant="body2">Added Classes</Typography>
-                                    </div>
-                                }
-                                style={{
-                                    minHeight: 'auto',
-                                    height: '44px',
-                                    padding: 3,
-                                }}
-                            />
-                            <Tab
-                                label={
-                                    <div
-                                        style={{
-                                            display: 'inline-flex',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        <MyLocation style={{ height: 16 }} />
-                                        <Typography variant="body2">Map</Typography>
-                                    </div>
-                                }
-                                style={{
-                                    minHeight: 'auto',
-                                    height: '44px',
-                                    padding: 3,
-                                }}
-                            />
-                        </Tabs>
-                    </Paper>
-                    <div
-                        style={{
-                            padding: RightPaneStore.getActiveTab() === 2 ? '0px' : '8px',
-                            height: `calc(100vh - 104px)`,
-                            overflowY: RightPaneStore.getActiveTab() === 1 ? 'auto' : 'hidden',
-                        }}
-                    >
-                        {currentTab}
-                    </div>
+                        <Tab
+                            label={
+                                <div
+                                    style={{
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <Search style={{ height: 16 }} />
+                                    <Typography variant="body2">Class Search</Typography>
+                                </div>
+                            }
+                            style={{
+                                minHeight: 'auto',
+                                height: '44px',
+                                padding: 3,
+                            }}
+                        />
+                        <Tab
+                            label={
+                                <div
+                                    style={{
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <FormatListBulleted style={{ height: 16 }} />
+                                    <Typography variant="body2">Added Classes</Typography>
+                                </div>
+                            }
+                            style={{
+                                minHeight: 'auto',
+                                height: '44px',
+                                padding: 3,
+                            }}
+                        />
+                        <Tab
+                            label={
+                                <div
+                                    style={{
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <MyLocation style={{ height: 16 }} />
+                                    <Typography variant="body2">Map</Typography>
+                                </div>
+                            }
+                            style={{
+                                minHeight: 'auto',
+                                height: '44px',
+                                padding: 3,
+                            }}
+                        />
+                    </Tabs>
+                </Paper>
+                <div
+                    style={{
+                        padding: RightPaneStore.getActiveTab() === 2 ? '0px' : '8px',
+                        height: `calc(100% - 54px)`,
+                        overflowY: RightPaneStore.getActiveTab() === 1 ? 'auto' : 'hidden',
+                    }}
+                >
+                    {currentTab}
                 </div>
-            </Grid>
+            </div>
         );
     }
 }


### PR DESCRIPTION
## Summary
AntAlmanac now works on mobile! 

When the screen size is less than 750px, a tab bar will appear on the bottom with calendar and search tabs. Users can switch between either the Calendar view or the right pane view.

![mobile](https://user-images.githubusercontent.com/29494270/153859102-51a10b1a-c338-4acf-b1bc-d68be192f22f.gif)
_Note: the gif looks like it's off-center, but that's just because I misaligned the screen recording_

In this PR, I also created a new component called `Home` since `App` was starting to get bloated. There were several small css changes too.

## Test Plan
- On mobile, search for a class, add a class, view class on the map, view classes under "Added Classes", view class on the calendar, click on classes in the calendar
- On desktop, verify that the styling for the right pane did not create any regressions. Check class search, added classes, and map.

## Issues
Closes #125

## Future Followup
The more I look at our styling, the sadder I become. There's a lot of refactoring that needs to be done with our CSS. It's pretty inconsistent and hard to work with. 

I think we should look into standardizing the left pane calendar and right pane desktop tabs into a `View` component that had a menu bar and content. This would help us keep margins and paddings are consistent. 
