### PR TITLE
Staging actions

### DIFF
--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -1,32 +1,53 @@
 name: "Pull Request Clean Up"
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: main
     types: [unlabeled, closed]
 
+permissions:
+  id-token: write
+  contents: read
+  deployments: write
+
 jobs:
   clean-up:
     if: |
-      (github.event.action == 'unlabeled' && github.event.label.name == ':rocket: deploy') ||
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-latest
+    env: # env variables for Node.js
+      HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
+      CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+
     steps:
       - name: inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: set STAGE variable in environment for next steps
-        run: echo "STAGE=pr-${{ github.event.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
+        run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          
       - name: checkout antalmanac-cdk
         uses: actions/checkout@v3
         with:
-          repository: icssc/antalmanc-cdk
+          repository: icssc/antalmanac-cdk
           ref: dev # CHANGE TO MAIN WHEN CDK REPO IS UPDATED
         
+      - name: checkout antalmanac
+        uses: actions/checkout@v3
+        with:
+          path: functions/AntAlmanac
+      
       - name: install node dependencies cdk
         uses: bahmutov/npm-install@v1
+
+      - name: make empty folder # so cdk doesn't complain
+        run: mkdir functions/AntAlmanac/build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@master
@@ -35,7 +56,7 @@ jobs:
           aws-region: us-east-1
 
       - name: destroy the stack on AWS
-        run: cdk destroy github-actions-stack-${{ github.event.issue.number }}
+        run: npx cdk destroy github-actions-stack-${{ github.event.pull_request.number }} --force
 
       - name: delete the github deployments and the corresponding environment
         uses: strumwolf/delete-deployment-environment@v1.1.0

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -1,0 +1,43 @@
+name: "Pull Request Clean Up"
+
+on:
+  pull_request:
+    types: [unlabeled, closed]
+
+jobs:
+  clean-up:
+    if: |
+      (github.event.action == 'unlabeled' && github.event.label.name == ':rocket: deploy') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+
+      - name: set STAGE variable in environment for next steps
+        run: echo "STAGE=pr-${{ github.event.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
+
+      - name: checkout antalmanac-cdk
+        uses: actions/checkout@v3
+        with:
+          repository: icssc/antalmanc-cdk
+          ref: dev # CHANGE TO MAIN WHEN CDK REPO IS UPDATED
+        
+      - name: install node dependencies cdk
+        uses: bahmutov/npm-install@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
+          aws-region: us-east-1
+
+      - name: destroy the stack on AWS
+        run: cdk destroy github-actions-stack-${{ github.event.issue.number }}
+
+      - name: delete the github deployments and the corresponding environment
+        uses: strumwolf/delete-deployment-environment@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: ${{ env.STAGE }}
+      

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -1,6 +1,7 @@
 name: "Pull Request Clean Up"
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [unlabeled, closed]
 

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -3,6 +3,7 @@ name: "Pull Request Clean Up"
 on:
   workflow_dispatch:
   pull_request:
+    branches: main
     types: [unlabeled, closed]
 
 jobs:

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -1,6 +1,7 @@
 name: "Deploy Pull Request"
 
 on: 
+  workflow_dispatch:
   pull_request:
     types: [labeled, opened, synchronize]
 

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -1,0 +1,77 @@
+name: "Deploy Pull Request"
+
+on: 
+  pull_request:
+    types: [labeled, opened, synchronize]
+
+jobs:
+  deploy:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == ':rocket: deploy') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+    runs-on: ubuntu-latest
+    env: # env variables for Node.js
+      HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
+      CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
+      PR_NUM: ${{ github.event.issue.number }}
+      NODE_ENV: development # to change endpoint to dev
+
+    steps: 
+      - name: set STAGE variable in environment for next steps
+        run: echo "STAGE=pr-${{ github.event.issue.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
+
+      - name: create a github deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.STAGE }}
+          ref: ${{ github.head_ref }}
+          no_override: false
+          transient: true
+      
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          
+      - name: checkout antalmanac-cdk
+        uses: actions/checkout@v3
+        with:
+          repository: icssc/antalmanc-cdk
+          ref: dev # CHANGE TO MAIN WHEN CDK REPO IS UPDATED
+        
+      - name: checkout antalmanac
+        uses: actions/checkout@v3
+        with:
+          path: functions
+      
+      - name: install node dependencies cdk
+        uses: bahmutov/npm-install@v1
+
+      - name: install node dependencies frontend
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: functions/AntAlmanac
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
+          aws-region: us-east-1
+      
+      - name: build CDK
+        run: npm run build
+
+      - name: deploy the stack to AWS
+        run: npx cdk deploy github-actions-stack-${{ github.event.issue.number }}
+
+      - name: update the github deployment status
+        uses: bobheadxi/deployments@v0.5.2
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: https://${{ github.event.issue.number }}.staging.antalmanac.com

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -62,6 +62,9 @@ jobs:
       
       - name: build CDK
         run: npm run build
+        
+      - name: build frontend
+        run: npm run build-client
 
       - name: deploy the stack to AWS
         run: npx cdk deploy github-actions-stack-${{ github.event.issue.number }}

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -1,26 +1,32 @@
 name: "Deploy Pull Request"
 
 on: 
-  workflow_dispatch:
   pull_request:
     branches: main
     types: [labeled, opened, synchronize]
 
+permissions:
+  id-token: write
+  contents: read
+  deployments: write
+
 jobs:
   deploy:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == ':rocket: deploy') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-latest
     env: # env variables for Node.js
       HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
       CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
-      PR_NUM: ${{ github.event.issue.number }}
-      NODE_ENV: development # to change endpoint to dev
+      PR_NUM: ${{ github.event.pull_request.number }}
 
     steps: 
+      - name: inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+
       - name: set STAGE variable in environment for next steps
-        run: echo "STAGE=pr-${{ github.event.issue.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
+        run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
       - name: create a github deployment
         uses: bobheadxi/deployments@v1
@@ -30,8 +36,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ env.STAGE }}
           ref: ${{ github.head_ref }}
-          no_override: false
-          transient: true
       
       - uses: actions/setup-node@v2
         with:
@@ -40,13 +44,13 @@ jobs:
       - name: checkout antalmanac-cdk
         uses: actions/checkout@v3
         with:
-          repository: icssc/antalmanc-cdk
+          repository: icssc/antalmanac-cdk
           ref: dev # CHANGE TO MAIN WHEN CDK REPO IS UPDATED
         
       - name: checkout antalmanac
         uses: actions/checkout@v3
         with:
-          path: functions
+          path: functions/AntAlmanac
       
       - name: install node dependencies cdk
         uses: bahmutov/npm-install@v1
@@ -62,14 +66,14 @@ jobs:
           role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
           aws-region: us-east-1
       
+      - name: build frontend
+        run: REACT_APP_STAGING=true SKIP_PREFLIGHT_CHECK=true npm run build-client
+
       - name: build CDK
         run: npm run build
-        
-      - name: build frontend
-        run: npm run build-client
 
       - name: deploy the stack to AWS
-        run: npx cdk deploy github-actions-stack-${{ github.event.issue.number }}
+        run: npx cdk deploy github-actions-stack-${{ github.event.pull_request.number }} --require-approval never
 
       - name: update the github deployment status
         uses: bobheadxi/deployments@v0.5.2
@@ -79,4 +83,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://${{ github.event.issue.number }}.staging.antalmanac.com
+          env_url: https://${{ github.event.pull_request.number }}.antalmanac.com

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -3,6 +3,7 @@ name: "Deploy Pull Request"
 on: 
   workflow_dispatch:
   pull_request:
+    branches: main
     types: [labeled, opened, synchronize]
 
 jobs:

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -83,4 +83,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://${{ github.event.pull_request.number }}.antalmanac.com
+          env_url: https://staging-${{ github.event.pull_request.number }}.antalmanac.com

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -1,7 +1,7 @@
 function endpointTransform(path) {
     if (process.env.NODE_ENV === 'development' || process.env.REACT_APP_STAGING === 'true')
         return `https://dev.api.antalmanac.com${path}`;
-    else return `https://dev.api.antalmanac.com${path}`;
+    else return `https://api.antalmanac.com${path}`;
 }
 
 export const WEBSOC_ENDPOINT = endpointTransform('/api/websocapi');

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -1,6 +1,7 @@
 function endpointTransform(path) {
-    if (process.env.NODE_ENV === 'development') return `https://dev.api.antalmanac.com${path}`;
-    else return `https://api.antalmanac.com${path}`;
+    if (process.env.NODE_ENV === 'development' || process.env.REACT_APP_STAGING === 'true')
+        return `https://dev.api.antalmanac.com${path}`;
+    else return `https://dev.api.antalmanac.com${path}`;
 }
 
 export const WEBSOC_ENDPOINT = endpointTransform('/api/websocapi');


### PR DESCRIPTION
## Summary
Add Github Action that deploys a copy of the pull request to AWS. The action is triggered by pull requests with the `deploy` label and should update on changes to the PR. Heavily references https://github.com/jgoux/preview-environments-per-pull-request-using-aws-cdk-and-github-actions .

This action deploys:
- S3 bucket to store site
- Cloudfront distribution and corresponding record to redirect URL (`staging-pr_num.antalmanac.com`) to S3 bucket

The dev backend is used in the deployment.

The URL can be easily accessed by clicking `pr-xxx-staging-actions`
![image](https://user-images.githubusercontent.com/53128285/163734504-b2984dbb-bd98-45bf-a539-82514d9cfd2b.png)


## Test Plan
https://github.com/icssc/AntAlmanac/pull/347 for the full struggle, otherwise just check this PR.

## Issues

## Future Followup (Optional)