### PR TITLE
Add Past Enrollment button that links to ZotTracker

### DIFF
--- a/client/src/components/SectionTable/SectionTable.js
+++ b/client/src/components/SectionTable/SectionTable.js
@@ -16,6 +16,7 @@ import CourseInfoBar from './CourseInfoBar';
 import SectionTableBody from './SectionTableBody';
 import CourseInfoButton from './CourseInfoButton';
 import { Help, Assessment, Assignment } from '@material-ui/icons';
+import ShowChartIcon from '@material-ui/icons/ShowChart';
 import PropTypes from 'prop-types';
 
 const styles = {
@@ -63,7 +64,7 @@ const styles = {
 class SectionTable extends PureComponent {
     render() {
         const { classes, courseDetails } = this.props;
-        const urlEncode = encodeURIComponent(courseDetails.deptCode);
+        const encodedDept = encodeURIComponent(courseDetails.deptCode);
 
         return (
             <Fragment>
@@ -94,7 +95,12 @@ class SectionTable extends PureComponent {
                     <CourseInfoButton
                         text="Zotistics"
                         icon={<Assessment />}
-                        redirectLink={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${urlEncode}&classNum=${courseDetails.courseNumber}&code=&submit=Submit`}
+                        redirectLink={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${encodedDept}&classNum=${courseDetails.courseNumber}&code=&submit=Submit`}
+                    />
+                    <CourseInfoButton
+                        text="Past Enrollment"
+                        icon={<ShowChartIcon />}
+                        redirectLink={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseDetails.courseNumber}&courseType=all`}
                     />
                 </div>
 


### PR DESCRIPTION
## Summary
- For each course, there is a Past Enrollment button that links to that course's enrollment data on ZotTracker. In ZotTracker, the user will be able to see the enrollment data of every lecture, lab, discussion, etc. for the most recent offering of the course. For example, CS 121 was most recently offered in Winter 2022, so the user will be directed to the data for Winter 2022 first.

## Test Plan
- The redirect link works on both desktop and mobile.
- In ZotTracker, the correct course's data is shown, and the user's search history on ZotTracker is updated correctly.
- The redirect link is a proper URL; if a department is more than one word, the redirect is successful because we encoded it correctly.

Demo:

https://user-images.githubusercontent.com/78244965/154623969-0d3decfb-7f2d-43fe-9793-00dfac0620df.mp4


## Issues
Closes #255 

## Future Followup:
- The Past Enrollment button takes up a lot of space on mobile, so we should probably improve the styling.