### PR TITLE
Changed 'cancel' and 'load' button to white in the save/load option a…

### DIFF
--- a/src/components/App/LoadSaveFunctionality.js
+++ b/src/components/App/LoadSaveFunctionality.js
@@ -103,10 +103,10 @@ class LoadSaveButtonBase extends PureComponent {
                         />
                     </DialogContent>
                     <DialogActions>
-                        <Button onClick={() => this.handleClose(true)} color="primary">
+                        <Button onClick={() => this.handleClose(true)} color="white">
                             Cancel
                         </Button>
-                        <Button onClick={() => this.handleClose(false)} color="primary">
+                        <Button onClick={() => this.handleClose(false)} color="white">
                             {this.props.actionName}
                         </Button>
                     </DialogActions>

--- a/src/components/App/LoadSaveFunctionality.js
+++ b/src/components/App/LoadSaveFunctionality.js
@@ -12,6 +12,7 @@ import {
 import { loadSchedule, saveSchedule } from '../../actions/AppStoreActions';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import { isDarkMode } from '../../helpers';
 
 class LoadSaveButtonBase extends PureComponent {
     state = {
@@ -103,10 +104,10 @@ class LoadSaveButtonBase extends PureComponent {
                         />
                     </DialogContent>
                     <DialogActions>
-                        <Button onClick={() => this.handleClose(true)} color="white">
+                        <Button onClick={() => this.handleClose(true)} color={isDarkMode() ? 'white' : 'primary'}>
                             Cancel
                         </Button>
-                        <Button onClick={() => this.handleClose(false)} color="white">
+                        <Button onClick={() => this.handleClose(false)} color={isDarkMode() ? 'white' : 'primary'}>
                             {this.props.actionName}
                         </Button>
                     </DialogActions>

--- a/src/components/CoursePane/CoursePaneButtonRow.js
+++ b/src/components/CoursePane/CoursePaneButtonRow.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { IconButton, Tooltip } from '@material-ui/core';
 import { ArrowBack, Refresh } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
+import { withThemeCreator } from '@material-ui/styles';
 
 const styles = {
     buttonRow: {
@@ -15,6 +16,10 @@ const styles = {
         backgroundColor: 'rgba(236, 236, 236, 1)',
         marginRight: 5,
         boxShadow: 2,
+        color: 'black',
+        '&:hover': {
+            backgroundColor: 'grey',
+        },
     },
 };
 

--- a/src/components/CoursePane/CoursePaneButtonRow.js
+++ b/src/components/CoursePane/CoursePaneButtonRow.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { IconButton, Tooltip } from '@material-ui/core';
 import { ArrowBack, Refresh } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
-import { withThemeCreator } from '@material-ui/styles';
 
 const styles = {
     buttonRow: {


### PR DESCRIPTION
## Summary
Changed 'load' and 'cancel' button to white and made back and back button more visible by changing color to black and removing transparency.
## Test Plan
Checked changes on localhost
## Issues
Issue #224
## Future Followup (Optional)
<img width="944" alt="Screen Shot 2022-03-30 at 12 26 18 AM" src="https://user-images.githubusercontent.com/65580950/160776357-a54f0661-9016-42cd-8045-96f465d9a070.png">
<img width="644" alt="Screen Shot 2022-03-30 at 12 25 48 AM" src="https://user-images.githubusercontent.com/65580950/160776364-8771279d-8366-4bdd-a6b5-3fbed6a06f75.png">
<img width="1087" alt="Screen Shot 2022-03-30 at 12 26 28 AM" src="https://user-images.githubusercontent.com/65580950/160776338-acaa1ab6-4166-48c3-9a41-a2e4f84e3df6.png">
