### PR TITLE
Simplify SOC updates

### DIFF
--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -6,22 +6,15 @@ import Today from '@material-ui/icons/Today';
 import { saveAs } from 'file-saver';
 import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
+import { termData } from '../../termData';
 
-// Hardcoded first mondays
-// You can find the start dates here: https://www.reg.uci.edu/calendars/academic/tenyr-19-29.html
-// Note: months are 0-indexed
 // TODO(chase): support summer sessions
-const quarterStartDates = {
-    '2019 Fall': [2019, 8, 26],
-    '2020 Winter': [2020, 0, 6],
-    '2020 Spring': [2020, 2, 30],
-    '2020 Fall': [2020, 9, 1],
-    '2021 Winter': [2021, 0, 4],
-    '2021 Spring': [2021, 2, 29],
-    '2021 Fall': [2021, 8, 23],
-    '2022 Winter': [2022, 0, 3],
-    '2022 Spring': [2022, 2, 28],
-};
+let quarterStartDates = {};
+for (const q of termData) {
+    if (!q.shortName.includes('Summer') && q.startDate) {
+        quarterStartDates[q.shortName] = q.startDate;
+    }
+}
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 const daysOffset = { SU: -1, MO: 0, TU: 1, WE: 2, TH: 3, FR: 4, SA: 5 };

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -9,12 +9,9 @@ import AppStore from '../../stores/AppStore';
 import { termData } from '../../termData';
 
 // TODO(chase): support summer sessions
-let quarterStartDates = {};
-for (const q of termData) {
-    if (!q.shortName.includes('Summer') && q.startDate) {
-        quarterStartDates[q.shortName] = q.startDate;
-    }
-}
+const quarterStartDates = termData
+    .filter((term) => !term.longName.includes('Summer') && term.startDate.length)
+    .reduce((prev, curr) => ({ ...prev, [curr.shortName]: curr.startDate }), {}); // https://stackoverflow.com/q/36388401
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 const daysOffset = { SU: -1, MO: 0, TU: 1, WE: 2, TH: 3, FR: 4, SA: 5 };

--- a/src/components/EnrollmentGraph/GraphModalContent.js
+++ b/src/components/EnrollmentGraph/GraphModalContent.js
@@ -3,6 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { FormControl, InputLabel, MenuItem, Paper, Select, Typography } from '@material-ui/core';
 import GraphRenderPane from './GraphRenderPane';
 import { queryWebsoc } from '../../helpers';
+import { termData, defaultTerm } from '../../termData';
 
 const styles = {
     paper: {
@@ -27,7 +28,7 @@ const styles = {
 
 class GraphModalContent extends PureComponent {
     state = {
-        pastTerm: '2022 Winter',
+        pastTerm: termData[defaultTerm + 1].shortName,
         pastSections: null,
     };
 
@@ -94,9 +95,13 @@ class GraphModalContent extends PureComponent {
                 <FormControl fullWidth>
                     <InputLabel>Term</InputLabel>
                     <Select value={this.state.pastTerm} onChange={this.handleChange}>
-                        <MenuItem value={'2021 Winter'}>2021 Winter Quarter</MenuItem>
-                        <MenuItem value={'2021 Spring'}>2021 Spring Quarter</MenuItem>
-                        <MenuItem value={'2021 Fall'}>2021 Fall Quarter</MenuItem>
+                        {termData
+                            .slice(defaultTerm + 2, defaultTerm + 8)
+                            .filter((q) => !q.shortName.includes('Summer'))
+                            .reverse()
+                            .map((q) => (
+                                <MenuItem value={q.shortName}>{q.longName}</MenuItem>
+                            ))}
                     </Select>
                 </FormControl>
                 {whatToDisplay}

--- a/src/components/SearchForm/TermSelector.js
+++ b/src/components/SearchForm/TermSelector.js
@@ -35,8 +35,8 @@ class TermSelector extends PureComponent {
             <FormControl fullWidth>
                 <InputLabel>Term</InputLabel>
                 <Select value={this.state.term} onChange={this.handleChange}>
-                    {termData.map((q) => (
-                        <MenuItem value={q.shortName}>{q.longName}</MenuItem>
+                    {termData.map((term) => (
+                        <MenuItem value={term.shortName}>{term.longName}</MenuItem>
                     ))}
                 </Select>
             </FormControl>

--- a/src/components/SearchForm/TermSelector.js
+++ b/src/components/SearchForm/TermSelector.js
@@ -5,6 +5,7 @@ import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import { updateFormValue } from '../../actions/RightPaneActions';
 import RightPaneStore from '../../stores/RightPaneStore.js';
+import { termData } from '../../termData';
 
 class TermSelector extends PureComponent {
     state = {
@@ -34,45 +35,9 @@ class TermSelector extends PureComponent {
             <FormControl fullWidth>
                 <InputLabel>Term</InputLabel>
                 <Select value={this.state.term} onChange={this.handleChange}>
-                    <MenuItem value={'2022 Spring'}>2022 Spring Quarter</MenuItem>
-                    <MenuItem value={'2022 Winter'}>2022 Winter Quarter</MenuItem>
-                    <MenuItem value={'2021 Fall'}>2021 Fall Quarter</MenuItem>
-                    <MenuItem value={'2021 Spring'}>2021 Spring Quarter</MenuItem>
-                    <MenuItem value={'2021 Winter'}>2021 Winter Quarter</MenuItem>
-                    <MenuItem value={'2020 Fall'}>2020 Fall Quarter</MenuItem>
-                    <MenuItem value={'2020 Spring'}>2020 Spring Quarter</MenuItem>
-                    <MenuItem value={'2020 Winter'}>2020 Winter Quarter</MenuItem>
-                    <MenuItem value={'2019 Fall'}>2019 Fall Quarter</MenuItem>
-                    <MenuItem value={'2019 Summer2'}>2019 Summer Session 2</MenuItem>
-                    <MenuItem value={'2019 Summer10wk'}>2019 10-wk Summer</MenuItem>
-                    <MenuItem value={'2019 Summer1'}>2019 Summer Session 1</MenuItem>
-                    <MenuItem value={'2019 Spring'}>2019 Spring Quarter</MenuItem>
-                    <MenuItem value={'2019 Winter'}>2019 Winter Quarter</MenuItem>
-                    <MenuItem value={'2018 Fall'}>2018 Fall Quarter</MenuItem>
-                    <MenuItem value={'2018 Summer2'}>2018 Summer Session 2</MenuItem>
-                    <MenuItem value={'2018 Summer10wk'}>2018 10-wk Summer</MenuItem>
-                    <MenuItem value={'2018 Summer1'}>2018 Summer Session 1</MenuItem>
-                    <MenuItem value={'2018 Spring'}>2018 Spring Quarter</MenuItem>
-                    <MenuItem value={'2018 Winter'}>2018 Winter Quarter</MenuItem>
-                    <MenuItem value={'2017 Fall'}>2017 Fall Quarter</MenuItem>
-                    <MenuItem value={'2017 Summer2'}>2017 Summer Session 2</MenuItem>
-                    <MenuItem value={'2017 Summer10wk'}>2017 10-wk Summer</MenuItem>
-                    <MenuItem value={'2017 Summer1'}>2017 Summer Session 1</MenuItem>
-                    <MenuItem value={'2017 Spring'}>2017 Spring Quarter</MenuItem>
-                    <MenuItem value={'2017 Winter'}>2017 Winter Quarter</MenuItem>
-                    <MenuItem value={'2016 Fall'}>2016 Fall Quarter</MenuItem>
-                    <MenuItem value={'2016 Summer2'}>2016 Summer Session 2</MenuItem>
-                    <MenuItem value={'2016 Summer10wk'}>2016 10-wk Summer</MenuItem>
-                    <MenuItem value={'2016 Summer1'}>2016 Summer Session 1</MenuItem>
-                    <MenuItem value={'2016 Spring'}>2016 Spring Quarter</MenuItem>
-                    <MenuItem value={'2016 Winter'}>2016 Winter Quarter</MenuItem>
-                    <MenuItem value={'2015 Fall'}>2015 Fall Quarter</MenuItem>
-                    <MenuItem value={'2015 Summer2'}>2015 Summer Session 2</MenuItem>
-                    <MenuItem value={'2015 Summer10wk'}>2015 10-wk Summer</MenuItem>
-                    <MenuItem value={'2015 Summer1'}>2015 Summer Session 1</MenuItem>
-                    <MenuItem value={'2015 Spring'}>2015 Spring Quarter</MenuItem>
-                    <MenuItem value={'2015 Winter'}>2015 Winter Quarter</MenuItem>
-                    <MenuItem value={'2014 Fall'}>2014 Fall Quarter</MenuItem>
+                    {termData.map((q) => (
+                        <MenuItem value={q.shortName}>{q.longName}</MenuItem>
+                    ))}
                 </Select>
             </FormControl>
         );

--- a/src/stores/RightPaneStore.js
+++ b/src/stores/RightPaneStore.js
@@ -1,12 +1,13 @@
 import { EventEmitter } from 'events';
 import dispatcher from '../dispatcher';
 import { clearCache } from '../helpers';
+import { termData, defaultTerm } from '../termData';
 
 const defaultFormValues = {
     deptValue: 'ALL',
     deptLabel: 'ALL: Include All Departments',
     ge: 'ANY',
-    term: '2022 Spring',
+    term: termData[defaultTerm].shortName,
     courseNumber: '',
     sectionCode: '',
     instructor: '',

--- a/src/termData.js
+++ b/src/termData.js
@@ -1,0 +1,64 @@
+function Term(shortName, longName, startDate = []) {
+    this.shortName = shortName;
+    this.longName = longName;
+    this.startDate = startDate;
+    Object.seal(this);
+}
+
+// Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2021-2022/quarterly21-22.html
+// Note: months are 0-indexed
+const termData = [
+    new Term('2022 Summer2', '2022 Summer Session 2'),
+    new Term('2022 Summer10wk', '2022 10-wk Summer'),
+    new Term('2022 Summer1', '2022 Summer Session 1'),
+    new Term('2022 Spring', '2022 Spring Quarter', [2022, 2, 28]),
+    new Term('2022 Winter', '2022 Winter Quarter', [2022, 0, 3]),
+    new Term('2021 Fall', '2021 Fall Quarter', [2021, 8, 23]),
+    new Term('2021 Summer2', '2021 Summer Session 2'),
+    new Term('2021 Summer10wk', '2021 10-wk Summer'),
+    new Term('2021 Summer1', '2021 Summer Session 1'),
+    new Term('2021 Spring', '2021 Spring Quarter', [2021, 2, 29]),
+    new Term('2021 Winter', '2021 Winter Quarter', [2021, 0, 4]),
+    new Term('2020 Fall', '2020 Fall Quarter', [2020, 9, 1]),
+    new Term('2020 Summer2', '2020 Summer Session 2'),
+    new Term('2020 Summer10wk', '2020 10-wk Summer'),
+    new Term('2020 Summer1', '2020 Summer Session 1'),
+    new Term('2020 Spring', '2020 Spring Quarter', [2020, 2, 30]),
+    new Term('2020 Winter', '2020 Winter Quarter', [2020, 0, 6]),
+    new Term('2019 Fall', '2019 Fall Quarter', [2019, 8, 26]),
+    new Term('2019 Summer2', '2019 Summer Session 2'),
+    new Term('2019 Summer10wk', '2019 10-wk Summer'),
+    new Term('2019 Summer1', '2019 Summer Session 1'),
+    new Term('2019 Spring', '2019 Spring Quarter'),
+    new Term('2019 Winter', '2019 Winter Quarter'),
+    new Term('2018 Fall', '2018 Fall Quarter'),
+    new Term('2018 Summer2', '2018 Summer Session 2'),
+    new Term('2018 Summer10wk', '2018 10-wk Summer'),
+    new Term('2018 Summer1', '2018 Summer Session 1'),
+    new Term('2018 Spring', '2018 Spring Quarter'),
+    new Term('2018 Winter', '2018 Winter Quarter'),
+    new Term('2017 Fall', '2017 Fall Quarter'),
+    new Term('2017 Summer2', '2017 Summer Session 2'),
+    new Term('2017 Summer10wk', '2017 10-wk Summer'),
+    new Term('2017 Summer1', '2017 Summer Session 1'),
+    new Term('2017 Spring', '2017 Spring Quarter'),
+    new Term('2017 Winter', '2017 Winter Quarter'),
+    new Term('2016 Fall', '2016 Fall Quarter'),
+    new Term('2016 Summer2', '2016 Summer Session 2'),
+    new Term('2016 Summer10wk', '2016 10-wk Summer'),
+    new Term('2016 Summer1', '2016 Summer Session 1'),
+    new Term('2016 Spring', '2016 Spring Quarter'),
+    new Term('2016 Winter', '2016 Winter Quarter'),
+    new Term('2015 Fall', '2015 Fall Quarter'),
+    new Term('2015 Summer2', '2015 Summer Session 2'),
+    new Term('2015 Summer10wk', '2015 10-wk Summer'),
+    new Term('2015 Summer1', '2015 Summer Session 1'),
+    new Term('2015 Spring', '2015 Spring Quarter'),
+    new Term('2015 Winter', '2015 Winter Quarter'),
+    new Term('2014 Fall', '2014 Fall Quarter'),
+];
+
+// The index of the default term in termData, as per WebSOC
+const defaultTerm = 3;
+
+export { termData, defaultTerm };

--- a/src/termData.js
+++ b/src/termData.js
@@ -1,8 +1,10 @@
+// The index of the default term in termData, as per WebSOC
+const defaultTerm = 3;
+
 function Term(shortName, longName, startDate = []) {
     this.shortName = shortName;
     this.longName = longName;
     this.startDate = startDate;
-    Object.seal(this);
 }
 
 // Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2021-2022/quarterly21-22.html
@@ -57,8 +59,5 @@ const termData = [
     new Term('2015 Winter', '2015 Winter Quarter'),
     new Term('2014 Fall', '2014 Fall Quarter'),
 ];
-
-// The index of the default term in termData, as per WebSOC
-const defaultTerm = 3;
 
 export { termData, defaultTerm };


### PR DESCRIPTION
## Summary
Collect all term data used by AntAlmanac into `termData`, which exports an `Array` of `Term` objects and the index of the default `Term` (as per the default term in WebSOC's term dropdown). This way, updates for future quarters simply involves adding a new `Term` object to the front of the `termData.termData` array literal, and updating the `termData.defaultTerm` constant to the index of the new default term.

The `defaultTerm` constant is useful for cases where the first `Term` in the array is not necessarily the current or immediate next term. For instance, WebSOC's default term as of the time of writing is 2022 Spring, while the Schedules of Classes for all Summer Sessions have already been released and are ahead of 2022 Spring in the dropdown.

## Test Plan
1. The Term dropdown in the Class Search tab still works as it did prior to this change.
2. Downloading a schedule (with classes from non-Summer Session terms) as an `.ics` file still works as it did prior to this change.

## Issues
Closes #227.

## Future Followup (Optional)
There have been proposals regarding scraping in other projects (e.g. icssc-projects/peterportal-public-api#16), so I'm wondering whether it would be possible and/or useful to scrape the registrar page for future terms and relevant dates. This might be out of scope for AntAlmanac, but if implemented properly the terms wouldn't be needed to be added manually even to `termData`.