### PR TITLE
Custom Events header is now hidden if there aren't any events

### DIFF
--- a/src/components/AddedCourses/AddedCoursePane.js
+++ b/src/components/AddedCourses/AddedCoursePane.js
@@ -101,6 +101,14 @@ class AddedCoursePane extends PureComponent {
         this.setState({ customEvents: AppStore.getCustomEvents() });
     };
 
+    custEventHeader = (props) => {
+        const hasEvents = props.hasEvents;
+        if (hasEvents) {
+            return <Typography variant="h6">Custom Events</Typography>;
+        }
+        return;
+    };
+
     getGrid = () => {
         return (
             <Fragment>
@@ -173,7 +181,7 @@ class AddedCoursePane extends PureComponent {
                         </Grid>
                     );
                 })}
-                <Typography variant="h6">Custom Events</Typography>
+                <custEventHeader hasEvents={this.state.customEvents.length !== 0} />
                 {this.state.customEvents.map((customEvent) => {
                     if (customEvent.scheduleIndices.includes(AppStore.getCurrentScheduleIndex())) {
                         return (

--- a/src/components/AddedCourses/AddedCoursePane.js
+++ b/src/components/AddedCourses/AddedCoursePane.js
@@ -101,14 +101,6 @@ class AddedCoursePane extends PureComponent {
         this.setState({ customEvents: AppStore.getCustomEvents() });
     };
 
-    custEventHeader = (props) => {
-        const hasEvents = props.hasEvents;
-        if (hasEvents) {
-            return <Typography variant="h6">Custom Events</Typography>;
-        }
-        return;
-    };
-
     getGrid = () => {
         return (
             <Fragment>
@@ -181,7 +173,7 @@ class AddedCoursePane extends PureComponent {
                         </Grid>
                     );
                 })}
-                <custEventHeader hasEvents={this.state.customEvents.length !== 0} />
+                {this.state.customEvents.length > 0 && <Typography variant="h6">Custom Events</Typography>}
                 {this.state.customEvents.map((customEvent) => {
                     if (customEvent.scheduleIndices.includes(AppStore.getCurrentScheduleIndex())) {
                         return (


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/44384988/158108505-56c6e842-938c-49bc-a87c-81dea9571c78.png)

## Summary
Custom Events header is not hidden if there aren't any events

## Test Plan
Verified that the header is not shown without any events

## Issues
Closes #270


