### PR TITLE
Changed Department Search field label name to "Department"

### DIFF
--- a/client/src/components/SearchForm/DeptSearchBar/DeptSearchBar.js
+++ b/client/src/components/SearchForm/DeptSearchBar/DeptSearchBar.js
@@ -103,7 +103,7 @@ class DeptSearchBar extends PureComponent {
                     includeInputInList={true}
                     noOptionsText="No departments match the search"
                     groupBy={(dept) => (dept.isFavorite ? 'Recent Departments' : 'Departments')}
-                    renderInput={(params) => <TextField {...params} label="Search for a department" />}
+                    renderInput={(params) => <TextField {...params} label="Department" />}
                 />
             </div>
         );


### PR DESCRIPTION
## Summary
Changed Department search field label name from "Search for a department" to "Department"
<img width="777" alt="Department" src="https://user-images.githubusercontent.com/78000116/158013768-ddfb934d-a43d-46cc-8420-6c9733c1ea89.png">



## Test Plan
Verified Department search field label is named "Department"

## Issues
Closes #268 
