### PR TITLE
Improved "different terms" warning triggers

### DIFF
--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -35,7 +35,7 @@ const arrayOfColors = [
     blueGrey[500],
 ];
 
-export const addCourse = (section, courseDetails, term, scheduleIndex, color) => {
+export const addCourse = (section, courseDetails, term, scheduleIndex, color, quiet) => {
     const addedCourses = AppStore.getAddedCourses();
     const terms = termsInSchedule(addedCourses, term, scheduleIndex);
     let existingCourse;
@@ -51,7 +51,7 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
         }
     }
 
-    if (terms.size > 1) warnMultipleTerms(terms);
+    if (terms.size > 1 && !quiet) warnMultipleTerms(terms);
 
     if (color === undefined) {
         const setOfUsedColors = new Set(addedCourses.map((course) => course.color));

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -42,7 +42,7 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
     let multipleTerms = new Set([term]);
 
     for (const course of addedCourses) {
-        multipleTerms.add(course.term);
+        if (course.scheduleIndices.includes(scheduleIndex)) multipleTerms.add(course.term);
 
         if (course.section.sectionCode === section.sectionCode && term === course.term) {
             existingCourse = course;

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -16,7 +16,7 @@ import {
     red,
     teal,
 } from '@material-ui/core/colors';
-import { getCoursesData } from '../helpers';
+import { getCoursesData, termsInSchedule, warnMultipleTerms } from '../helpers';
 import { LOAD_DATA_ENDPOINT, SAVE_DATA_ENDPOINT } from '../api/endpoints';
 
 const arrayOfColors = [
@@ -37,13 +37,10 @@ const arrayOfColors = [
 
 export const addCourse = (section, courseDetails, term, scheduleIndex, color) => {
     const addedCourses = AppStore.getAddedCourses();
-
+    const terms = termsInSchedule(addedCourses, term, scheduleIndex);
     let existingCourse;
-    let multipleTerms = new Set([term]);
 
     for (const course of addedCourses) {
-        if (course.scheduleIndices.includes(scheduleIndex)) multipleTerms.add(course.term);
-
         if (course.section.sectionCode === section.sectionCode && term === course.term) {
             existingCourse = course;
             if (course.scheduleIndices.includes(scheduleIndex)) {
@@ -54,16 +51,7 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
         }
     }
 
-    if (multipleTerms.size > 1)
-        openSnackbar(
-            'warning',
-            `Course added from different term.\nSchedule now contains courses from ${[...multipleTerms]
-                .sort()
-                .join(', ')}.`,
-            null,
-            null,
-            { whiteSpace: 'pre-line' }
-        );
+    if (terms.size > 1) warnMultipleTerms(terms);
 
     if (color === undefined) {
         const setOfUsedColors = new Set(addedCourses.map((course) => course.color));

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -152,6 +152,17 @@ export async function queryWebsocMultiple(params, fieldName) {
     return combineSOCObjects(responses);
 }
 
+export const addCoursesMultiple = (courseInfo, term, scheduleIndex) => {
+    let sectionsAdded = 0;
+    for (const section of Object.values(courseInfo)) {
+        addCourse(section.section, section.courseDetails, term, scheduleIndex, undefined, true);
+        ++sectionsAdded;
+    }
+    const terms = termsInSchedule(AppStore.getAddedCourses(), term, scheduleIndex);
+    if (terms.size > 1) warnMultipleTerms(terms);
+    return sectionsAdded;
+};
+
 export const termsInSchedule = (courses, term, scheduleIndex) =>
     new Set([
         term,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-import { openSnackbar } from './actions/AppStoreActions';
+import { addCourse, openSnackbar } from './actions/AppStoreActions';
 import { PETERPORTAL_WEBSOC_ENDPOINT, WEBSOC_ENDPOINT } from './api/endpoints';
 import AppStore from './stores/AppStore';
 
@@ -151,6 +151,22 @@ export async function queryWebsocMultiple(params, fieldName) {
     }
     return combineSOCObjects(responses);
 }
+
+export const termsInSchedule = (courses, term, scheduleIndex) =>
+    new Set([
+        term,
+        ...courses.filter((course) => course.scheduleIndices.includes(scheduleIndex)).map((course) => course.term),
+    ]);
+
+export const warnMultipleTerms = (terms) => {
+    openSnackbar(
+        'warning',
+        `Course added from different term.\nSchedule now contains courses from ${[...terms].sort().join(', ')}.`,
+        null,
+        null,
+        { whiteSpace: 'pre-line' }
+    );
+};
 
 export function clickToCopy(event, sectionCode) {
     event.stopPropagation();


### PR DESCRIPTION
## Summary
Refactored `addCourse` so that it would trigger the warning for different terms in the same schedule only when appropriate. Additionally, implemented a wrapper `addCoursesMultiple` that is used by `ImportStudyList`, which would suppress all warnings and trigger the warning once only if the user tried to import a Study List from a different term.

## Test Plan
1. Adding a class from one term to an empty schedule, when another schedule has classes from another term, no longer triggers the warning.
2. Clearing a schedule that had classes from one term, and then adding classes from another term, no longer triggers the warning. (NB: I could not reproduce this on `main`, but tested it here regardless to make sure I didn't accidentally introduce a regression.)
3. Importing a Study List from a different term into the current schedule triggers the warning only once.

## Issues
Closes #319.
