### PR TITLE
Renamed 'Settings' button as 'Theme', updated icon

### DIFF
--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -1,6 +1,6 @@
 import React, { Fragment, PureComponent } from 'react';
 import { Button, FormControl, FormControlLabel, FormLabel, Popover, RadioGroup, Radio, Paper } from '@material-ui/core';
-import { Settings } from '@material-ui/icons';
+import Brightness4Icon from '@material-ui/icons/Brightness4';
 import AppStore from '../../stores/AppStore';
 import { toggleTheme } from '../../actions/AppStoreActions';
 import { withStyles } from '@material-ui/core/styles';
@@ -40,9 +40,9 @@ class SettingsMenu extends PureComponent {
                         });
                     }}
                     color="inherit"
-                    startIcon={<Settings />}
+                    startIcon={<Brightness4Icon />}
                 >
-                    Settings
+                    Theme
                 </Button>
                 <Popover
                     open={Boolean(this.state.anchorEl)}


### PR DESCRIPTION
## Summary
- Imported/used 'Brightness4Icon' to replace the 'Settings' icon. 
- Renamed the 'Settings' button as 'Theme'
- Removed the 'Theme' label from the popup box.

![Screen Shot 2022-03-10 at 3 46 55 PM](https://user-images.githubusercontent.com/94736149/157774570-99a31b40-f3e0-43b8-b320-f785b4e2810e.png)

## Test Plan
- Verified that the new icon shows up and that button is renamed
- Verified that the 'Theme' label in the popup box is gone

## Issues
Closes #277
