### PR TITLE
Mobile fixes

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -14,7 +14,10 @@
             }
         </style>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
+        />
         <meta name="theme-color" content="#000000" />
         <meta
             name="keywords"
@@ -82,6 +85,6 @@
     </head>
     <body style="overflow: hidden">
         <noscript> You need to enable JavaScript to run this app. </noscript>
-        <div id="root" style="height: 100vh"></div>
+        <div id="root" style="height: 100vh; position: fixed; top: 0; width: 100%"></div>
     </body>
 </html>

--- a/client/src/components/App/MobileHome.js
+++ b/client/src/components/App/MobileHome.js
@@ -9,8 +9,7 @@ const MobileHome = () => {
     const components = [<Calendar isMobile={true} />, <DesktopTabs style={{ height: 'calc(100% - 50px' }} />];
 
     return (
-        <div style={{ height: 'calc(100% - 60px' }}>
-            {components[selectedTab]}
+        <div style={{ height: 'calc(100% - 60px)' }}>
             <Paper elevation={0} variant="outlined" square style={{ margin: '4px', height: '50px' }}>
                 <Tabs
                     value={selectedTab}
@@ -28,6 +27,7 @@ const MobileHome = () => {
                     <Tab label={<div>Search</div>} />
                 </Tabs>
             </Paper>
+            {components[selectedTab]}
         </div>
     );
 };

--- a/client/src/components/Calendar/CalendarPaneToolbar.js
+++ b/client/src/components/Calendar/CalendarPaneToolbar.js
@@ -16,7 +16,7 @@ import ConditionalWrapper from '../App/ConditionalWrapper';
 const styles = {
     toolbar: {
         display: 'flex',
-        overflow: 'auto',
+        overflow: 'hidden',
         marginBottom: '4px',
         alignItems: 'center',
         height: '50px',

--- a/client/src/components/Calendar/ScheduleCalendar.js
+++ b/client/src/components/Calendar/ScheduleCalendar.js
@@ -224,7 +224,7 @@ class ScheduleCalendar extends PureComponent {
         return (
             <div
                 className={classes.container}
-                style={isMobile && { height: 'calc(100% - 50px' }}
+                style={isMobile && { height: 'calc(100% - 50px)' }}
                 onClick={this.handleClosePopover}
             >
                 <CalendarPaneToolbar

--- a/client/src/components/CoursePane/DesktopTabs.js
+++ b/client/src/components/CoursePane/DesktopTabs.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Grid, Tab, Tabs, Typography, Paper } from '@material-ui/core';
+import { Tab, Tabs, Typography, Paper } from '@material-ui/core';
 import { FormatListBulleted, MyLocation, Search } from '@material-ui/icons';
 import AddedCoursePane from '../AddedCourses/AddedCoursePane';
 import RightPane from './RightPane';

--- a/client/src/components/CoursePane/DesktopTabs.js
+++ b/client/src/components/CoursePane/DesktopTabs.js
@@ -116,7 +116,7 @@ class DesktopTabs extends PureComponent {
                     style={{
                         padding: RightPaneStore.getActiveTab() === 2 ? '0px' : '8px 8px 0 8px',
                         height: `calc(100% - 54px)`,
-                        overflowY: RightPaneStore.getActiveTab() === 1 ? 'auto' : 'hidden',
+                        overflowY: 'auto',
                     }}
                 >
                     {currentTab}
@@ -125,7 +125,5 @@ class DesktopTabs extends PureComponent {
         );
     }
 }
-
-//TODO: Mobile
 
 export default DesktopTabs;

--- a/client/src/components/SearchForm/SearchForm.js
+++ b/client/src/components/SearchForm/SearchForm.js
@@ -14,7 +14,6 @@ const styles = {
     container: {
         display: 'flex',
         flexDirection: 'column',
-        height: '100%',
         position: 'relative',
     },
     search: {


### PR DESCRIPTION
## Summary
| Update | Before | After |
| --- | --- | --- |
| - Move tabbar to top of the page, above the components | (Hidden by url bar) <img width="564" alt="Screen Shot 2022-02-16 at 6 29 04 PM" src="https://user-images.githubusercontent.com/29494270/154393042-714ebf3d-026b-4ddd-a5f9-3cf37f332b11.png"> | (Move to the top) <img width="564" alt="Screen Shot 2022-02-16 at 6 28 06 PM" src="https://user-images.githubusercontent.com/29494270/154392942-7cd6433c-cc6f-4548-b83d-3e6fdbfe6898.png"> |
| - Fix a bug where the site wouldn't stick to the top of the page | <img width="564" alt="Screen Shot 2022-02-16 at 6 30 35 PM" src="https://user-images.githubusercontent.com/29494270/154393217-da8e1078-e9ce-468d-83bc-5b0c59fa1679.png"> | Sticks to the top (see picture above) |
| - Enable scrolling on search form when the input fields take up too much height | <img width="564" alt="Screen Shot 2022-02-16 at 6 32 50 PM" src="https://user-images.githubusercontent.com/29494270/154393501-ffa42153-22b5-41c1-9119-69d5e579b911.png"> | <img width="564" alt="Screen Shot 2022-02-16 at 6 32 14 PM" src="https://user-images.githubusercontent.com/29494270/154393449-7f05527e-4268-464d-a917-478447774a5d.png"> |
| - Remove scrollbar from CalendarPaneToolbar | <img width="429" alt="image" src="https://user-images.githubusercontent.com/29494270/154393889-6286e863-2958-4f42-9bf0-27766f7cf132.png"> | <img width="433" alt="image" src="https://user-images.githubusercontent.com/29494270/154393948-7389e9cb-53be-4772-8add-5f73ff739412.png"> |
| - Other misc code fixes | n/a | n/a |

## Test Plan
- Test on xcode iPhone 13 and iPhone 8 simulator
- Test on Desktop 

## Issues
Update to #125 

## Future Followup
- Improve how we do heights in the css
- Consider merging desktop tab bar into top nav bar