### PR TITLE
Preselect current schedule when creating a custom event 

### DIFF
--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -130,7 +130,7 @@ const CalendarPaneToolbar = (props) => {
                 {[
                     <ExportCalendar />,
                     <ScreenshotButton onTakeScreenshot={props.onTakeScreenshot} />,
-                    <CustomEventsDialog editMode={false} />,
+                    <CustomEventsDialog editMode={false} currentScheduleIndex={props.currentScheduleIndex} />,
                 ].map((element, index) => (
                     <ConditionalWrapper
                         key={index}

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -36,7 +36,9 @@ class CustomEventDialog extends PureComponent {
         end: this.props.customEvent ? this.props.customEvent.end : '15:30',
         eventName: this.props.customEvent ? this.props.customEvent.title : '',
         days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false],
-        scheduleIndices: this.props.customEvent ? this.props.customEvent.scheduleIndices : [],
+        scheduleIndices: this.props.customEvent
+            ? this.props.customEvent.scheduleIndices
+            : [this.props.currentScheduleIndex],
         customEventID: this.props.customEvent ? this.props.customEvent.customEventID : 0,
     };
 
@@ -160,6 +162,7 @@ class CustomEventDialog extends PureComponent {
                         <ScheduleSelector
                             scheduleIndices={this.state.scheduleIndices}
                             onSelectScheduleIndices={this.handleSelectScheduleIndices}
+                            currentScheduleIndex={this.props.currentScheduleIndex}
                             customEvent={this.props.customEvent}
                         />
                     </DialogContent>

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -36,14 +36,12 @@ class CustomEventDialog extends PureComponent {
         end: this.props.customEvent ? this.props.customEvent.end : '15:30',
         eventName: this.props.customEvent ? this.props.customEvent.title : '',
         days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false],
-        scheduleIndices: this.props.customEvent
-            ? this.props.customEvent.scheduleIndices
-            : [this.props.currentScheduleIndex],
+        scheduleIndices: this.props.customEvent ? this.props.customEvent.scheduleIndices : [],
         customEventID: this.props.customEvent ? this.props.customEvent.customEventID : 0,
     };
 
     handleOpen = () => {
-        this.setState({ open: true });
+        this.setState({ open: true, scheduleIndices: [this.props.currentScheduleIndex] });
         ReactGA.event({
             category: 'antalmanac-rewrite',
             action: 'Click Custom Event button',
@@ -162,7 +160,6 @@ class CustomEventDialog extends PureComponent {
                         <ScheduleSelector
                             scheduleIndices={this.state.scheduleIndices}
                             onSelectScheduleIndices={this.handleSelectScheduleIndices}
-                            currentScheduleIndex={this.props.currentScheduleIndex}
                             customEvent={this.props.customEvent}
                         />
                     </DialogContent>

--- a/src/components/CustomEvents/ScheduleSelector.js
+++ b/src/components/CustomEvents/ScheduleSelector.js
@@ -5,7 +5,9 @@ import Checkbox from '@material-ui/core/Checkbox';
 
 class ScheduleSelector extends PureComponent {
     state = {
-        scheduleIndices: this.props.customEvent ? this.props.customEvent.scheduleIndices : [],
+        scheduleIndices: this.props.customEvent
+            ? this.props.customEvent.scheduleIndices
+            : [this.props.currentScheduleIndex],
     };
 
     handleChange = (dayIndex) => (event) => {

--- a/src/components/CustomEvents/ScheduleSelector.js
+++ b/src/components/CustomEvents/ScheduleSelector.js
@@ -5,9 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 
 class ScheduleSelector extends PureComponent {
     state = {
-        scheduleIndices: this.props.customEvent
-            ? this.props.customEvent.scheduleIndices
-            : [this.props.currentScheduleIndex],
+        scheduleIndices: this.props.customEvent ? this.props.customEvent.scheduleIndices : this.props.scheduleIndices,
     };
 
     handleChange = (dayIndex) => (event) => {


### PR DESCRIPTION
## Summary
Upon clicking the **Add Custom** button on the **CalendarPaneToolbar**, one of the Schedule checkboxes will be preselected depending upon which schedule # the user is currently on. For example, if the user is on **Schedule 4**, the Schedule 4 checkbox will be preselected.
![image](https://user-images.githubusercontent.com/28518335/158096780-c3600500-6b72-4bba-aaef-d46a7e9e006c.png)

## Test Plan

- Open AntAlmanac
- Select Schedule 4
- Click **Add Custom** button
- Enter "Test" in **Event Name**
- Select **Tuesday**
- Click the **Add Event** button

## Issues
Closes #271

## Future Followup
- User can add custom events with a blank Event Name

