### PR TITLE
Add refresh button to CourseRenderPane

### DIFF
--- a/src/components/CoursePane/CoursePaneButtonRow.js
+++ b/src/components/CoursePane/CoursePaneButtonRow.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { IconButton, Tooltip } from '@material-ui/core';
-import { ArrowBack } from '@material-ui/icons';
+import { ArrowBack, Refresh } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
@@ -30,11 +30,11 @@ class CoursePaneButtonRow extends PureComponent {
                     </IconButton>
                 </Tooltip>
 
-                {/*<Tooltip title="Refresh Search Results">*/}
-                {/*    <IconButton onClick={this.fetchSearch} className={classes.button}>*/}
-                {/*        <Refresh />*/}
-                {/*    </IconButton>*/}
-                {/*</Tooltip>*/}
+                <Tooltip title="Refresh Search Results">
+                    <IconButton onClick={this.props.onRefreshSearch} className={classes.button}>
+                        <Refresh />
+                    </IconButton>
+                </Tooltip>
             </div>
         );
     }

--- a/src/components/CoursePane/RightPane.js
+++ b/src/components/CoursePane/RightPane.js
@@ -5,6 +5,7 @@ import CourseRenderPane from './CourseRenderPane';
 import { withStyles } from '@material-ui/core/styles';
 import RightPaneStore from '../../stores/RightPaneStore';
 import dispatcher from '../../dispatcher';
+import { clearCache } from '../../helpers';
 
 const styles = {
     container: {
@@ -13,6 +14,19 @@ const styles = {
 };
 
 class RightPane extends PureComponent {
+    // When a user clicks the refresh button in CoursePaneButtonRow,
+    // we increment the refresh state by 1.
+    // Since it's the key for CourseRenderPane, it triggers a rerender
+    // and reloads the latest course data
+    state = {
+        refresh: 0,
+    };
+
+    refreshSearch = () => {
+        clearCache();
+        this.setState({ refresh: this.state.refresh + 1 });
+    };
+
     toggleSearch = () => {
         dispatcher.dispatch({
             type: 'TOGGLE_SEARCH',
@@ -26,11 +40,12 @@ class RightPane extends PureComponent {
                 <CoursePaneButtonRow
                     showSearch={!RightPaneStore.getDoDisplaySearch()}
                     onDismissSearchResults={this.toggleSearch}
+                    onRefreshSearch={this.refreshSearch}
                 />
                 {RightPaneStore.getDoDisplaySearch() ? (
                     <SearchForm toggleSearch={this.toggleSearch} />
                 ) : (
-                    <CourseRenderPane />
+                    <CourseRenderPane key={this.state.refresh} />
                 )}
             </Fragment>
         );


### PR DESCRIPTION
## Summary
Adds a refresh button to the Class Search page, so users can reload the latest data from WebSoc.
![refresh](https://user-images.githubusercontent.com/29494270/158492071-b0d822da-6c3f-4440-aecc-7ec85a06027c.gif)


## Test Plan
- Search for a class
- Press the refresh button
    - verify that the component reloads
- Switch to "Added Class" tab and then back to "Class Search"
    - verify that the course data is still cached

## Issues
Close #116 
