### PR TITLE
Add contributors to about modal

### DIFF
--- a/src/components/App/AboutPage.js
+++ b/src/components/App/AboutPage.js
@@ -30,13 +30,6 @@ class AboutPage extends PureComponent {
                             AntAlmanac is a schedule planning tool for UCI students.
                             <br />
                             <br />
-                            The website is maintained by the{' '}
-                            <Link target="_blank" href="https://studentcouncil.ics.uci.edu/">
-                                ICS Student Council
-                            </Link>{' '}
-                            Projects Committee.
-                            <br />
-                            <br />
                             Interested in helping out? Join our{' '}
                             <Link target="_blank" href="https://discord.gg/GzF76D7UhY">
                                 Discord
@@ -45,8 +38,23 @@ class AboutPage extends PureComponent {
                             <Link target="_blank" href="https://github.com/icssc/AntAlmanac">
                                 code on GitHub
                             </Link>
-                            .<br />
+                            .
                             <br />
+                            <br />
+                            This website is maintained by the{' '}
+                            <Link target="_blank" href="https://studentcouncil.ics.uci.edu/">
+                                ICS Student Council
+                            </Link>{' '}
+                            Projects Committee and built by students from the UCI community.
+                            <br />
+                            <br />
+                            <Link target="_blank" href="https://github.com/icssc/AntAlmanac/contributors">
+                                <img
+                                    src="https://contrib.rocks/image?repo=icssc/antalmanac"
+                                    width={'100%'}
+                                    alt="AntAlmanac Contributors"
+                                />
+                            </Link>
                         </DialogContentText>
                     </DialogContent>
                     <DialogActions>


### PR DESCRIPTION
## Summary
Added contributor github profile pics to the about modal. Clicking on the image redirects to AntAlmanac Contributor page. 
This uses https://contrib.rocks to dynamically generate the contributors image.

| Desktop | Mobile |
| --- | --- |
| <img width="618" alt="image" src="https://user-images.githubusercontent.com/29494270/163050723-217abbb1-d092-43c7-9049-3028be511733.png"> | <img width="427" alt="image" src="https://user-images.githubusercontent.com/29494270/163050849-fc8bb731-0b08-4b98-96af-433be50407f2.png"> |


## Test Plan
- Open the the About Modal on desktop and mobile.
- Verify that the contributors icons show up
- Verify that clicking on the contributors image takes the user to the Contributor graph 