### PR TITLE
Import from Study List feature

### DIFF
--- a/src/components/App/CustomAppBar.js
+++ b/src/components/App/CustomAppBar.js
@@ -12,6 +12,7 @@ import { ReactComponent as MobileLogo } from './mobile-logo.svg';
 import News from './News';
 import AboutPage from './AboutPage';
 import ConditionalWrapper from './ConditionalWrapper';
+import ImportStudyList from './ImportStudyList';
 
 const styles = {
     appBar: {
@@ -46,6 +47,8 @@ const CustomAppBar = (props) => {
                 {isMobileScreen ? <MobileLogo height={32} /> : <Logo height={32} />}
 
                 <div style={{ flexGrow: '1' }} />
+
+                <ImportStudyList />
 
                 <LoadSaveScheduleFunctionality />
 

--- a/src/components/App/CustomAppBar.js
+++ b/src/components/App/CustomAppBar.js
@@ -48,8 +48,6 @@ const CustomAppBar = (props) => {
 
                 <div style={{ flexGrow: '1' }} />
 
-                <ImportStudyList />
-
                 <LoadSaveScheduleFunctionality />
 
                 <ConditionalWrapper
@@ -66,6 +64,7 @@ const CustomAppBar = (props) => {
                     {[
                         <SettingsMenu />,
                         <NotificationHub />,
+                        <ImportStudyList />,
                         <Tooltip title="Give Us Feedback!">
                             <Button
                                 onClick={() => {

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -17,6 +17,13 @@ import { termData } from '../../termData';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import InputLabel from '@material-ui/core/InputLabel';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = {
+    input: {
+        'margin-top': '10px',
+    },
+};
 
 class ImportStudyList extends PureComponent {
     state = {
@@ -119,6 +126,7 @@ class ImportStudyList extends PureComponent {
     }
 
     render() {
+        const { classes } = this.props;
         return (
             <>
                 {/* TODO after mui v5 migration: change icon to ContentPasteGo */}
@@ -133,26 +141,30 @@ class ImportStudyList extends PureComponent {
                             the right term selected below.
                         </DialogContentText>
                         {/* TODO refactor to use a modified TermSelector */}
-                        <InputLabel>Term</InputLabel>
-                        <Select value={this.state.selectedTerm} onChange={this.handleChange}>
-                            {termData.map((term, index) => (
-                                <MenuItem key={index} value={term.shortName}>
-                                    {term.longName}
-                                </MenuItem>
-                            ))}
-                        </Select>
+                        <div className={classes.input}>
+                            <InputLabel>Term</InputLabel>
+                            <Select value={this.state.selectedTerm} onChange={this.handleChange}>
+                                {termData.map((term, index) => (
+                                    <MenuItem key={index} value={term.shortName}>
+                                        {term.longName}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </div>
                         <br />
-                        <InputLabel>Study List</InputLabel>
-                        <TextField
-                            autoFocus
-                            fullWidth
-                            multiline
-                            margin="dense"
-                            type="text"
-                            placeholder="Paste here"
-                            value={this.state.studyListText}
-                            onChange={(event) => this.setState({ studyListText: event.target.value })}
-                        />
+                        <div className={classes.input}>
+                            <InputLabel>Study List</InputLabel>
+                            <TextField
+                                autoFocus
+                                fullWidth
+                                multiline
+                                margin="dense"
+                                type="text"
+                                placeholder="Paste here"
+                                value={this.state.studyListText}
+                                onChange={(event) => this.setState({ studyListText: event.target.value })}
+                            />
+                        </div>
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={() => this.handleClose(false)} color="primary">
@@ -168,4 +180,4 @@ class ImportStudyList extends PureComponent {
     }
 }
 
-export default ImportStudyList;
+export default withStyles(styles)(ImportStudyList);

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -49,7 +49,6 @@ class ImportStudyList extends PureComponent {
         this.setState({ isOpen: false }, async () => {
             document.removeEventListener('keydown', this.enterEvent, false);
             if (doImport) {
-                document.removeEventListener('keydown', this.enterEvent, false);
                 const sectionCodes = this.state.studyListText.match(/\d{5}/g);
                 if (!sectionCodes) {
                     openSnackbar('error', 'Cannot import an empty/invalid Study List.');

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -1,0 +1,122 @@
+import React, { PureComponent } from 'react';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    TextField,
+} from '@material-ui/core';
+import { queryWebsoc } from '../../helpers';
+import store from '../../stores/RightPaneStore';
+import { addCourse, clearSchedules, openSnackbar } from '../../actions/AppStoreActions';
+import AppStore from '../../stores/AppStore';
+import { GetApp } from '@material-ui/icons';
+
+class ImportStudyList extends PureComponent {
+    state = {
+        isOpen: false,
+        selectedTerm: null,
+        studyListText: '',
+    };
+
+    handleError = (index) => {
+        clearSchedules([index]);
+        openSnackbar('error', 'An error occurred while trying to import the Study List.');
+    };
+
+    handleOpen = () => {
+        this.setState({ isOpen: true, selectedTerm: store.getFormData().term });
+    };
+
+    handleClose = (doImport) => {
+        this.setState({ isOpen: false }, () => {
+            document.removeEventListener('keydown', this.enterEvent, false);
+            this.setState({ studyListText: '' });
+        });
+        if (doImport) {
+            document.removeEventListener('keydown', this.enterEvent, false);
+            if (!(this.state.studyListText && this.state.studyListText.match(/\d{5}/g))) {
+                openSnackbar('error', 'Cannot import an empty/invalid Study List.');
+                return;
+            }
+            const currIndex = AppStore.getCurrentScheduleIndex();
+            try {
+                Promise.all(
+                    this.state.studyListText
+                        .split('\n')
+                        .map((line) => line.match(/\d{5}/g))
+                        .filter((id) => id)
+                        .flat()
+                        .map((sectionCode) => queryWebsoc({ term: this.state.selectedTerm, sectionCodes: sectionCode }))
+                )
+                    .then((r) => {
+                        r.forEach((response) => {
+                            const courseData = response.schools[0].departments[0].courses[0];
+                            addCourse(courseData.sections[0], courseData, this.state.selectedTerm, currIndex);
+                        });
+
+                        openSnackbar('success', 'Study List successfully imported!');
+                    })
+                    .catch(() => this.handleError(currIndex));
+            } catch (e) {
+                this.handleError(currIndex);
+            }
+        }
+    };
+
+    enterEvent = (event) => {
+        const charCode = event.which ? event.which : event.keyCode;
+        if (charCode === 13 || charCode === 10) {
+            event.preventDefault();
+            this.handleClose(true);
+        }
+    };
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (!prevState.isOpen && this.state.isOpen) {
+            document.addEventListener('keydown', this.enterEvent, false);
+        } else if (prevState.isOpen && !this.state.isOpen) {
+            document.removeEventListener('keydown', this.enterEvent, false);
+        }
+    }
+
+    render() {
+        return (
+            <>
+                <Button onClick={this.handleOpen} color="inherit" startIcon={<GetApp />}>
+                    Import
+                </Button>
+                <Dialog open={this.state.isOpen}>
+                    <DialogTitle>Import Schedule</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText>
+                            Paste the contents of your Study List below to import it into AntAlmanac.
+                        </DialogContentText>
+                        <TextField
+                            autoFocus
+                            fullWidth
+                            multiline
+                            margin="dense"
+                            type="text"
+                            placeholder="Paste here"
+                            value={this.state.studyListText}
+                            onChange={(event) => this.setState({ studyListText: event.target.value })}
+                        />
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={() => this.handleClose(false)} color="primary">
+                            Cancel
+                        </Button>
+                        <Button onClick={() => this.handleClose(true)} color="primary">
+                            Import
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            </>
+        );
+    }
+}
+
+export default ImportStudyList;

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -50,12 +50,12 @@ class ImportStudyList extends PureComponent {
             document.removeEventListener('keydown', this.enterEvent, false);
             if (doImport) {
                 document.removeEventListener('keydown', this.enterEvent, false);
-                if (!this.state.studyListText.match(/\d{5}/g)) {
+                const sectionCodes = this.state.studyListText.match(/\d{5}/g);
+                if (!sectionCodes) {
                     openSnackbar('error', 'Cannot import an empty/invalid Study List.');
                     return;
                 }
                 const currSchedule = AppStore.getCurrentScheduleIndex();
-                const sectionCodes = this.state.studyListText.match(/\d{5}/g);
                 let sectionsAdded = 0;
                 try {
                     (

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -60,10 +60,7 @@ class ImportStudyList extends PureComponent {
                         .reduce((result, item, index) => {
                             // WebSOC queries can have a maximum of 8 course codes in tandem
                             const chunkIndex = Math.floor(index / 8);
-                            if (!result[chunkIndex]) {
-                                result[chunkIndex] = [];
-                            }
-                            result[chunkIndex].push(item);
+                            result[chunkIndex] ? result[chunkIndex].push(item) : (result[chunkIndex] = [item]);
                             return result;
                         }, []) // https://stackoverflow.com/a/37826698
                         .map((sectionCode) =>

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -9,16 +9,24 @@ import {
     TextField,
 } from '@material-ui/core';
 import { queryWebsoc } from '../../helpers';
-import store from '../../stores/RightPaneStore';
-import { addCourse, clearSchedules, openSnackbar } from '../../actions/AppStoreActions';
+import RightPaneStore from '../../stores/RightPaneStore';
+import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
 import { GetApp } from '@material-ui/icons';
+import { termData } from '../../termData';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import InputLabel from '@material-ui/core/InputLabel';
 
 class ImportStudyList extends PureComponent {
     state = {
         isOpen: false,
-        selectedTerm: null,
+        selectedTerm: RightPaneStore.getFormData().term,
         studyListText: '',
+    };
+
+    handleChange = (event) => {
+        this.setState({ selectedTerm: event.target.value });
     };
 
     handleError = (error) => {
@@ -27,7 +35,7 @@ class ImportStudyList extends PureComponent {
     };
 
     handleOpen = () => {
-        this.setState({ isOpen: true, selectedTerm: store.getFormData().term });
+        this.setState({ isOpen: true });
     };
 
     handleClose = (doImport) => {
@@ -37,7 +45,7 @@ class ImportStudyList extends PureComponent {
         });
         if (doImport) {
             document.removeEventListener('keydown', this.enterEvent, false);
-            if (!(this.state.studyListText && this.state.studyListText.match(/\d{5}/g))) {
+            if (!this.state.studyListText.match(/\d{5}/g)) {
                 openSnackbar('error', 'Cannot import an empty/invalid Study List.');
                 return;
             }
@@ -110,8 +118,17 @@ class ImportStudyList extends PureComponent {
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Paste the contents of your Study List below to import it into AntAlmanac.
+                            Paste the contents of your Study List below to import it into AntAlmanac. Make sure you have
+                            the right term selected below.
                         </DialogContentText>
+                        <InputLabel>Term</InputLabel>
+                        <Select value={this.state.selectedTerm} onChange={this.handleChange}>
+                            {termData.map((term) => (
+                                <MenuItem value={term.shortName}>{term.longName}</MenuItem>
+                            ))}
+                        </Select>
+                        <br />
+                        <InputLabel>Study List</InputLabel>
                         <TextField
                             autoFocus
                             fullWidth

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -21,9 +21,9 @@ class ImportStudyList extends PureComponent {
         studyListText: '',
     };
 
-    handleError = (index) => {
-        clearSchedules([index]);
+    handleError = (error) => {
         openSnackbar('error', 'An error occurred while trying to import the Study List.');
+        console.error(error);
     };
 
     handleOpen = () => {
@@ -59,9 +59,9 @@ class ImportStudyList extends PureComponent {
 
                         openSnackbar('success', 'Study List successfully imported!');
                     })
-                    .catch(() => this.handleError(currIndex));
+                    .catch((e) => this.handleError(e));
             } catch (e) {
-                this.handleError(currIndex);
+                this.handleError(e);
             }
         }
     };

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -12,7 +12,7 @@ import { queryWebsoc } from '../../helpers';
 import RightPaneStore from '../../stores/RightPaneStore';
 import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
-import { GetApp } from '@material-ui/icons';
+import { PostAdd } from '@material-ui/icons';
 import { termData } from '../../termData';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
@@ -66,19 +66,21 @@ class ImportStudyList extends PureComponent {
                                 queryWebsoc({ term: this.state.selectedTerm, sectionCodes: sectionCode.join(',') })
                             )
                     )
-                ).forEach((response) => {
-                    response.schools
-                        .map((school) => school.departments)
-                        .flat()
-                        .map((dept) => dept.courses)
-                        .flat()
-                        .forEach((course) => {
-                            course.sections.forEach((section) => {
-                                addCourse(section, course, this.state.selectedTerm, currSchedule);
-                                ++sectionsAdded;
+                )
+                    // TODO refactor to use helper function for extracting course info from WebSOC query
+                    .forEach((response) => {
+                        response.schools
+                            .map((school) => school.departments)
+                            .flat()
+                            .map((dept) => dept.courses)
+                            .flat()
+                            .forEach((course) => {
+                                course.sections.forEach((section) => {
+                                    addCourse(section, course, this.state.selectedTerm, currSchedule);
+                                    ++sectionsAdded;
+                                });
                             });
-                        });
-                });
+                    });
                 if (sectionsAdded === sectionCodes.length) {
                     openSnackbar('success', `Successfully imported ${sectionsAdded} of ${sectionsAdded} classes!`);
                 } else if (sectionsAdded !== 0) {
@@ -119,7 +121,8 @@ class ImportStudyList extends PureComponent {
     render() {
         return (
             <>
-                <Button onClick={this.handleOpen} color="inherit" startIcon={<GetApp />}>
+                {/* TODO after mui v5 migration: change icon to ContentPasteGo */}
+                <Button onClick={this.handleOpen} color="inherit" startIcon={<PostAdd />}>
                     Import
                 </Button>
                 <Dialog open={this.state.isOpen}>
@@ -129,10 +132,13 @@ class ImportStudyList extends PureComponent {
                             Paste the contents of your Study List below to import it into AntAlmanac. Make sure you have
                             the right term selected below.
                         </DialogContentText>
+                        {/* TODO refactor to use a modified TermSelector */}
                         <InputLabel>Term</InputLabel>
                         <Select value={this.state.selectedTerm} onChange={this.handleChange}>
-                            {termData.map((term) => (
-                                <MenuItem value={term.shortName}>{term.longName}</MenuItem>
+                            {termData.map((term, index) => (
+                                <MenuItem key={index} value={term.shortName}>
+                                    {term.longName}
+                                </MenuItem>
                             ))}
                         </Select>
                         <br />

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -50,19 +50,15 @@ class ImportStudyList extends PureComponent {
                 return;
             }
             const currSchedule = AppStore.getCurrentScheduleIndex();
-            const sectionCodes = this.state.studyListText
-                .split('\n')
-                .map((line) => line.match(/\d{5}/g))
-                .filter((id) => id)
-                .flat();
+            const sectionCodes = this.state.studyListText.match(/\d{5}/g);
             let sectionsAdded = 0;
             try {
                 (
                     await Promise.all(
                         sectionCodes
                             .reduce((result, item, index) => {
-                                // WebSOC queries can have a maximum of 8 course codes in tandem
-                                const chunkIndex = Math.floor(index / 8);
+                                // WebSOC queries can have a maximum of 10 course codes in tandem
+                                const chunkIndex = Math.floor(index / 10);
                                 result[chunkIndex] ? result[chunkIndex].push(item) : (result[chunkIndex] = [item]);
                                 return result;
                             }, []) // https://stackoverflow.com/a/37826698
@@ -105,6 +101,7 @@ class ImportStudyList extends PureComponent {
 
     enterEvent = (event) => {
         const charCode = event.which ? event.which : event.keyCode;
+        // enter (13) or newline (10)
         if (charCode === 13 || charCode === 10) {
             event.preventDefault();
             this.handleClose(true);

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -137,21 +137,14 @@ class ImportStudyList extends PureComponent {
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Paste the contents of your Study List below to import it into AntAlmanac. Make sure you have
-                            the right term selected below.
+                            Paste the contents of your Study List below to import it into AntAlmanac.
+                            <br />
+                            To find your Study List, go to{' '}
+                            <a href={'https://www.reg.uci.edu/cgi-bin/webreg-redirect.sh'}>WebReg</a> or{' '}
+                            <a href={'https://www.reg.uci.edu/access/student/welcome/'}>StudentAccess</a>, and click on
+                            Study List once you've logged in. Copy everything below the column names (Code, Dept, etc.)
+                            under the Enrolled Classes section.
                         </DialogContentText>
-                        {/* TODO refactor to use a modified TermSelector */}
-                        <div className={classes.input}>
-                            <InputLabel>Term</InputLabel>
-                            <Select value={this.state.selectedTerm} onChange={this.handleChange}>
-                                {termData.map((term, index) => (
-                                    <MenuItem key={index} value={term.shortName}>
-                                        {term.longName}
-                                    </MenuItem>
-                                ))}
-                            </Select>
-                        </div>
-                        <br />
                         <div className={classes.input}>
                             <InputLabel>Study List</InputLabel>
                             <TextField
@@ -164,6 +157,19 @@ class ImportStudyList extends PureComponent {
                                 value={this.state.studyListText}
                                 onChange={(event) => this.setState({ studyListText: event.target.value })}
                             />
+                        </div>
+                        <br />
+                        <DialogContentText>Make sure you also have the right term selected.</DialogContentText>
+                        {/* TODO refactor to use a modified TermSelector */}
+                        <div className={classes.input}>
+                            <InputLabel>Term</InputLabel>
+                            <Select value={this.state.selectedTerm} onChange={this.handleChange}>
+                                {termData.map((term, index) => (
+                                    <MenuItem key={index} value={term.shortName}>
+                                        {term.longName}
+                                    </MenuItem>
+                                ))}
+                            </Select>
                         </div>
                     </DialogContent>
                     <DialogActions>


### PR DESCRIPTION
## Summary

Allows new users to AntAlmanac to import their WebReg study list, which they can then save to the backend if they so choose.

Demo (you may need to open in new tab to view it in full resolution):
![antalmanac-import-studylist](https://user-images.githubusercontent.com/89349085/158491098-6fa45e86-01f4-4457-a6fa-5526034553c8.gif)
<sub>Incidentally, if anyone knows of a dark theme for WebReg please let me know…</sub>

## Test Plan
1. Leaving the textbox blank results in an error `Snackbar` telling the user that they cannot import an empty/invalid Study List.
2. Filling the textbox with gibberish results in the same `Snackbar` as above.
3. Pasting a properly formatted Study List as copy-pasted from WebReg, with the term selector in the right-hand pane set to the corresponding term, correctly imports the Study List into the currently focused Schedule.
4. Same as 3) but with the Study List from StudentAccess, which has a drastically different format compared to the Study List from WebReg, also correctly imports the Study List into the currently focused Schedule.

~~5. Any errors due to API calls failing (e.g. due to a term mismatch causing certain section codes to not exist) will result in a `Snackbar` notifying the user of an error , and the currently focused Schedule will be cleared. Any classes that were successfully added will remain added to the currently focused Schedule (possible caveat?).~~ Deprecated as of 577f946.

5. If a section cannot be added (e.g. due to a term mismatch causing that section code to not exist), the import process will continue silently. Upon conclusion of the process, a snackbar with the appropriate variant will be displayed, along with relevant information (success => all sections imported, warning => some sections imported, error => no sections imported).
6. Typing in any number of valid section codes for the current term, as long as they are delimited by a non-numeric character, correctly imports the courses as in 3) and 4). This is not really an expected usecase, but is useful if you just have a list of course codes for whatever reason, and works properly.

## Issues
Closes #225.

## Possible Enhancements before Merging

* Theming
  * Location: ~~Is the top bar appropriate for a feature like this?~~ Still provisional but has been moved into the overflow menu on mobile as of ad5efc2.
  * Icon: ~~Are there better icons than "download?" It might be a bit confusing.~~ Changed to `PostAdd` in a208b82 with the intent to update it to `ContentPasteGo` after migrating to mui v5.
* Error Handling: ~~The import can fail because of a multitude of reasons (API failure, mismatched term, empty/invalid input, etc). Do we want to tell the user what specifically went wrong, or is it okay to just say that it failed? If it comes down to user error, do we want to further delineate what exactly they did wrong?~~ Added logging to console in 3ee4ff9.
* Clearing Schedules: ~~This might not be such a good idea if (for example) the user tries to overwrite an existing schedule with a malformed Study List import, which would cause them to lose everything in that schedule. Maybe making a copy of the existing schedule and restoring it if something goes wrong would be better?~~ Removed in 3ee4ff9.
* Term Selection: ~~Add a drop-down in the dialog so users can select the term their Study List is from.~~ Implemented in 5857ce5.
* User Experience: Add a blurb to the dialog that tells the user where to actually find their Study List, as well as what and what not to copy.

Any thoughts and/or possible additional features are greatly appreciated.