### PR TITLE
Encapsulate extraction of course info

### DIFF
--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -8,7 +8,7 @@ import {
     DialogTitle,
     TextField,
 } from '@material-ui/core';
-import { queryWebsoc } from '../../helpers';
+import { getCourseInfo, queryWebsoc } from '../../helpers';
 import RightPaneStore from '../../stores/RightPaneStore';
 import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
@@ -70,21 +70,12 @@ class ImportStudyList extends PureComponent {
                                     queryWebsoc({ term: this.state.selectedTerm, sectionCodes: sectionCode.join(',') })
                                 )
                         )
-                    )
-                        // TODO refactor to use helper function for extracting course info from WebSOC query
-                        .forEach((response) => {
-                            response.schools
-                                .map((school) => school.departments)
-                                .flat()
-                                .map((dept) => dept.courses)
-                                .flat()
-                                .forEach((course) => {
-                                    course.sections.forEach((section) => {
-                                        addCourse(section, course, this.state.selectedTerm, currSchedule);
-                                        ++sectionsAdded;
-                                    });
-                                });
-                        });
+                    ).forEach((response) => {
+                        for (const section of Object.values(getCourseInfo(response))) {
+                            addCourse(section.section, section.courseDetails, this.state.selectedTerm, currSchedule);
+                            ++sectionsAdded;
+                        }
+                    });
                     if (sectionsAdded === sectionCodes.length) {
                         openSnackbar('success', `Successfully imported ${sectionsAdded} of ${sectionsAdded} classes!`);
                     } else if (sectionsAdded !== 0) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,30 +37,42 @@ export async function getCoursesData(userData) {
 
             const jsonResp = await queryWebsoc(params);
 
-            for (const school of jsonResp.schools) {
-                for (const department of school.departments) {
-                    for (const course of department.courses) {
-                        for (const section of course.sections) {
-                            addedCourses.push({
-                                ...sectionCodeToInfoMapping[section.sectionCode],
-                                deptCode: department.deptCode,
-                                courseNumber: course.courseNumber,
-                                courseTitle: course.courseTitle,
-                                courseComment: course.courseComment,
-                                prerequisiteLink: course.prerequisiteLink,
-                                section: section,
-                            });
-                        }
-                    }
-                }
+            for (const [sectionCode, courseData] of Object.entries(getCourseInfo(jsonResp))) {
+                addedCourses.push({
+                    ...sectionCodeToInfoMapping[sectionCode],
+                    ...courseData.courseDetails,
+                    section: courseData.section,
+                });
             }
         }
     }
-
     return {
         addedCourses: addedCourses,
         customEvents: userData.customEvents,
     };
+}
+
+export function getCourseInfo(SOCObject) {
+    let courseInfo = {};
+    for (const school of SOCObject.schools) {
+        for (const department of school.departments) {
+            for (const course of department.courses) {
+                for (const section of course.sections) {
+                    courseInfo[section.sectionCode] = {
+                        courseDetails: {
+                            deptCode: department.deptCode,
+                            courseNumber: course.courseNumber,
+                            courseTitle: course.courseTitle,
+                            courseComment: course.courseComment,
+                            prerequisiteLink: course.prerequisiteLink,
+                        },
+                        section: section,
+                    };
+                }
+            }
+        }
+    }
+    return courseInfo;
 }
 
 const websocCache = {};


### PR DESCRIPTION
## Summary
Move the nested for loops which handle the extraction of course info from SOC queries into a separate helper function. This function returns the `courseDetails` required by `addCourse`, as well as the section data itself.

## Test Plan
1. Loading a schedule from the backend still works as it did prior to this change.
2. Importing a schedule from the Study List still works as it did prior to this change.

## Issues
Closes #308.
