### PR TITLE
Change 3 dots icon in course info button to info icon & move to left …

### DIFF
--- a/src/components/SectionTable/CourseInfoBar.js
+++ b/src/components/SectionTable/CourseInfoBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Button, Popover } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import { MoreVert } from '@material-ui/icons';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { PETERPORTAL_REST_ENDPOINT } from '../../api/endpoints';
 
 const styles = () => ({
@@ -138,8 +138,8 @@ class CourseInfoBar extends PureComponent {
                     }}
                     style={{ marginRight: '4px' }}
                 >
+                    <InfoOutlinedIcon fontSize="small" marginRight={5} />
                     {`${deptCode} ${courseNumber} | ${courseTitle}`}
-                    <MoreVert fontSize="small" />
                 </Button>
                 <Popover
                     anchorEl={this.state.anchorEl}

--- a/src/components/SectionTable/CourseInfoBar.js
+++ b/src/components/SectionTable/CourseInfoBar.js
@@ -138,7 +138,7 @@ class CourseInfoBar extends PureComponent {
                     }}
                     style={{ marginRight: '4px' }}
                 >
-                    <InfoOutlinedIcon fontSize="small" marginRight={5} />
+                    <InfoOutlinedIcon fontSize="small" style={{ marginRight: '5px' }} />
                     {`${deptCode} ${courseNumber} | ${courseTitle}`}
                 </Button>
                 <Popover


### PR DESCRIPTION
…of text

## Summary
Changed "3 dots icon" in course info button to "info outline icon"
Moved icon to left of the text
Before:
<img width="571" alt="Screen Shot 2022-03-19 at 3 18 54 PM" src="https://user-images.githubusercontent.com/74145903/159140623-4389d04e-9303-4adc-9c3c-9e40e78ddf9f.png">
Current:
<img width="571" alt="Screen Shot 2022-03-19 at 3 18 37 PM" src="https://user-images.githubusercontent.com/74145903/159140619-585e5794-d221-4ee0-beaa-45c725f63092.png">


## Test Plan
Verified in browser locally

## Issues
Closes #253 

## Future Followup (Optional)
