### PR TITLE
Colorpicker fix for update and closing

### DIFF
--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -326,6 +326,8 @@ export const changeCustomEventColor = (customEventID, newColor) => {
     dispatcher.dispatch({
         type: 'CUSTOM_EVENT_COLOR_CHANGE',
         customEventsAfterColorChange,
+        customEventID,
+        newColor,
     });
 };
 
@@ -343,6 +345,8 @@ export const changeCourseColor = (sectionCode, newColor, term) => {
     dispatcher.dispatch({
         type: 'COURSE_COLOR_CHANGE',
         addedCoursesAfterColorChange,
+        sectionCode,
+        newColor,
     });
 };
 

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -1,3 +1,4 @@
+import AppStore from '../../stores/AppStore';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Popover, IconButton } from '@material-ui/core';
@@ -40,10 +41,26 @@ class ColorPicker extends PureComponent {
             action: 'Change Course Color',
         });
     };
+    updateColor = (color) => {
+        console.log(color);
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.color !== this.props.color) this.setState({ color: this.props.color });
-    }
+        if (color !== this.props.color) {
+            this.setState({ color: color });
+        }
+    };
+
+    componentDidMount = () => {
+        AppStore.registerColorPicker(
+            this.props.isCustomEvent ? this.props.customEventID : this.props.sectionCode,
+            this.updateColor
+        );
+    };
+    componentWillUnmount = () => {
+        AppStore.unregisterColorPicker(
+            this.props.isCustomEvent ? this.props.customEventID : this.props.sectionCode,
+            this.updateColor
+        );
+    };
 
     render() {
         return (

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -42,8 +42,6 @@ class ColorPicker extends PureComponent {
         });
     };
     updateColor = (color) => {
-        console.log(color);
-
         if (color !== this.props.color) {
             this.setState({ color: color });
         }

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -41,6 +41,10 @@ class ColorPicker extends PureComponent {
         });
     };
 
+    componentDidUpdate(prevProps) {
+        if (prevProps.color !== this.props.color) this.setState({ color: this.props.color });
+    }
+
     render() {
         return (
             <>

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -129,23 +129,25 @@ class ScheduleCalendar extends PureComponent {
         });
     };
 
-    updateEventsInCalendar = () => {
+    updateEventsInCalendar = (close = true) => {
         this.setState({
             eventsInCalendar: AppStore.getEventsInCalendar(),
             finalsEventsInCalendar: AppStore.getFinalEventsInCalendar(),
         });
-        this.handleClosePopover();
+        if (close) this.handleClosePopover();
     };
 
     componentDidMount = () => {
         AppStore.on('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.on('customEventsChange', this.updateEventsInCalendar);
+        AppStore.on('colorChange', this.updateEventsInCalendar);
         AppStore.on('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
     };
 
     componentWillUnmount = () => {
         AppStore.removeListener('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.removeListener('customEventsChange', this.updateEventsInCalendar);
+        AppStore.removeListener('colorChange', this.updateEventsInCalendar);
         AppStore.removeListener('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
     };
 

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -42,6 +42,15 @@ class AppStore extends EventEmitter {
     }
 
     getCustomEvents() {
+        // Note: remove this forEach loop after Spring 2022 ends
+        this.customEvents.forEach((customEvent) => {
+            if (customEvent.days.length === 5) {
+                customEvent.days = [false, ...customEvent.days, false];
+            } else if (customEvent.days.length === 6) {
+                customEvent.days = [...customEvent.days, false];
+            }
+        });
+
         return this.customEvents;
     }
 


### PR DESCRIPTION
## Summary
This adds a mapping between course code/ event id to the event emitters of color pickers, which should allow consistent and faster updating of the color pickers. This also fixes the colorpicker closing when click on it in the calendar.

## Test Plan
Tested all 3 color pickers in added courses, calendar, and search and they all update now.

## Issues
#263
#323 

## Future Followup (Optional)
I am not sure the best implementation for updating only the color pickers  as updating everything creates a lot of lag in the color picker. This was the most efficient I could think of, but it adds new emitters to AppStore.
