### PR TITLE
Renamed 'Settings' button as 'Theme', updated icon

### DIFF
--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -1,6 +1,6 @@
 import React, { Fragment, PureComponent } from 'react';
 import { Button, FormControl, FormControlLabel, FormLabel, Popover, RadioGroup, Radio, Paper } from '@material-ui/core';
-import { Settings } from '@material-ui/icons';
+import Brightness4Icon from '@material-ui/icons/Brightness4';
 import AppStore from '../../stores/AppStore';
 import { toggleTheme } from '../../actions/AppStoreActions';
 import { withStyles } from '@material-ui/core/styles';
@@ -40,9 +40,9 @@ class SettingsMenu extends PureComponent {
                         });
                     }}
                     color="inherit"
-                    startIcon={<Settings />}
+                    startIcon={<Brightness4Icon />}
                 >
-                    Settings
+                    Theme
                 </Button>
                 <Popover
                     open={Boolean(this.state.anchorEl)}

--- a/client/src/components/App/SettingsMenu.js
+++ b/client/src/components/App/SettingsMenu.js
@@ -61,7 +61,6 @@ class SettingsMenu extends PureComponent {
                 >
                     <Paper className={classes.container}>
                         <FormControl>
-                            <FormLabel>Theme</FormLabel>
                             <RadioGroup aria-label="theme" name="theme" value={this.state.theme} onChange={toggleTheme}>
                                 <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
                                 <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />


### PR DESCRIPTION
## Summary
- Imported/used 'Brightness4Icon' to replace the 'Settings' icon.
- Renamed the 'Settings' button as 'Theme'
- Removed the 'Theme' label from the popup box.

![Screen Shot 2022-03-10 at 3 58 21 PM](https://user-images.githubusercontent.com/94736149/157775483-824bb418-6b4e-407e-8e3a-74f815d7e4ee.png)

## Test Plan
- Verified that the new icon shows up and that button is renamed
- Verified that the 'Theme' label in the popup box is gone

## Issues
Closes #277
