### PR TITLE
Make class search back button float over results

### DIFF
--- a/client/src/components/CoursePane/CoursePaneButtonRow.js
+++ b/client/src/components/CoursePane/CoursePaneButtonRow.js
@@ -9,6 +9,7 @@ const styles = {
         width: '100%',
         zIndex: 3,
         marginBottom: 8,
+        position: 'absolute',
     },
     button: {
         backgroundColor: 'rgba(236, 236, 236, 1)',

--- a/client/src/components/CoursePane/CourseRenderPane.js
+++ b/client/src/components/CoursePane/CourseRenderPane.js
@@ -38,9 +38,10 @@ const styles = (theme) => ({
         marginLeft: theme.spacing(),
     },
     root: {
-        height: 'calc(100% - 50px)',
+        height: '100%',
         overflowY: 'scroll',
         position: 'relative',
+        paddingTop: '50px',
     },
     noResultsDiv: {
         height: '100%',


### PR DESCRIPTION
## Summary
The Back Button now floats over the search results. 
![back](https://user-images.githubusercontent.com/29494270/158049445-0a09ccaa-43e8-41a8-a66b-69cdec7b28aa.gif)

## Test Plan
- Verify that it floats over content on both desktop and mobile
- Verify that the back button still works 

## Issues
N/A

## Future Followup
When you hover over the button, it goes slightly transparent and doesn't look very good. We should fix this in #224 
