### PR TITLE
LegacySearch moved under options dropdown

### DIFF
--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -128,6 +128,7 @@ class FuzzySearch extends PureComponent {
     render() {
         return (
             <Autocomplete
+                style={{ width: '100%' }}
                 options={Object.keys(this.state.results)}
                 renderInput={(params) => <TextField {...params} fullWidth label={'Search'} />}
                 filterOptions={this.filterOptions}

--- a/src/components/SearchForm/LegacySearch.js
+++ b/src/components/SearchForm/LegacySearch.js
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import DeptSearchBar from './DeptSearchBar/DeptSearchBar';
 import GESelector from './GESelector';
 import SectionCodeSearchBar from './SectionCodeSearchBar';
 import CourseNumberSearchBar from './CourseNumberSearchBar';
-import { Button, Collapse, Typography } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import AdvancedSearch from './AdvancedSearch';
-import { ExpandLess, ExpandMore } from '@material-ui/icons';
 
 const styles = {
     container: {
@@ -47,51 +46,37 @@ const styles = {
 };
 
 function LegacySearch({ classes, onSubmit, onReset }) {
-    const [expandLegacy, setExpandLegacy] = useState(false);
-
-    const handleExpand = () => {
-        setExpandLegacy(!expandLegacy);
-    };
-
     return (
         <>
-            <div onClick={handleExpand} className={classes.collapse}>
-                <Typography noWrap variant="body1">
-                    Legacy Search
-                </Typography>
-                {expandLegacy ? <ExpandLess /> : <ExpandMore />}
+            <div className={classes.margin}>
+                <DeptSearchBar />
+                <CourseNumberSearchBar />
             </div>
-            <Collapse in={expandLegacy}>
-                <div className={classes.margin}>
-                    <DeptSearchBar />
-                    <CourseNumberSearchBar />
+
+            <div className={classes.margin}>
+                <GESelector />
+                <SectionCodeSearchBar />
+            </div>
+
+            <AdvancedSearch />
+
+            <div className={classes.search}>
+                <div className={classes.buttonContainer}>
+                    <Button
+                        className={classes.searchButton}
+                        color="primary"
+                        variant="contained"
+                        onClick={onSubmit}
+                        type="submit"
+                    >
+                        Search
+                    </Button>
+
+                    <Button variant="contained" onClick={onReset}>
+                        Reset
+                    </Button>
                 </div>
-
-                <div className={classes.margin}>
-                    <GESelector />
-                    <SectionCodeSearchBar />
-                </div>
-
-                <AdvancedSearch />
-
-                <div className={classes.search}>
-                    <div className={classes.buttonContainer}>
-                        <Button
-                            className={classes.searchButton}
-                            color="primary"
-                            variant="contained"
-                            onClick={onSubmit}
-                            type="submit"
-                        >
-                            Search
-                        </Button>
-
-                        <Button variant="contained" onClick={onReset}>
-                            Reset
-                        </Button>
-                    </div>
-                </div>
-            </Collapse>
+            </div>
         </>
     );
 }

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -1,16 +1,23 @@
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 import TermSelector from './TermSelector';
 import { withStyles } from '@material-ui/core/styles';
 import PrivacyPolicyBanner from '../App/PrivacyPolicyBanner';
 import { updateFormValue, resetFormValues } from '../../actions/RightPaneActions';
 import FuzzySearch from './FuzzySearch';
 import LegacySearch from './LegacySearch';
+import { IconButton, Tooltip } from '@material-ui/core';
+import { Tune } from '@material-ui/icons';
 
 const styles = {
     container: {
         display: 'flex',
         flexDirection: 'column',
         position: 'relative',
+    },
+    searchBar: {
+        display: 'flex',
+        flexDirection: 'row',
+        marginTop: '1rem',
     },
     margin: {
         borderTop: 'solid 8px transparent',
@@ -22,34 +29,45 @@ const styles = {
     },
 };
 
-class SearchForm extends PureComponent {
-    onFormSubmit = (event) => {
-        event.preventDefault();
-        this.props.toggleSearch();
+const SearchForm = (props) => {
+    const { classes, toggleSearch } = props;
+
+    const [showLegacySearch, setShowLegacySearch] = useState(false);
+
+    const toggleShowLegacySearch = () => {
+        setShowLegacySearch(!showLegacySearch);
     };
 
-    render() {
-        const { classes } = this.props;
+    const onFormSubmit = (event) => {
+        event.preventDefault();
+        toggleSearch();
+    };
 
-        return (
-            <>
-                <form onSubmit={this.onFormSubmit} className={classes.form}>
-                    <div className={classes.container}>
-                        <div className={classes.margin}>
-                            <TermSelector changeState={updateFormValue} fieldName={'term'} />
-                        </div>
-
-                        <div className={classes.container}>
-                            <FuzzySearch toggleSearch={this.props.toggleSearch} />
-                        </div>
-
-                        <LegacySearch onSubmit={() => this.props.toggleSearch()} onReset={resetFormValues} />
+    return (
+        <>
+            <form onSubmit={onFormSubmit} className={classes.form}>
+                <div className={classes.container}>
+                    <div className={classes.margin}>
+                        <TermSelector changeState={updateFormValue} fieldName={'term'} />
                     </div>
-                </form>
-                <PrivacyPolicyBanner />
-            </>
-        );
-    }
-}
+
+                    <div className={classes.container}>
+                        <div className={classes.searchBar}>
+                            <FuzzySearch toggleSearch={toggleSearch} toggleShowLegacySearch={toggleShowLegacySearch} />
+                            <Tooltip title="Manual Search">
+                                <IconButton onClick={toggleShowLegacySearch}>
+                                    <Tune />
+                                </IconButton>
+                            </Tooltip>
+                        </div>
+                    </div>
+
+                    {showLegacySearch && <LegacySearch onSubmit={() => toggleSearch()} onReset={resetFormValues} />}
+                </div>
+            </form>
+            <PrivacyPolicyBanner />
+        </>
+    );
+};
 
 export default withStyles(styles)(SearchForm);


### PR DESCRIPTION
## Summary
- LegacySearch is now nicely hidden under a 'Manual Options' button
- Converted SearchForm to functional component
![toggle-search](https://user-images.githubusercontent.com/29494270/163706153-d745c937-bc12-4798-819f-a56d5df31ff3.gif)

## Test Plan
Tested options toggle on mobile and desktop