### PR TITLE
Fix ics download

### DIFF
--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -113,8 +113,8 @@ const getExamTime = (exam, year) => {
     const [examStartTime, examEndTime] = parseTimes(time);
 
     return [
-        [year, months[month], day, ...examStartTime],
-        [year, months[month], day, ...examEndTime],
+        [year, months[month], parseInt(day), ...examStartTime],
+        [year, months[month], parseInt(day), ...examEndTime],
     ];
 };
 
@@ -163,7 +163,7 @@ const parseTimes = (time) => {
 // getYear returns the year of a given term
 //  Ex: "2019 Fall" -> "2019"
 const getYear = (term) => {
-    return term.split(' ')[0];
+    return parseInt(term.split(' ')[0]);
 };
 
 // getQuarter returns the quarter of a given term


### PR DESCRIPTION
## Summary
ics `createEvent` expects a list of ints.
Having year and day as strings caused it to break.

It's unclear why this broke now.
I'm assuming it's because package-lock was updated to a newer version of ics.

## Test Plan
- Download a schedule
- Verify that download succeeds and that the finals dates are correct.

## Issues
Closes #295

## Future Followup
We should add automated tests for ics downloads. This feature breaks fairly often.