### PR TITLE
Add expiration to websoc cache

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -85,7 +85,8 @@ export async function queryWebsoc(params) {
     // Construct a request to PeterPortal with the params as a query string
     const url = new URL(PETERPORTAL_WEBSOC_ENDPOINT);
     const searchString = new URLSearchParams(params).toString();
-    if (websocCache[searchString]) {
+    if (websocCache[searchString]?.timestamp > Date.now() - 30 * 60 * 1000) {
+        //if cache hit and less than 30 minutes old
         return websocCache[searchString];
     }
     url.search = searchString;
@@ -101,6 +102,8 @@ export async function queryWebsoc(params) {
         }).then((res) => res.json());
         websocCache[searchString] = backupResponse;
         return backupResponse;
+    } finally {
+        websocCache[searchString].timestamp = Date.now();
     }
 }
 

--- a/src/stores/RightPaneStore.js
+++ b/src/stores/RightPaneStore.js
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
 import dispatcher from '../dispatcher';
-import { clearCache } from '../helpers';
 import { termData, defaultTerm } from '../termData';
 
 const defaultFormValues = {
@@ -55,7 +54,6 @@ class RightPaneStore extends EventEmitter {
                 this.emit('formReset');
                 break;
             case 'TOGGLE_SEARCH':
-                if (this.doDisplaySearch) clearCache();
                 this.doDisplaySearch = !this.doDisplaySearch;
                 // this.emit('searchToggle');
                 break;


### PR DESCRIPTION
## Summary
Before, the cache was cleared on every new search and when pressing refresh. Now, it isn't cleared on search and still is cleared by the fresh button, as well as after 30 minutes.
## Test Plan
I changed the expiration time to 5 seconds to see whether the expiration worked and it does, then changed it back to 30 minutes.
## Issues
Closes #318 