### PR TITLE
Hide LegacySearch 

### DIFF
--- a/src/components/App/PrivacyPolicyBanner.js
+++ b/src/components/App/PrivacyPolicyBanner.js
@@ -5,7 +5,8 @@ import { withStyles } from '@material-ui/core';
 const styles = {
     container: {
         padding: 12,
-        marginTop: '10%',
+        marginBottom: '10px',
+        marginRight: '5px',
     },
 };
 

--- a/src/components/SearchForm/LegacySearch.js
+++ b/src/components/SearchForm/LegacySearch.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import DeptSearchBar from './DeptSearchBar/DeptSearchBar';
+import GESelector from './GESelector';
+import SectionCodeSearchBar from './SectionCodeSearchBar';
+import CourseNumberSearchBar from './CourseNumberSearchBar';
+import { Button, Collapse, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import AdvancedSearch from './AdvancedSearch';
+import { ExpandLess, ExpandMore } from '@material-ui/icons';
+
+const styles = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+    },
+    collapse: {
+        display: 'inline-flex',
+        cursor: 'pointer',
+        marginTop: 20,
+        marginBotton: 10,
+    },
+    search: {
+        display: 'flex',
+        justifyContent: 'center',
+        borderTop: 'solid 8px transparent',
+    },
+    margin: {
+        borderTop: 'solid 8px transparent',
+        display: 'inline-flex',
+        width: '100%',
+    },
+    new: {
+        width: '55%',
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+    },
+    searchButton: {
+        width: '50%',
+    },
+    buttonContainer: {
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'space-evenly',
+    },
+};
+
+function LegacySearch({ classes, onSubmit, onReset }) {
+    const [expandLegacy, setExpandLegacy] = useState(false);
+
+    const handleExpand = () => {
+        setExpandLegacy(!expandLegacy);
+    };
+
+    return (
+        <>
+            <div onClick={handleExpand} className={classes.collapse}>
+                <Typography noWrap variant="body1">
+                    Legacy Search
+                </Typography>
+                {expandLegacy ? <ExpandLess /> : <ExpandMore />}
+            </div>
+            <Collapse in={expandLegacy}>
+                <div className={classes.margin}>
+                    <DeptSearchBar />
+                    <CourseNumberSearchBar />
+                </div>
+
+                <div className={classes.margin}>
+                    <GESelector />
+                    <SectionCodeSearchBar />
+                </div>
+
+                <AdvancedSearch />
+
+                <div className={classes.search}>
+                    <div className={classes.buttonContainer}>
+                        <Button
+                            className={classes.searchButton}
+                            color="primary"
+                            variant="contained"
+                            onClick={onSubmit}
+                            type="submit"
+                        >
+                            Search
+                        </Button>
+
+                        <Button variant="contained" onClick={onReset}>
+                            Reset
+                        </Button>
+                    </div>
+                </div>
+            </Collapse>
+        </>
+    );
+}
+
+export default withStyles(styles)(LegacySearch);

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -1,15 +1,10 @@
-import DeptSearchBar from './DeptSearchBar/DeptSearchBar';
-import GESelector from './GESelector';
-import TermSelector from './TermSelector';
-import SectionCodeSearchBar from './SectionCodeSearchBar';
-import CourseNumberSearchBar from './CourseNumberSearchBar';
 import React, { PureComponent } from 'react';
-import { Button } from '@material-ui/core';
+import TermSelector from './TermSelector';
 import { withStyles } from '@material-ui/core/styles';
-import AdvancedSearch from './AdvancedSearch';
 import PrivacyPolicyBanner from '../App/PrivacyPolicyBanner';
 import { updateFormValue, resetFormValues } from '../../actions/RightPaneActions';
 import FuzzySearch from './FuzzySearch';
+import LegacySearch from './LegacySearch';
 
 const styles = {
     container: {
@@ -17,28 +12,9 @@ const styles = {
         flexDirection: 'column',
         position: 'relative',
     },
-    search: {
-        display: 'flex',
-        justifyContent: 'center',
-        borderTop: 'solid 8px transparent',
-    },
     margin: {
         borderTop: 'solid 8px transparent',
         display: 'inline-flex',
-    },
-    new: {
-        width: '55%',
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-    },
-    searchButton: {
-        width: '50%',
-    },
-    buttonContainer: {
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'space-evenly',
     },
 };
 
@@ -52,48 +28,21 @@ class SearchForm extends PureComponent {
         const { classes } = this.props;
 
         return (
-            <>
-                <FuzzySearch toggleSearch={this.props.toggleSearch} />
-                <form onSubmit={this.onFormSubmit}>
-                    <div className={classes.container}>
-                        <div className={classes.margin}>
-                            <TermSelector changeState={updateFormValue} fieldName={'term'} />
-                        </div>
-
-                        <div className={classes.margin}>
-                            <DeptSearchBar />
-                            <CourseNumberSearchBar />
-                        </div>
-
-                        <div className={classes.margin}>
-                            <GESelector />
-                            <SectionCodeSearchBar />
-                        </div>
-
-                        <AdvancedSearch />
-
-                        <div className={classes.search}>
-                            <div className={classes.buttonContainer}>
-                                <Button
-                                    className={classes.searchButton}
-                                    color="primary"
-                                    variant="contained"
-                                    onClick={() => this.props.toggleSearch()}
-                                    type="submit"
-                                >
-                                    Search
-                                </Button>
-
-                                <Button variant="contained" onClick={resetFormValues}>
-                                    Reset
-                                </Button>
-                            </div>
-                        </div>
-
-                        <PrivacyPolicyBanner />
+            <form onSubmit={this.onFormSubmit}>
+                <div className={classes.container}>
+                    <div className={classes.margin}>
+                        <TermSelector changeState={updateFormValue} fieldName={'term'} />
                     </div>
-                </form>
-            </>
+
+                    <div className={classes.container}>
+                        <FuzzySearch toggleSearch={this.props.toggleSearch} />
+                    </div>
+
+                    <LegacySearch onSubmit={() => this.props.toggleSearch()} onReset={resetFormValues} />
+
+                    <PrivacyPolicyBanner />
+                </div>
+            </form>
         );
     }
 }

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -16,6 +16,10 @@ const styles = {
         borderTop: 'solid 8px transparent',
         display: 'inline-flex',
     },
+    form: {
+        minHeight: 'calc(100% - 120px)',
+        marginBottom: '20px',
+    },
 };
 
 class SearchForm extends PureComponent {
@@ -28,21 +32,22 @@ class SearchForm extends PureComponent {
         const { classes } = this.props;
 
         return (
-            <form onSubmit={this.onFormSubmit}>
-                <div className={classes.container}>
-                    <div className={classes.margin}>
-                        <TermSelector changeState={updateFormValue} fieldName={'term'} />
-                    </div>
-
+            <>
+                <form onSubmit={this.onFormSubmit} className={classes.form}>
                     <div className={classes.container}>
-                        <FuzzySearch toggleSearch={this.props.toggleSearch} />
+                        <div className={classes.margin}>
+                            <TermSelector changeState={updateFormValue} fieldName={'term'} />
+                        </div>
+
+                        <div className={classes.container}>
+                            <FuzzySearch toggleSearch={this.props.toggleSearch} />
+                        </div>
+
+                        <LegacySearch onSubmit={() => this.props.toggleSearch()} onReset={resetFormValues} />
                     </div>
-
-                    <LegacySearch onSubmit={() => this.props.toggleSearch()} onReset={resetFormValues} />
-
-                    <PrivacyPolicyBanner />
-                </div>
-            </form>
+                </form>
+                <PrivacyPolicyBanner />
+            </>
         );
     }
 }


### PR DESCRIPTION
## Summary
- Move old search to LegacySearch component
- Move term to top
- Move fuzzy inside of form

| Mobile | Desktop |
| --- | --- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/29494270/163501254-a1cede18-cba4-4cc0-8e05-6d69830be64c.png"> | ![image](https://user-images.githubusercontent.com/29494270/163501293-5ee52560-7c03-43cf-a7b9-23742ba0de83.png) |
| <img width="401" alt="image" src="https://user-images.githubusercontent.com/29494270/163501278-5ce15e59-c4c4-45ed-8bbf-6383af7d560b.png"> | ![image](https://user-images.githubusercontent.com/29494270/163501335-363d12d9-8592-4327-ae35-d9456ac0f371.png) |

## Test Plan
- Tested locally for mobile and desktop

## Future Followup
"Legacy Search" dropdown looks kinda ugly. Maybe there's more we can do there.
