### PR TITLE
Fix indexing for old custom events

### DIFF
--- a/src/components/AddedCourses/CustomEventDetailView.js
+++ b/src/components/AddedCourses/CustomEventDetailView.js
@@ -38,7 +38,9 @@ const CustomEventDetailView = (props) => {
         });
 
         const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-        const daysString = days.map((includeDate, index) => (includeDate ? dayAbbreviations[index] : '')).join(' ');
+        const daysString = days
+            .map((includeDate, index) => (includeDate ? dayAbbreviations[days.length === 7 ? index : index + 1] : ''))
+            .join(' ');
 
         return `${startTime.format('h:mm A')} — ${endTime.format('h:mm A')} • ${daysString}`;
     };

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -35,7 +35,7 @@ class CustomEventDialog extends PureComponent {
         start: this.props.customEvent ? this.props.customEvent.start : '10:30',
         end: this.props.customEvent ? this.props.customEvent.end : '15:30',
         eventName: this.props.customEvent ? this.props.customEvent.title : '',
-        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false],
+        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false, false, false],
         scheduleIndices: this.props.customEvent ? this.props.customEvent.scheduleIndices : [],
         customEventID: this.props.customEvent ? this.props.customEvent.customEventID : 0,
     };
@@ -54,7 +54,12 @@ class CustomEventDialog extends PureComponent {
             this.handleAddToCalendar();
         }
 
-        this.setState({ open: false, eventName: '', days: [false, false, false, false, false], scheduleIndices: [] });
+        this.setState({
+            open: false,
+            eventName: '',
+            days: [false, false, false, false, false, false, false],
+            scheduleIndices: [],
+        });
     };
 
     handleEventNameChange = (event) => {

--- a/src/components/CustomEvents/DaySelector.js
+++ b/src/components/CustomEvents/DaySelector.js
@@ -4,8 +4,22 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
 class DaySelector extends PureComponent {
+    getDays = (customEvent) => {
+        if (!customEvent) {
+            return [false, false, false, false, false, false, false];
+        }
+
+        const days = customEvent.days;
+
+        if (days.length === 5) {
+            return [false, ...days, false];
+        }
+
+        return days;
+    };
+
     state = {
-        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false, false, false],
+        days: this.getDays(this.props.customEvent),
     };
 
     handleChange = (dayIndex) => (event) => {

--- a/src/stores/calenderizeHelpers.js
+++ b/src/stores/calenderizeHelpers.js
@@ -123,7 +123,7 @@ export const calendarizeCustomEvents = () => {
                 const endMin = parseInt(customEvent.end.slice(3, 5), 10);
 
                 // AntAlmanac originally only had a 5-day calendar, which used a slightly
-                // different indexing system for custom events. Thus, to support old custom events,
+                // different indexing system for custom events. Therefore, to support old custom events,
                 // we use customEvent.days.length === 7 ? dayIndex : dayIndex + 1
                 customEventsInCalendar.push({
                     customEventID: customEvent.customEventID,

--- a/src/stores/calenderizeHelpers.js
+++ b/src/stores/calenderizeHelpers.js
@@ -115,19 +115,28 @@ export const calendarizeCustomEvents = () => {
     const customEventsInCalendar = [];
 
     for (const customEvent of customEvents) {
-        for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
-            if (customEvent.days[dayIndex] === true) {
+        for (let dayIndex = 0; dayIndex < customEvent.days.length; dayIndex++) {
+            if (customEvent.days[dayIndex]) {
                 const startHour = parseInt(customEvent.start.slice(0, 2), 10);
                 const startMin = parseInt(customEvent.start.slice(3, 5), 10);
                 const endHour = parseInt(customEvent.end.slice(0, 2), 10);
                 const endMin = parseInt(customEvent.end.slice(3, 5), 10);
 
+                // AntAlmanac originally only had a 5-day calendar, which used a slightly
+                // different indexing system for custom events. Thus, to support old custom events,
+                // we use customEvent.days.length === 7 ? dayIndex : dayIndex + 1
                 customEventsInCalendar.push({
                     customEventID: customEvent.customEventID,
                     color: customEvent.color,
-                    start: new Date(2018, 0, dayIndex, startHour, startMin),
+                    start: new Date(
+                        2018,
+                        0,
+                        customEvent.days.length === 7 ? dayIndex : dayIndex + 1,
+                        startHour,
+                        startMin
+                    ),
                     isCustomEvent: true,
-                    end: new Date(2018, 0, dayIndex, endHour, endMin),
+                    end: new Date(2018, 0, customEvent.days.length === 7 ? dayIndex : dayIndex + 1, endHour, endMin),
                     scheduleIndices: customEvent.scheduleIndices,
                     title: customEvent.title,
                 });


### PR DESCRIPTION
## Summary
- Custom events that were added before #230 are now one day earlier than they're supposed to be. This is because Sunday is now the first day instead of Monday.
- To resolve this issue, we have to check if a custom event's `days` array is of length 5 (instead of 7) in `calenderizeHelpers.js`. If the array is of length 5, `dayIndex` should be incremented by 1 so that all the old custom events are shifted to the right day.
- Additionally, we have to make sure the custom events have the correct day on the Added Classes page. The Custom Events dialog for old custom events should also have the correct days checked/selected.

## Test Plan
- Added custom events using the code before #230. These custom events are now in the correct place after this bug fix.
- The Added Classes page correctly displays custom events.
- The Custom Events dialog is correct for old custom events.
- Adding/deleting custom events on the weekdays and weekend still works.
- Loading, saving, and screenshotting the schedule all work normally.

## Issues
Closes #292 
