### PR TITLE
Handle custom events with 6 days

### DIFF
--- a/src/components/AddedCourses/CustomEventDetailView.js
+++ b/src/components/AddedCourses/CustomEventDetailView.js
@@ -38,9 +38,7 @@ const CustomEventDetailView = (props) => {
         });
 
         const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-        const daysString = days
-            .map((includeDate, index) => (includeDate ? dayAbbreviations[days.length === 7 ? index : index + 1] : ''))
-            .join(' ');
+        const daysString = days.map((includeDate, index) => (includeDate ? dayAbbreviations[index] : '')).join(' ');
 
         return `${startTime.format('h:mm A')} — ${endTime.format('h:mm A')} • ${daysString}`;
     };

--- a/src/components/CustomEvents/DaySelector.js
+++ b/src/components/CustomEvents/DaySelector.js
@@ -4,22 +4,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
 class DaySelector extends PureComponent {
-    getDays = (customEvent) => {
-        if (!customEvent) {
-            return [false, false, false, false, false, false, false];
-        }
-
-        const days = customEvent.days;
-
-        if (days.length === 5) {
-            return [false, ...days, false];
-        }
-
-        return days;
-    };
-
     state = {
-        days: this.getDays(this.props.customEvent),
+        days: this.props.customEvent ? this.props.customEvent.days : [false, false, false, false, false, false, false],
     };
 
     handleChange = (dayIndex) => (event) => {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -41,6 +41,15 @@ class AppStore extends EventEmitter {
     }
 
     getCustomEvents() {
+        // Note: remove this forEach loop after Spring 2022 ends
+        this.customEvents.forEach((customEvent) => {
+            if (customEvent.days.length === 5) {
+                customEvent.days = [false, ...customEvent.days, false];
+            } else if (customEvent.days.length === 6) {
+                customEvent.days = [...customEvent.days, false];
+            }
+        });
+
         return this.customEvents;
     }
 

--- a/src/stores/calenderizeHelpers.js
+++ b/src/stores/calenderizeHelpers.js
@@ -122,21 +122,12 @@ export const calendarizeCustomEvents = () => {
                 const endHour = parseInt(customEvent.end.slice(0, 2), 10);
                 const endMin = parseInt(customEvent.end.slice(3, 5), 10);
 
-                // AntAlmanac originally only had a 5-day calendar, which used a slightly
-                // different indexing system for custom events. Therefore, to support old custom events,
-                // we use customEvent.days.length === 7 ? dayIndex : dayIndex + 1
                 customEventsInCalendar.push({
                     customEventID: customEvent.customEventID,
                     color: customEvent.color,
-                    start: new Date(
-                        2018,
-                        0,
-                        customEvent.days.length === 7 ? dayIndex : dayIndex + 1,
-                        startHour,
-                        startMin
-                    ),
+                    start: new Date(2018, 0, dayIndex, startHour, startMin),
                     isCustomEvent: true,
-                    end: new Date(2018, 0, customEvent.days.length === 7 ? dayIndex : dayIndex + 1, endHour, endMin),
+                    end: new Date(2018, 0, dayIndex, endHour, endMin),
                     scheduleIndices: customEvent.scheduleIndices,
                     title: customEvent.title,
                 });


### PR DESCRIPTION
## Summary
- Custom events with 6 days are now in the correct place. This was done by deleting the conditional logic from #292 and adding some code in `src\stores\AppStore.js`. This should be more concise and less prone to bugs.
- All custom events will have a `days` array of length 7 after the user saves, even if the user didn't directly edit the event.

## Test Plan
- Try adding custom events with a `days` array of length 5 or 6. This can be done by editing the `days` array in MongoDB. These custom events should still be in the correct place.
- Adding and editing custom events still work properly.
- Saving will make all custom events have a `days` array of length 7.

## Issues
Closes #310 

## Future Followup
- We should find out why some custom events have 6 values (instead of 5 or 7) in their `days` array.