### PR TITLE
Add schedules with their own names

### DIFF
--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -37,8 +37,7 @@ const arrayOfColors = [
 
 export const addCourse = (section, courseDetails, term, scheduleIndex, color) => {
     const addedCourses = AppStore.getAddedCourses();
-    const scheduleNames = AppStore.getScheduleNames();
-
+    const terms = termsInSchedule(addedCourses, term, scheduleIndex);
     let existingCourse;
     let multipleTerms = new Set([term]);
 
@@ -77,6 +76,7 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
         if (color === undefined) color = '#5ec8e0';
     }
 
+    const scheduleNames = AppStore.getScheduleNames();
     if (existingCourse === undefined) {
         const newCourse = {
             color: color,

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -37,7 +37,7 @@ const arrayOfColors = [
 
 export const addCourse = (section, courseDetails, term, scheduleIndex, color) => {
     const addedCourses = AppStore.getAddedCourses();
-    const terms = termsInSchedule(addedCourses, term, scheduleIndex);
+
     let existingCourse;
     let multipleTerms = new Set([term]);
 

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -349,10 +349,12 @@ export const changeCourseColor = (sectionCode, newColor, term) => {
 export const copySchedule = (from, to) => {
     const addedCourses = AppStore.getAddedCourses();
     const customEvents = AppStore.getCustomEvents();
+    const scheduleNames = AppStore.getScheduleNames();
 
     const addedCoursesAfterCopy = addedCourses.map((addedCourse) => {
         if (addedCourse.scheduleIndices.includes(from) && !addedCourse.scheduleIndices.includes(to)) {
-            if (to === 4) return { ...addedCourse, scheduleIndices: [0, 1, 2, 3] };
+            if (to === scheduleNames.length)
+                return { ...addedCourse, scheduleIndices: scheduleNames.map((_, index) => index) };
             else
                 return {
                     ...addedCourse,
@@ -365,7 +367,8 @@ export const copySchedule = (from, to) => {
 
     const customEventsAfterCopy = customEvents.map((customEvent) => {
         if (customEvent.scheduleIndices.includes(from) && !customEvent.scheduleIndices.includes(to)) {
-            if (to === 4) return { ...customEvent, scheduleIndices: [0, 1, 2, 3] };
+            if (to === scheduleNames.length)
+                return { ...customEvent, scheduleIndices: scheduleNames.map((_, index) => index) };
             else
                 return {
                     ...customEvent,

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -398,3 +398,10 @@ export const toggleTheme = (radioGroupEvent) => {
         action: 'toggle theme',
     });
 };
+
+export const addSchedule = (scheduleName) => {
+    dispatcher.dispatch({
+        type: 'ADD_SCHEDULE',
+        scheduleName,
+    });
+};

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -400,8 +400,10 @@ export const toggleTheme = (radioGroupEvent) => {
 };
 
 export const addSchedule = (scheduleName) => {
+    const newScheduleNames = [...AppStore.getScheduleNames(), scheduleName];
+
     dispatcher.dispatch({
         type: 'ADD_SCHEDULE',
-        scheduleName,
+        newScheduleNames,
     });
 };

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -37,6 +37,7 @@ const arrayOfColors = [
 
 export const addCourse = (section, courseDetails, term, scheduleIndex, color) => {
     const addedCourses = AppStore.getAddedCourses();
+    const scheduleNames = AppStore.getScheduleNames();
 
     let existingCourse;
     let multipleTerms = new Set([term]);
@@ -85,14 +86,18 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
             courseTitle: courseDetails.courseTitle,
             courseComment: courseDetails.courseComment,
             prerequisiteLink: courseDetails.prerequisiteLink,
-            scheduleIndices: [scheduleIndex],
+            scheduleIndices:
+                scheduleIndex === scheduleNames.length ? scheduleNames.map((_, index) => index) : [scheduleIndex],
             section: section,
         };
         dispatcher.dispatch({ type: 'ADD_COURSE', newCourse });
     } else {
         const newSection = {
             ...existingCourse,
-            scheduleIndices: existingCourse.scheduleIndices.concat(scheduleIndex),
+            scheduleIndices:
+                scheduleIndex === scheduleNames.length
+                    ? scheduleNames.map((_, index) => index)
+                    : existingCourse.scheduleIndices.concat(scheduleIndex),
         };
         dispatcher.dispatch({ type: 'ADD_SECTION', newSection });
     }
@@ -353,6 +358,9 @@ export const copySchedule = (from, to) => {
 
     const addedCoursesAfterCopy = addedCourses.map((addedCourse) => {
         if (addedCourse.scheduleIndices.includes(from) && !addedCourse.scheduleIndices.includes(to)) {
+            // If to is equal to the length of scheduleNames, then the user wanted to copy to
+            // all schedules; otherwise, if to is less than the length of scheduleNames, then
+            // only one schedule should be altered
             if (to === scheduleNames.length)
                 return { ...addedCourse, scheduleIndices: scheduleNames.map((_, index) => index) };
             else

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -85,14 +85,14 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
             courseTitle: courseDetails.courseTitle,
             courseComment: courseDetails.courseComment,
             prerequisiteLink: courseDetails.prerequisiteLink,
-            scheduleIndices: scheduleIndex === 4 ? [0, 1, 2, 3] : [scheduleIndex],
+            scheduleIndices: [scheduleIndex],
             section: section,
         };
         dispatcher.dispatch({ type: 'ADD_COURSE', newCourse });
     } else {
         const newSection = {
             ...existingCourse,
-            scheduleIndices: scheduleIndex === 4 ? [0, 1, 2, 3] : existingCourse.scheduleIndices.concat(scheduleIndex),
+            scheduleIndices: existingCourse.scheduleIndices.concat(scheduleIndex),
         };
         dispatcher.dispatch({ type: 'ADD_SECTION', newSection });
     }

--- a/src/components/AddedCourses/AddedCoursePane.js
+++ b/src/components/AddedCourses/AddedCoursePane.js
@@ -32,6 +32,7 @@ class AddedCoursePane extends PureComponent {
         courses: [],
         customEvents: [],
         totalUnits: 0,
+        scheduleNames: AppStore.getScheduleNames(),
     };
 
     componentDidMount = () => {
@@ -41,6 +42,7 @@ class AddedCoursePane extends PureComponent {
         AppStore.on('customEventsChange', this.loadCustomEvents);
         AppStore.on('currentScheduleIndexChange', this.loadCourses);
         AppStore.on('currentScheduleIndexChange', this.loadCustomEvents);
+        AppStore.on('scheduleNamesChange', this.loadScheduleNames);
     };
 
     componentWillUnmount() {
@@ -48,6 +50,7 @@ class AddedCoursePane extends PureComponent {
         AppStore.removeListener('customEventsChange', this.loadCustomEvents);
         AppStore.removeListener('currentScheduleIndexChange', this.loadCourses);
         AppStore.removeListener('currentScheduleIndexChange', this.loadCustomEvents);
+        AppStore.removeListener('scheduleNamesChange', this.loadScheduleNames);
     }
 
     loadCourses = () => {
@@ -101,12 +104,18 @@ class AddedCoursePane extends PureComponent {
         this.setState({ customEvents: AppStore.getCustomEvents() });
     };
 
+    loadScheduleNames = () => {
+        this.setState({ scheduleNames: AppStore.getScheduleNames() });
+    };
+
     getGrid = () => {
         return (
             <>
                 <div className={this.props.classes.titleRow}>
                     <Typography variant="h6">
-                        {`Schedule ${AppStore.getCurrentScheduleIndex() + 1} (${this.state.totalUnits} Units)`}
+                        {`${this.state.scheduleNames[AppStore.getCurrentScheduleIndex()]} (${
+                            this.state.totalUnits
+                        } Units)`}
                     </Typography>
 
                     <div>
@@ -181,6 +190,7 @@ class AddedCoursePane extends PureComponent {
                                 <CustomEventDetailView
                                     customEvent={customEvent}
                                     currentScheduleIndex={AppStore.getCurrentScheduleIndex()}
+                                    scheduleNames={this.state.scheduleNames}
                                 />
                             </Grid>
                         );

--- a/src/components/AddedCourses/AddedCoursePane.js
+++ b/src/components/AddedCourses/AddedCoursePane.js
@@ -126,7 +126,7 @@ class AddedCoursePane extends PureComponent {
                                         Copy Schedule
                                     </Button>
                                     <Menu {...bindMenu(popupState)}>
-                                        {[0, 1, 2, 3].map((index) => {
+                                        {this.state.scheduleNames.map((name, index) => {
                                             return (
                                                 <MenuItem
                                                     key={index}
@@ -136,13 +136,16 @@ class AddedCoursePane extends PureComponent {
                                                         popupState.close();
                                                     }}
                                                 >
-                                                    Copy to Schedule {index + 1}
+                                                    Copy to {name}
                                                 </MenuItem>
                                             );
                                         })}
                                         <MenuItem
                                             onClick={() => {
-                                                copySchedule(AppStore.getCurrentScheduleIndex(), 4);
+                                                copySchedule(
+                                                    AppStore.getCurrentScheduleIndex(),
+                                                    this.state.scheduleNames.length
+                                                );
                                                 popupState.close();
                                             }}
                                         >

--- a/src/components/AddedCourses/AddedCoursePane.js
+++ b/src/components/AddedCourses/AddedCoursePane.js
@@ -109,14 +109,13 @@ class AddedCoursePane extends PureComponent {
     };
 
     getGrid = () => {
+        const scheduleName = this.state.scheduleNames[AppStore.getCurrentScheduleIndex()];
+        const scheduleUnits = this.state.totalUnits;
+
         return (
             <>
                 <div className={this.props.classes.titleRow}>
-                    <Typography variant="h6">
-                        {`${this.state.scheduleNames[AppStore.getCurrentScheduleIndex()]} (${
-                            this.state.totalUnits
-                        } Units)`}
-                    </Typography>
+                    <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
 
                     <div>
                         <PopupState variant="popover">

--- a/src/components/AddedCourses/CustomEventDetailView.js
+++ b/src/components/AddedCourses/CustomEventDetailView.js
@@ -71,7 +71,7 @@ const CustomEventDetailView = (props) => {
                 >
                     <Delete fontSize="small" />
                 </IconButton>
-                <CustomEventDialog customEvent={customEvent} />
+                <CustomEventDialog customEvent={customEvent} scheduleNames={props.scheduleNames} />
             </CardActions>
         </Card>
     );

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -64,14 +64,6 @@ class AddScheduleDialog extends PureComponent {
                                 label="Name"
                                 placeholder="Schedule 2"
                                 onChange={this.handleNameChange}
-                                required
-                            />
-                            <TextField
-                                className={this.props.classes.textField}
-                                label="Notes"
-                                placeholder="An optional space to record thoughts about this schedule"
-                                maxRows={5}
-                                multiline
                             />
                         </FormControl>
                     </DialogContent>

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -26,6 +26,7 @@ const styles = () => ({
 class AddScheduleDialog extends PureComponent {
     state = {
         isOpen: false,
+        scheduleName: '',
     };
 
     handleOpen = () => {
@@ -36,7 +37,14 @@ class AddScheduleDialog extends PureComponent {
         this.setState({ isOpen: false });
     };
 
-    handleAdd = () => {};
+    handleNameChange = (event) => {
+        this.setState({ scheduleName: event.target.value });
+    };
+
+    handleAdd = () => {
+        this.props.onNameChange(this.state.scheduleName);
+        this.setState({ isOpen: false });
+    };
 
     render() {
         return (
@@ -49,11 +57,12 @@ class AddScheduleDialog extends PureComponent {
                 <Dialog open={this.state.isOpen} fullWidth>
                     <DialogTitle>Add a New Schedule</DialogTitle>
                     <DialogContent>
-                        <FormControl className={this.props.classes.formContainer} fullWidth>
+                        <FormControl fullWidth>
                             <TextField
                                 className={this.props.classes.textField}
                                 label="Name"
                                 placeholder="Schedule 2"
+                                onChange={this.handleNameChange}
                                 required
                             />
                             <TextField

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -1,0 +1,82 @@
+import React, { PureComponent } from 'react';
+import {
+    Tooltip,
+    Button,
+    Dialog,
+    DialogTitle,
+    DialogActions,
+    DialogContent,
+    TextField,
+    FormControl,
+} from '@material-ui/core';
+import { Add } from '@material-ui/icons';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = () => ({
+    addButton: {
+        padding: '3px 7px',
+        minWidth: 0,
+        minHeight: 0,
+    },
+    textField: {
+        marginBottom: '25px',
+    },
+});
+
+class AddScheduleDialog extends PureComponent {
+    state = {
+        isOpen: false,
+    };
+
+    handleOpen = () => {
+        this.setState({ isOpen: true });
+    };
+
+    handleClose = () => {
+        this.setState({ isOpen: false });
+    };
+
+    handleAdd = () => {};
+
+    render() {
+        return (
+            <>
+                <Tooltip title="Add a Schedule">
+                    <Button className={this.props.classes.addButton} variant="outlined" onClick={this.handleOpen}>
+                        <Add />
+                    </Button>
+                </Tooltip>
+                <Dialog open={this.state.isOpen} fullWidth>
+                    <DialogTitle>Add a New Schedule</DialogTitle>
+                    <DialogContent>
+                        <FormControl className={this.props.classes.formContainer} fullWidth>
+                            <TextField
+                                className={this.props.classes.textField}
+                                label="Name"
+                                placeholder="Schedule 2"
+                                required
+                            />
+                            <TextField
+                                className={this.props.classes.textField}
+                                label="Notes"
+                                placeholder="An optional space to record thoughts about this schedule"
+                                maxRows={5}
+                                multiline
+                            />
+                        </FormControl>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={this.handleClose} color="primary">
+                            Cancel
+                        </Button>
+                        <Button onClick={this.handleAdd} variant="contained" color="primary">
+                            Add Schedule
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            </>
+        );
+    }
+}
+
+export default withStyles(styles)(AddScheduleDialog);

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -1,14 +1,5 @@
 import React, { PureComponent } from 'react';
-import {
-    Tooltip,
-    Button,
-    Dialog,
-    DialogTitle,
-    DialogActions,
-    DialogContent,
-    TextField,
-    FormControl,
-} from '@material-ui/core';
+import { Tooltip, Button, Dialog, DialogTitle, DialogActions, DialogContent, TextField } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
 import { addSchedule } from '../../actions/AppStoreActions';
@@ -58,14 +49,13 @@ class AddScheduleDialog extends PureComponent {
                 <Dialog open={this.state.isOpen} fullWidth>
                     <DialogTitle>Add a New Schedule</DialogTitle>
                     <DialogContent>
-                        <FormControl fullWidth>
-                            <TextField
-                                className={this.props.classes.textField}
-                                label="Name"
-                                placeholder="Schedule 2"
-                                onChange={this.handleNameChange}
-                            />
-                        </FormControl>
+                        <TextField
+                            className={this.props.classes.textField}
+                            label="Name"
+                            placeholder="Schedule 2"
+                            onChange={this.handleNameChange}
+                            fullWidth
+                        />
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={this.handleClose} color="primary">

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -1,8 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 import { Tooltip, Button, Dialog, DialogTitle, DialogActions, DialogContent, TextField } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
 import { addSchedule } from '../../actions/AppStoreActions';
+import { isDarkMode } from '../../helpers';
 
 const styles = () => ({
     addButton: {
@@ -15,60 +16,63 @@ const styles = () => ({
     },
 });
 
-class AddScheduleDialog extends PureComponent {
-    state = {
-        isOpen: false,
-        scheduleName: '',
+const AddScheduleDialog = (props) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [scheduleName, setScheduleName] = useState('');
+
+    const handleOpen = () => {
+        setIsOpen(true);
     };
 
-    handleOpen = () => {
-        this.setState({ isOpen: true });
+    const handleClose = () => {
+        setIsOpen(false);
+        setScheduleName('');
     };
 
-    handleClose = () => {
-        this.setState({ isOpen: false });
+    const handleNameChange = (event) => {
+        setScheduleName(event.target.value);
     };
 
-    handleNameChange = (event) => {
-        this.setState({ scheduleName: event.target.value });
+    const handleAdd = () => {
+        addSchedule(scheduleName);
+        setIsOpen(false);
+        setScheduleName('');
     };
 
-    handleAdd = () => {
-        addSchedule(this.state.scheduleName);
-        this.setState({ isOpen: false });
-    };
-
-    render() {
-        return (
-            <>
-                <Tooltip title="Add a Schedule">
-                    <Button className={this.props.classes.addButton} variant="outlined" onClick={this.handleOpen}>
-                        <Add />
+    return (
+        <>
+            <Tooltip title="Add a Schedule">
+                <Button className={props.classes.addButton} variant="outlined" onClick={handleOpen}>
+                    <Add />
+                </Button>
+            </Tooltip>
+            <Dialog open={isOpen} fullWidth>
+                <DialogTitle>Add a New Schedule</DialogTitle>
+                <DialogContent>
+                    <TextField
+                        className={props.classes.textField}
+                        label="Name"
+                        placeholder="Schedule 2"
+                        onChange={handleNameChange}
+                        fullWidth
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose} color={isDarkMode() ? 'white' : 'primary'}>
+                        Cancel
                     </Button>
-                </Tooltip>
-                <Dialog open={this.state.isOpen} fullWidth>
-                    <DialogTitle>Add a New Schedule</DialogTitle>
-                    <DialogContent>
-                        <TextField
-                            className={this.props.classes.textField}
-                            label="Name"
-                            placeholder="Schedule 2"
-                            onChange={this.handleNameChange}
-                            fullWidth
-                        />
-                    </DialogContent>
-                    <DialogActions>
-                        <Button onClick={this.handleClose} color="primary">
-                            Cancel
-                        </Button>
-                        <Button onClick={this.handleAdd} variant="contained" color="primary">
-                            Add Schedule
-                        </Button>
-                    </DialogActions>
-                </Dialog>
-            </>
-        );
-    }
-}
+                    <Button
+                        onClick={handleAdd}
+                        variant="contained"
+                        color="primary"
+                        disabled={scheduleName.trim() === ''}
+                    >
+                        Add Schedule
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};
 
 export default withStyles(styles)(AddScheduleDialog);

--- a/src/components/Calendar/AddScheduleDialog.js
+++ b/src/components/Calendar/AddScheduleDialog.js
@@ -11,6 +11,7 @@ import {
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
+import { addSchedule } from '../../actions/AppStoreActions';
 
 const styles = () => ({
     addButton: {
@@ -42,7 +43,7 @@ class AddScheduleDialog extends PureComponent {
     };
 
     handleAdd = () => {
-        this.props.onNameChange(this.state.scheduleName);
+        addSchedule(this.state.scheduleName);
         this.setState({ isOpen: false });
     };
 

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -12,6 +12,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
 import ConditionalWrapper from '../App/ConditionalWrapper';
+import AddScheduleDialog from './AddScheduleDialog';
 
 const styles = {
     toolbar: {
@@ -37,6 +38,7 @@ const styles = {
     },
     scheduleSelector: {
         marginLeft: '10px',
+        maxWidth: '9rem',
     },
 };
 
@@ -61,12 +63,14 @@ const CalendarPaneToolbar = (props) => {
 
     return (
         <Paper elevation={0} variant="outlined" square className={classes.toolbar}>
+            <AddScheduleDialog />
+
             <Select
                 className={classes.scheduleSelector}
                 value={props.currentScheduleIndex}
                 onChange={handleScheduleChange}
             >
-                <MenuItem value={0}>Schedule 1</MenuItem>
+                <MenuItem value={0}>Schedule 1 Schedule 1 Schedule 1 Schedule 1</MenuItem>
                 <MenuItem value={1}>Schedule 2</MenuItem>
                 <MenuItem value={2}>Schedule 3</MenuItem>
                 <MenuItem value={3}>Schedule 4</MenuItem>

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -70,10 +70,6 @@ const CalendarPaneToolbar = (props) => {
                 value={props.currentScheduleIndex}
                 onChange={handleScheduleChange}
             >
-                {/* <MenuItem value={0}>Schedule 1</MenuItem>
-                <MenuItem value={1}>Schedule 2</MenuItem>
-                <MenuItem value={2}>Schedule 3</MenuItem>
-                <MenuItem value={3}>Schedule 4</MenuItem> */}
                 {props.scheduleNames.map((name, index) => (
                     <MenuItem value={index}>{name}</MenuItem>
                 ))}

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -40,6 +40,9 @@ const styles = {
         marginLeft: '10px',
         maxWidth: '9rem',
     },
+    rootScheduleSelector: {
+        paddingLeft: '5px',
+    },
 };
 
 const CalendarPaneToolbar = (props) => {
@@ -66,6 +69,7 @@ const CalendarPaneToolbar = (props) => {
             <AddScheduleDialog />
 
             <Select
+                classes={{ root: classes.rootScheduleSelector }}
                 className={classes.scheduleSelector}
                 value={props.currentScheduleIndex}
                 onChange={handleScheduleChange}

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -13,8 +13,6 @@ import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
 import ConditionalWrapper from '../App/ConditionalWrapper';
 import AddScheduleDialog from './AddScheduleDialog';
-import AppStore from '../../stores/AppStore';
-import { addSchedule } from '../../actions/AppStoreActions';
 
 const styles = {
     toolbar: {
@@ -63,16 +61,9 @@ const CalendarPaneToolbar = (props) => {
         setAnchorEl(null);
     };
 
-    const [scheduleNames, setScheduleNames] = React.useState(AppStore.getScheduleNames());
-
-    const handleScheduleNameChange = (scheduleName) => {
-        setScheduleNames((prev) => [...prev, scheduleName]);
-        addSchedule(scheduleName);
-    };
-
     return (
         <Paper elevation={0} variant="outlined" square className={classes.toolbar}>
-            <AddScheduleDialog onNameChange={handleScheduleNameChange} />
+            <AddScheduleDialog />
 
             <Select
                 className={classes.scheduleSelector}
@@ -83,7 +74,7 @@ const CalendarPaneToolbar = (props) => {
                 <MenuItem value={1}>Schedule 2</MenuItem>
                 <MenuItem value={2}>Schedule 3</MenuItem>
                 <MenuItem value={3}>Schedule 4</MenuItem> */}
-                {scheduleNames.map((name, index) => (
+                {props.scheduleNames.map((name, index) => (
                     <MenuItem value={index}>{name}</MenuItem>
                 ))}
             </Select>

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -13,6 +13,8 @@ import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
 import ConditionalWrapper from '../App/ConditionalWrapper';
 import AddScheduleDialog from './AddScheduleDialog';
+import AppStore from '../../stores/AppStore';
+import { addSchedule } from '../../actions/AppStoreActions';
 
 const styles = {
     toolbar: {
@@ -61,19 +63,29 @@ const CalendarPaneToolbar = (props) => {
         setAnchorEl(null);
     };
 
+    const [scheduleNames, setScheduleNames] = React.useState(AppStore.getScheduleNames());
+
+    const handleScheduleNameChange = (scheduleName) => {
+        setScheduleNames((prev) => [...prev, scheduleName]);
+        addSchedule(scheduleName);
+    };
+
     return (
         <Paper elevation={0} variant="outlined" square className={classes.toolbar}>
-            <AddScheduleDialog />
+            <AddScheduleDialog onNameChange={handleScheduleNameChange} />
 
             <Select
                 className={classes.scheduleSelector}
                 value={props.currentScheduleIndex}
                 onChange={handleScheduleChange}
             >
-                <MenuItem value={0}>Schedule 1 Schedule 1 Schedule 1 Schedule 1</MenuItem>
+                {/* <MenuItem value={0}>Schedule 1</MenuItem>
                 <MenuItem value={1}>Schedule 2</MenuItem>
                 <MenuItem value={2}>Schedule 3</MenuItem>
-                <MenuItem value={3}>Schedule 4</MenuItem>
+                <MenuItem value={3}>Schedule 4</MenuItem> */}
+                {scheduleNames.map((name, index) => (
+                    <MenuItem value={index}>{name}</MenuItem>
+                ))}
             </Select>
 
             <Tooltip title="Toggle showing finals schedule">

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -137,7 +137,11 @@ const CalendarPaneToolbar = (props) => {
                 {[
                     <ExportCalendar />,
                     <ScreenshotButton onTakeScreenshot={props.onTakeScreenshot} />,
-                    <CustomEventsDialog editMode={false} currentScheduleIndex={props.currentScheduleIndex} />,
+                    <CustomEventsDialog
+                        editMode={false}
+                        currentScheduleIndex={props.currentScheduleIndex}
+                        scheduleNames={props.scheduleNames}
+                    />,
                 ].map((element, index) => (
                     <ConditionalWrapper
                         key={index}

--- a/src/components/Calendar/CourseCalendarEvent.js
+++ b/src/components/Calendar/CourseCalendarEvent.js
@@ -167,6 +167,7 @@ const CourseCalendarEvent = (props) => {
                         customEvent={AppStore.getCustomEvents().find(
                             (customEvent) => customEvent.customEventID === customEventID
                         )}
+                        scheduleNames={props.scheduleNames}
                     />
 
                     <Tooltip title="Delete">

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -148,14 +148,14 @@ class ScheduleCalendar extends PureComponent {
         AppStore.on('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.on('customEventsChange', this.updateEventsInCalendar);
         AppStore.on('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
-        AppStore.on('addedSchedule', this.updateScheduleNames);
+        AppStore.on('scheduleNamesChange', this.updateScheduleNames);
     };
 
     componentWillUnmount = () => {
         AppStore.removeListener('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.removeListener('customEventsChange', this.updateEventsInCalendar);
         AppStore.removeListener('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
-        AppStore.removeListener('addedSchedule', this.updateScheduleNames);
+        AppStore.removeListener('scheduleNamesChange', this.updateScheduleNames);
     };
 
     handleTakeScreenshot = async (html2CanvasScreenshot) => {

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -82,6 +82,7 @@ class ScheduleCalendar extends PureComponent {
         eventsInCalendar: AppStore.getEventsInCalendar(),
         finalsEventsInCalendar: AppStore.getFinalEventsInCalendar(),
         currentScheduleIndex: AppStore.getCurrentScheduleIndex(),
+        scheduleNames: AppStore.getScheduleNames(),
     };
 
     static eventStyleGetter = (event) => {
@@ -137,16 +138,24 @@ class ScheduleCalendar extends PureComponent {
         this.handleClosePopover();
     };
 
+    updateScheduleNames = () => {
+        this.setState({
+            scheduleNames: AppStore.getScheduleNames(),
+        });
+    };
+
     componentDidMount = () => {
         AppStore.on('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.on('customEventsChange', this.updateEventsInCalendar);
         AppStore.on('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
+        AppStore.on('addedSchedule', this.updateScheduleNames);
     };
 
     componentWillUnmount = () => {
         AppStore.removeListener('addedCoursesChange', this.updateEventsInCalendar);
         AppStore.removeListener('customEventsChange', this.updateEventsInCalendar);
         AppStore.removeListener('currentScheduleIndexChange', this.updateCurrentScheduleIndex);
+        AppStore.removeListener('addedSchedule', this.updateScheduleNames);
     };
 
     handleTakeScreenshot = async (html2CanvasScreenshot) => {
@@ -235,6 +244,7 @@ class ScheduleCalendar extends PureComponent {
                     currentScheduleIndex={this.state.currentScheduleIndex}
                     toggleDisplayFinalsSchedule={this.toggleDisplayFinalsSchedule}
                     showFinalsSchedule={this.state.showFinalsSchedule}
+                    scheduleNames={this.state.scheduleNames}
                 />
                 <div
                     id="screenshot"

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -280,6 +280,7 @@ class ScheduleCalendar extends PureComponent {
                             closePopover={this.handleClosePopover}
                             courseInMoreInfo={this.state.courseInMoreInfo}
                             currentScheduleIndex={this.state.currentScheduleIndex}
+                            scheduleNames={this.state.scheduleNames}
                         />
                     </Popper>
                     <Calendar

--- a/src/components/CoursePane/CourseRenderPane.js
+++ b/src/components/CoursePane/CourseRenderPane.js
@@ -82,8 +82,8 @@ const flattenSOCObject = (SOCObject) => {
     }, []);
 };
 
-const SectionTableWrapped = (index, data, scheduleNames) => {
-    const { courseData } = data;
+const SectionTableWrapped = (index, data) => {
+    const { courseData, scheduleNames } = data;
     const formData = RightPaneStore.getFormData();
 
     let component;
@@ -197,6 +197,7 @@ class CourseRenderPane extends PureComponent {
         } else if (!this.state.error) {
             const renderData = {
                 courseData: this.state.courseData,
+                scheduleNames: this.state.scheduleNames,
             };
 
             currentView = (
@@ -213,7 +214,7 @@ class CourseRenderPane extends PureComponent {
 
                             return (
                                 <LazyLoad once key={index} overflow height={heightEstimate} offset={500}>
-                                    {SectionTableWrapped(index, renderData, this.state.scheduleNames)}
+                                    {SectionTableWrapped(index, renderData)}
                                 </LazyLoad>
                             );
                         })

--- a/src/components/CoursePane/CourseRenderPane.js
+++ b/src/components/CoursePane/CourseRenderPane.js
@@ -82,7 +82,7 @@ const flattenSOCObject = (SOCObject) => {
     }, []);
 };
 
-const SectionTableWrapped = (index, data) => {
+const SectionTableWrapped = (index, data, scheduleNames) => {
     const { courseData } = data;
     const formData = RightPaneStore.getFormData();
 
@@ -115,6 +115,7 @@ const SectionTableWrapped = (index, data) => {
                 courseDetails={courseData[index]}
                 colorAndDelete={false}
                 highlightAdded={true}
+                scheduleNames={scheduleNames}
             />
         );
     }
@@ -127,6 +128,7 @@ class CourseRenderPane extends PureComponent {
         courseData: null,
         loading: true,
         error: false,
+        scheduleNames: AppStore.getScheduleNames(),
     };
 
     loadCourses = () => {
@@ -171,7 +173,16 @@ class CourseRenderPane extends PureComponent {
 
     componentDidMount() {
         this.loadCourses();
+        AppStore.on('scheduleNamesChange', this.updateScheduleNames);
     }
+
+    componentWillUnmount() {
+        AppStore.removeListener('scheduleNamesChange', this.updateScheduleNames);
+    }
+
+    updateScheduleNames = () => {
+        this.setState({ scheduleNames: AppStore.getScheduleNames() });
+    };
 
     render() {
         const { classes } = this.props;
@@ -202,7 +213,7 @@ class CourseRenderPane extends PureComponent {
 
                             return (
                                 <LazyLoad once key={index} overflow height={heightEstimate} offset={500}>
-                                    {SectionTableWrapped(index, renderData)}
+                                    {SectionTableWrapped(index, renderData, this.state.scheduleNames)}
                                 </LazyLoad>
                             );
                         })

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -166,6 +166,7 @@ class CustomEventDialog extends PureComponent {
                             scheduleIndices={this.state.scheduleIndices}
                             onSelectScheduleIndices={this.handleSelectScheduleIndices}
                             customEvent={this.props.customEvent}
+                            scheduleNames={this.props.scheduleNames}
                         />
                     </DialogContent>
 

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import { addCustomEvent, editCustomEvent } from '../../actions/AppStoreActions';
 import ScheduleSelector from './ScheduleSelector';
 import ReactGA from 'react-ga';
+import { isDarkMode } from '../../helpers';
 
 const styles = () => ({
     container: {
@@ -171,7 +172,7 @@ class CustomEventDialog extends PureComponent {
                     </DialogContent>
 
                     <DialogActions>
-                        <Button onClick={() => this.handleClose(true)} color="primary">
+                        <Button onClick={() => this.handleClose(true)} color={isDarkMode() ? 'white' : 'primary'}>
                             Cancel
                         </Button>
                         <Tooltip title="Schedule and day must be checked" disableHoverListener={!this.isAddDisabled()}>

--- a/src/components/CustomEvents/ScheduleSelector.js
+++ b/src/components/CustomEvents/ScheduleSelector.js
@@ -26,55 +26,25 @@ class ScheduleSelector extends PureComponent {
     };
 
     render() {
+        console.log(this.props);
+
         return (
             <FormGroup row>
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={this.state.scheduleIndices.includes(0)}
-                            onChange={this.handleChange(0)}
-                            value="1"
-                            color="primary"
+                {this.props.scheduleNames.map((name, index) => {
+                    return (
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={this.state.scheduleIndices.includes(index)}
+                                    onChange={this.handleChange(index)}
+                                    value={(index + 1).toString()}
+                                    color="primary"
+                                />
+                            }
+                            label={name}
                         />
-                    }
-                    label="Schedule 1"
-                />
-
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={this.state.scheduleIndices.includes(1)}
-                            onChange={this.handleChange(1)}
-                            value="2"
-                            color="primary"
-                        />
-                    }
-                    label="Schedule 2"
-                />
-
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={this.state.scheduleIndices.includes(2)}
-                            onChange={this.handleChange(2)}
-                            value="3"
-                            color="primary"
-                        />
-                    }
-                    label="Schedule 3"
-                />
-
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={this.state.scheduleIndices.includes(3)}
-                            onChange={this.handleChange(3)}
-                            value="4"
-                            color="primary"
-                        />
-                    }
-                    label="Schedule 4"
-                />
+                    );
+                })}
             </FormGroup>
         );
     }

--- a/src/components/CustomEvents/ScheduleSelector.js
+++ b/src/components/CustomEvents/ScheduleSelector.js
@@ -26,8 +26,6 @@ class ScheduleSelector extends PureComponent {
     };
 
     render() {
-        console.log(this.props);
-
         return (
             <FormGroup row>
                 {this.props.scheduleNames.map((name, index) => {
@@ -37,7 +35,7 @@ class ScheduleSelector extends PureComponent {
                                 <Checkbox
                                     checked={this.state.scheduleIndices.includes(index)}
                                     onChange={this.handleChange(index)}
-                                    value={(index + 1).toString()}
+                                    value={index + 1}
                                     color="primary"
                                 />
                             }

--- a/src/components/SectionTable/SectionTable.js
+++ b/src/components/SectionTable/SectionTable.js
@@ -165,6 +165,7 @@ class SectionTable extends PureComponent {
                                         term={this.props.term}
                                         colorAndDelete={this.props.colorAndDelete}
                                         highlightAdded={this.props.highlightAdded}
+                                        scheduleNames={this.props.scheduleNames}
                                     />
                                 );
                             })}

--- a/src/components/SectionTable/SectionTableBody.js
+++ b/src/components/SectionTable/SectionTableBody.js
@@ -270,7 +270,7 @@ const StatusCell = withStyles(styles)((props) => {
 });
 //TODO: SectionNum name parity -> SectionNumber
 const SectionTableBody = withStyles(styles)((props) => {
-    const { classes, section, courseDetails, term, colorAndDelete, highlightAdded } = props;
+    const { classes, section, courseDetails, term, colorAndDelete, highlightAdded, scheduleNames } = props;
     const [addedCourse, setAddedCourse] = useState(colorAndDelete);
     useEffect(() => {
         const toggleHighlight = () => {
@@ -296,7 +296,12 @@ const SectionTableBody = withStyles(styles)((props) => {
             className={classNames(classes.tr, { addedCourse: addedCourse && highlightAdded })}
         >
             {!addedCourse ? (
-                <ScheduleAddCell section={section} courseDetails={courseDetails} term={term} />
+                <ScheduleAddCell
+                    section={section}
+                    courseDetails={courseDetails}
+                    term={term}
+                    scheduleNames={scheduleNames}
+                />
             ) : (
                 <ColorAndDelete color={section.color} sectionCode={section.sectionCode} term={term} />
             )}

--- a/src/components/SectionTable/SectionTableButtons.js
+++ b/src/components/SectionTable/SectionTableButtons.js
@@ -41,7 +41,7 @@ export const ColorAndDelete = withStyles(styles)((props) => {
 });
 
 export const ScheduleAddCell = withStyles(styles)((props) => {
-    const { classes, section, courseDetails, term } = props;
+    const { classes, section, courseDetails, term, scheduleNames } = props;
     const popupState = usePopupState({ variant: 'popover' });
 
     const closeAndAddCourse = (scheduleIndex) => {
@@ -69,11 +69,10 @@ export const ScheduleAddCell = withStyles(styles)((props) => {
                     <ArrowDropDown fontSize="small" />
                 </IconButton>
                 <Menu {...bindMenu(popupState)} onClose={() => closeAndAddCourse(-1)}>
-                    <MenuItem onClick={() => closeAndAddCourse(0)}>Add to schedule 1</MenuItem>
-                    <MenuItem onClick={() => closeAndAddCourse(1)}>Add to schedule 2</MenuItem>
-                    <MenuItem onClick={() => closeAndAddCourse(2)}>Add to schedule 3</MenuItem>
-                    <MenuItem onClick={() => closeAndAddCourse(3)}>Add to schedule 4</MenuItem>
-                    <MenuItem onClick={() => closeAndAddCourse(4)}>Add to all</MenuItem>
+                    {scheduleNames.map((name, index) => (
+                        <MenuItem onClick={() => closeAndAddCourse(index)}>Add to {name}</MenuItem>
+                    ))}
+                    <MenuItem onClick={() => closeAndAddCourse(scheduleNames.length)}>Add to All Schedules</MenuItem>
                 </Menu>
             </div>
         </TableCell>

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -9,7 +9,7 @@ class AppStore extends EventEmitter {
         this.currentScheduleIndex = 0;
         this.customEvents = [];
         this.addedCourses = [];
-        this.addedSectionCodes = { 0: new Set(), 1: new Set(), 2: new Set(), 3: new Set() };
+        this.addedSectionCodes = { 0: new Set() };
         this.deletedCourses = [];
         this.snackbarMessage = '';
         this.snackbarVariant = 'info';
@@ -19,7 +19,7 @@ class AppStore extends EventEmitter {
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
-        this.scheduleNames = ['Schedule 1', 'Schedule 2', 'Schedule 3', 'Schedule 4'];
+        this.scheduleNames = ['Schedule 1'];
         this.theme = (() => {
             // either 'light', 'dark', or 'auto'
             const theme = typeof Storage === 'undefined' ? 'auto' : window.localStorage.getItem('theme');
@@ -127,7 +127,12 @@ class AppStore extends EventEmitter {
     }
 
     updateAddedSectionCodes() {
-        this.addedSectionCodes = { 0: new Set(), 1: new Set(), 2: new Set(), 3: new Set() };
+        this.addedSectionCodes = {};
+
+        for (let i = 0; i < this.scheduleNames.length; i++) {
+            this.addedSectionCodes[i] = new Set();
+        }
+
         for (const course of this.addedCourses) {
             for (const scheduleIndex of course.scheduleIndices) {
                 this.addedSectionCodes[scheduleIndex].add(`${course.section.sectionCode} ${course.term}`);
@@ -213,6 +218,7 @@ class AppStore extends EventEmitter {
                 this.emit('customEventsChange');
                 break;
             case 'LOAD_SCHEDULE':
+                this.scheduleNames = ['Schedule 1', 'Schedule 2', 'Schedule 3', 'Schedule 4'];
                 this.addedCourses = action.userData.addedCourses;
                 this.updateAddedSectionCodes();
                 this.customEvents = action.userData.customEvents;
@@ -221,6 +227,7 @@ class AppStore extends EventEmitter {
                 this.unsavedChanges = false;
                 this.emit('addedCoursesChange');
                 this.emit('customEventsChange');
+                this.emit('scheduleNamesChange');
                 break;
             case 'SAVE_SCHEDULE':
                 this.unsavedChanges = false;
@@ -257,7 +264,8 @@ class AppStore extends EventEmitter {
                 break;
             case 'ADD_SCHEDULE':
                 this.scheduleNames = action.newScheduleNames;
-                this.emit('addedSchedule');
+                this.addedSectionCodes[this.scheduleNames.length - 1] = new Set();
+                this.emit('scheduleNamesChange');
                 break;
             default: //do nothing
         }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -19,6 +19,7 @@ class AppStore extends EventEmitter {
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
+        this.scheduleNames = ['Schedule 1', 'Schedule 2', 'Schedule 3', 'Schedule 4'];
         this.theme = (() => {
             // either 'light', 'dark', or 'auto'
             const theme = typeof Storage === 'undefined' ? 'auto' : window.localStorage.getItem('theme');
@@ -35,6 +36,34 @@ class AppStore extends EventEmitter {
     getCurrentScheduleIndex() {
         return this.currentScheduleIndex;
     }
+
+    getScheduleNames() {
+        return this.scheduleNames;
+    }
+
+    // getScheduleNames() {
+    //     let indices = new Set();
+
+    //     this.eventsInCalendar.forEach((event) => {
+    //         event.scheduleIndices.forEach((index) => {
+    //             indices.add(index);
+    //         });
+    //     });
+
+    //     this.eventsInCalendar.forEach((event) => {
+
+    //     });
+
+    //     if (indices.size === 0) {
+    //         return ["Schedule 1"];
+    //     }
+
+    //     let names = [];
+    //     for (let i = 1; i <= indices.size; i++) {
+    //         names.push(`Schedule ${i}`);
+    //     }
+    //     return names;
+    // }
 
     getAddedCourses() {
         return this.addedCourses;
@@ -225,6 +254,9 @@ class AppStore extends EventEmitter {
                 this.theme = action.theme;
                 this.emit('themeToggle');
                 window.localStorage.setItem('theme', action.theme);
+                break;
+            case 'ADD_SCHEDULE':
+                this.scheduleNames.push(action.scheduleName);
                 break;
             default: //do nothing
         }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -10,6 +10,7 @@ class AppStore extends EventEmitter {
         this.customEvents = [];
         this.addedCourses = [];
         this.addedSectionCodes = { 0: new Set() };
+        this.colorPickers = {};
         this.deletedCourses = [];
         this.snackbarMessage = '';
         this.snackbarVariant = 'info';

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -256,7 +256,8 @@ class AppStore extends EventEmitter {
                 window.localStorage.setItem('theme', action.theme);
                 break;
             case 'ADD_SCHEDULE':
-                this.scheduleNames.push(action.scheduleName);
+                this.scheduleNames = action.newScheduleNames;
+                this.emit('addedSchedule');
                 break;
             default: //do nothing
         }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -195,6 +195,7 @@ class AppStore extends EventEmitter {
                 this.emit('customEventsChange');
                 break;
             case 'LOAD_SCHEDULE':
+                // If the user already had schedules, load up four schedules
                 this.scheduleNames = ['Schedule 1', 'Schedule 2', 'Schedule 3', 'Schedule 4'];
                 this.addedCourses = action.userData.addedCourses;
                 this.updateAddedSectionCodes();
@@ -240,6 +241,9 @@ class AppStore extends EventEmitter {
                 window.localStorage.setItem('theme', action.theme);
                 break;
             case 'ADD_SCHEDULE':
+                // If the user adds a schedule, update the array of schedule names, add
+                // another key/value pair to keep track of the section codes for that schedule,
+                // and redirect the user to the new schedule
                 this.scheduleNames = action.newScheduleNames;
                 this.addedSectionCodes[action.newScheduleNames.length - 1] = new Set();
                 this.currentScheduleIndex = action.newScheduleNames.length - 1;

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -41,30 +41,6 @@ class AppStore extends EventEmitter {
         return this.scheduleNames;
     }
 
-    // getScheduleNames() {
-    //     let indices = new Set();
-
-    //     this.eventsInCalendar.forEach((event) => {
-    //         event.scheduleIndices.forEach((index) => {
-    //             indices.add(index);
-    //         });
-    //     });
-
-    //     this.eventsInCalendar.forEach((event) => {
-
-    //     });
-
-    //     if (indices.size === 0) {
-    //         return ["Schedule 1"];
-    //     }
-
-    //     let names = [];
-    //     for (let i = 1; i <= indices.size; i++) {
-    //         names.push(`Schedule ${i}`);
-    //     }
-    //     return names;
-    // }
-
     getAddedCourses() {
         return this.addedCourses;
     }
@@ -264,8 +240,10 @@ class AppStore extends EventEmitter {
                 break;
             case 'ADD_SCHEDULE':
                 this.scheduleNames = action.newScheduleNames;
-                this.addedSectionCodes[this.scheduleNames.length - 1] = new Set();
+                this.addedSectionCodes[action.newScheduleNames.length - 1] = new Set();
+                this.currentScheduleIndex = action.newScheduleNames.length - 1;
                 this.emit('scheduleNamesChange');
+                this.emit('currentScheduleIndexChange');
                 break;
             default: //do nothing
         }


### PR DESCRIPTION
## Summary
- Users can create additional schedules by clicking the + button next to the current schedule's name.
- Once the + button is clicked, a dialog will pop up and prompt the user for the name of the new schedule.
- Once a schedule is added, the user will be redirected to the new schedule and can add courses and custom events.
- If a user has no schedules, they will just be shown one schedule called `Schedule 1`.

## Test Plan
- Add a schedule and see if its name appears in the list of schedules.
- Add courses to the new schedule and see if the Added Courses pane updates.
- Add custom events to the new schedule and see if the Added Courses pane updates.
- Make sure the new schedule does not affect any other schedules.
- Test various schedule functions (finals calendar, undo last deleted course, download as an ics file, screenshot, copy schedule, clear schedule, viewing maps).
- Test if a user with no schedules starts with only `Schedule 1`.

Demo:

https://user-images.githubusercontent.com/78244965/163896748-213fc040-8ddf-4144-b77e-68c1ac5e823d.mp4

## Issues
- Closes #332 
- Closes #333 

## Next Steps
- Allow user to rename schedule
- Allow user to delete schedule
- Redesign the calendar pane toolbar; instead of the new + button, maybe create a central menu for adding a schedule, deleting the current schedule, adding custom events, and renaming the current schedule.


