### PR TITLE
Genericize TermSelector

### DIFF
--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -13,15 +13,13 @@ import RightPaneStore from '../../stores/RightPaneStore';
 import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
 import { PostAdd } from '@material-ui/icons';
-import { termData } from '../../termData';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
+import TermSelector from '../SearchForm/TermSelector';
 
 const styles = {
-    input: {
-        'margin-top': '10px',
+    inputLabel: {
+        'font-size': '9px',
     },
 };
 
@@ -30,6 +28,10 @@ class ImportStudyList extends PureComponent {
         isOpen: false,
         selectedTerm: RightPaneStore.getFormData().term,
         studyListText: '',
+    };
+
+    onTermSelectorChange = (field, value) => {
+        this.setState({ [field]: value });
     };
 
     handleChange = (event) => {
@@ -135,32 +137,20 @@ class ImportStudyList extends PureComponent {
                             Study List once you've logged in. Copy everything below the column names (Code, Dept, etc.)
                             under the Enrolled Classes section.
                         </DialogContentText>
-                        <div className={classes.input}>
-                            <InputLabel>Study List</InputLabel>
-                            <TextField
-                                autoFocus
-                                fullWidth
-                                multiline
-                                margin="dense"
-                                type="text"
-                                placeholder="Paste here"
-                                value={this.state.studyListText}
-                                onChange={(event) => this.setState({ studyListText: event.target.value })}
-                            />
-                        </div>
+                        <InputLabel className={classes.inputLabel}>Study List</InputLabel>
+                        <TextField
+                            autoFocus
+                            fullWidth
+                            multiline
+                            margin="dense"
+                            type="text"
+                            placeholder="Paste here"
+                            value={this.state.studyListText}
+                            onChange={(event) => this.setState({ studyListText: event.target.value })}
+                        />
                         <br />
                         <DialogContentText>Make sure you also have the right term selected.</DialogContentText>
-                        {/* TODO refactor to use a modified TermSelector */}
-                        <div className={classes.input}>
-                            <InputLabel>Term</InputLabel>
-                            <Select value={this.state.selectedTerm} onChange={this.handleChange}>
-                                {termData.map((term, index) => (
-                                    <MenuItem key={index} value={term.shortName}>
-                                        {term.longName}
-                                    </MenuItem>
-                                ))}
-                            </Select>
-                        </div>
+                        <TermSelector changeState={this.onTermSelectorChange} fieldName={'selectedTerm'} />
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={() => this.handleClose(false)} color="primary">

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -8,7 +8,7 @@ import { Button } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import AdvancedSearch from './AdvancedSearch';
 import PrivacyPolicyBanner from '../App/PrivacyPolicyBanner';
-import { resetFormValues } from '../../actions/RightPaneActions';
+import { updateFormValue, resetFormValues } from '../../actions/RightPaneActions';
 
 const styles = {
     container: {
@@ -54,7 +54,7 @@ class SearchForm extends PureComponent {
             <form onSubmit={this.onFormSubmit}>
                 <div className={classes.container}>
                     <div className={classes.margin}>
-                        <TermSelector />
+                        <TermSelector changeState={updateFormValue} fieldName={'term'} />
                     </div>
 
                     <div className={classes.margin}>

--- a/src/components/SearchForm/TermSelector.js
+++ b/src/components/SearchForm/TermSelector.js
@@ -3,7 +3,6 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
-import { updateFormValue } from '../../actions/RightPaneActions';
 import RightPaneStore from '../../stores/RightPaneStore.js';
 import { termData } from '../../termData';
 
@@ -27,7 +26,7 @@ class TermSelector extends PureComponent {
 
     handleChange = (event) => {
         this.setState({ term: event.target.value });
-        updateFormValue('term', event.target.value);
+        this.props.changeState(this.props.fieldName, event.target.value);
     };
 
     render() {

--- a/src/components/SearchForm/TermSelector.js
+++ b/src/components/SearchForm/TermSelector.js
@@ -35,8 +35,10 @@ class TermSelector extends PureComponent {
             <FormControl fullWidth>
                 <InputLabel>Term</InputLabel>
                 <Select value={this.state.term} onChange={this.handleChange}>
-                    {termData.map((term) => (
-                        <MenuItem value={term.shortName}>{term.longName}</MenuItem>
+                    {termData.map((term, index) => (
+                        <MenuItem key={index} value={term.shortName}>
+                            {term.longName}
+                        </MenuItem>
                     ))}
                 </Select>
             </FormControl>


### PR DESCRIPTION
## Summary
Refactor `TermSelector` such that it takes two props, changeState and `fieldName`. `changeState` is a function that takes two arguments, a field and a value, and changes the state of the other component so that it matches its internal state. `fieldName` specifies the name of the field in the other component's state to change.

`ImportStudyList` has additionally been refactored to use this, instead of bringing in MUI props to roll our own `TermSelector`-alike component locally.
## Test Plan
The term dropdowns in the right pane and the Import window still work as they did prior to this change.

## Issues
Closes #309.
