### PR TITLE
Unit filter enhancements

### DIFF
--- a/client/src/components/CoursePane/CourseRenderPane.js
+++ b/client/src/components/CoursePane/CourseRenderPane.js
@@ -10,7 +10,7 @@ import loadingGif from '../SearchForm/Gifs/loading.gif';
 import darkModeLoadingGif from '../SearchForm/Gifs/dark-loading.gif';
 import GeDataFetchProvider from '../SectionTable/GEDataFetchProvider';
 import LazyLoad from 'react-lazyload';
-import { queryWebsoc, isDarkMode } from '../../helpers';
+import { queryWebsoc, queryWebsocMultiple, isDarkMode } from '../../helpers';
 
 const styles = (theme) => ({
     course: {
@@ -148,7 +148,12 @@ class CourseRenderPane extends PureComponent {
             };
 
             try {
-                const jsonResp = await queryWebsoc(params);
+                let jsonResp;
+                if (params.units.includes(',')) {
+                    jsonResp = await queryWebsocMultiple(params, 'units');
+                } else {
+                    jsonResp = await queryWebsoc(params);
+                }
                 this.setState({
                     loading: false,
                     error: false,

--- a/client/src/components/SearchForm/AdvancedSearch.js
+++ b/client/src/components/SearchForm/AdvancedSearch.js
@@ -115,8 +115,8 @@ class AdvancedSearchTextFields extends PureComponent {
                     label="Units"
                     value={this.state.units}
                     onChange={this.handleChange('units')}
-                    type="number"
-                    helperText="ex. 3, 4, 1.7"
+                    type="search"
+                    helperText="ex. 3, 4, or VAR"
                     className={classes.units}
                 />
 

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -100,7 +100,11 @@ export async function queryWebsoc(params) {
                                 courses.add(course);
                             }
                             courses = Array.from(courses);
-                            courses.sort((left, right) => left.courseNumber > right.courseNumber);
+                            courses.sort(
+                                (left, right) =>
+                                    parseInt(left.courseNumber.replace(/\D/g, '')) >
+                                    parseInt(right.courseNumber.replace(/\D/g, ''))
+                            );
                             combinedResponse.schools[schoolIndex].departments[deptIndex].courses = courses;
                         } else {
                             combinedResponse.schools[schoolIndex].departments.push(dept);

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -70,53 +70,6 @@ export function clearCache() {
 }
 
 export async function queryWebsoc(params) {
-    // Check if params.units exists (indicating that it is a SOC query) and contains at least one comma
-    if (params.units && params.units.includes(',')) {
-        let responses = [];
-        // If so, make one query per (tokenized) unit input
-        for (const units of params.units.trim().replace(' ', '').split(',')) {
-            let req = JSON.parse(JSON.stringify(params));
-            req.units = units;
-            responses.push(await queryWebsoc(req));
-        }
-        // Find any bad requests from the API and return if found
-        const res = responses.find((r) => r.status === 400);
-        if (res) {
-            return res;
-        }
-        // Combine all responses into a single response object
-        let combinedResponse = responses.shift();
-        for (const res of responses) {
-            for (const school of res.schools) {
-                let schoolIndex = combinedResponse.schools.findIndex((s) => s.schoolName === school.schoolName);
-                if (schoolIndex !== -1) {
-                    for (const dept of school.departments) {
-                        let deptIndex = combinedResponse.schools[schoolIndex].departments.findIndex(
-                            (d) => d.deptCode === dept.deptCode
-                        );
-                        if (deptIndex !== -1) {
-                            let courses = new Set(combinedResponse.schools[schoolIndex].departments[deptIndex].courses);
-                            for (const course of dept.courses) {
-                                courses.add(course);
-                            }
-                            courses = Array.from(courses);
-                            courses.sort(
-                                (left, right) =>
-                                    parseInt(left.courseNumber.replace(/\D/g, '')) >
-                                    parseInt(right.courseNumber.replace(/\D/g, ''))
-                            );
-                            combinedResponse.schools[schoolIndex].departments[deptIndex].courses = courses;
-                        } else {
-                            combinedResponse.schools[schoolIndex].departments.push(dept);
-                        }
-                    }
-                } else {
-                    combinedResponse.schools.push(school);
-                }
-            }
-        }
-        return combinedResponse;
-    }
     // Construct a request to PeterPortal with the params as a query string
     const url = new URL(PETERPORTAL_WEBSOC_ENDPOINT);
     const searchString = new URLSearchParams(params).toString();
@@ -137,6 +90,54 @@ export async function queryWebsoc(params) {
         websocCache[searchString] = backupResponse;
         return backupResponse;
     }
+}
+
+export function combineSOCObjects(SOCObjects) {
+    let combined = SOCObjects.shift();
+    for (const res of SOCObjects) {
+        for (const school of res.schools) {
+            let schoolIndex = combined.schools.findIndex((s) => s.schoolName === school.schoolName);
+            if (schoolIndex !== -1) {
+                for (const dept of school.departments) {
+                    let deptIndex = combined.schools[schoolIndex].departments.findIndex(
+                        (d) => d.deptCode === dept.deptCode
+                    );
+                    if (deptIndex !== -1) {
+                        let courses = new Set(combined.schools[schoolIndex].departments[deptIndex].courses);
+                        for (const course of dept.courses) {
+                            courses.add(course);
+                        }
+                        courses = Array.from(courses);
+                        courses.sort(
+                            (left, right) =>
+                                parseInt(left.courseNumber.replace(/\D/g, '')) >
+                                parseInt(right.courseNumber.replace(/\D/g, ''))
+                        );
+                        combined.schools[schoolIndex].departments[deptIndex].courses = courses;
+                    } else {
+                        combined.schools[schoolIndex].departments.push(dept);
+                    }
+                }
+            } else {
+                combined.schools.push(school);
+            }
+        }
+    }
+    return combined;
+}
+
+export async function queryWebsocMultiple(params, fieldName) {
+    let responses = [];
+    for (const field of params[fieldName].trim().replace(' ', '').split(',')) {
+        let req = JSON.parse(JSON.stringify(params));
+        req[fieldName] = field;
+        responses.push(await queryWebsoc(req));
+    }
+    const res = responses.find((r) => r.status === 400);
+    if (res) {
+        return res;
+    }
+    return combineSOCObjects(responses);
 }
 
 export function clickToCopy(event, sectionCode) {


### PR DESCRIPTION
## Summary

Add support for "VAR" and multiple inputs to the unit filter; for instance, an input of "4,2" will return all courses that have either 2 or 4 units, while "VAR" returns only the courses that have variable units. Regardless of the query type, these courses are sorted in ascending order of course code, just like any other query.

Note that this does diverge from the behavior of WebSOC, as its Units field seems to discard all non-numeric characters after the last numeric character encountered.

## Test Plan

Actions tested:

1. The input `VAR` on its own returns all courses with variable units.
2. Two numerical inputs `x` and `y` returns all courses with `x` or `y` units.
3. One numerical input `x` and the input `VAR` returns all courses with `x` units or variable units.
4. Test cases 2) and 3) with varying order return the same results.
5. All test cases detailed above, but with the inclusion of varying amounts of whitespace either before, within, or after the query, return the same result.

## Issues

Closes #259.

## Known issues/Caveats

* There are provisions in the backing code to return an empty response if any child responses from splitting the unit input were empty. However, since a full response is returned given gibberish in the `units` field and an otherwise valid request, and an empty response is returned given an invalid response, this failure mode is not exactly meaningful.
* Unrelated to the issue at hand: While running `npm install` the `package[-lock].json` of both the frontend and backend were modified for reasons unknown. I did not commit them because the functionality did not change in their absence; it may be due to the fact that I'm using WSL as my dev environment.
