### PR TITLE
Add Snackbar on Export Calendar

### DIFF
--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -98,7 +98,11 @@ export const addCourse = (section, courseDetails, term, scheduleIndex, color) =>
     }
     return color;
 };
-
+/**
+ * @param variant usually 'info', 'error', 'warning', or 'success'
+ * @param message any string to display
+ * @param duration in seconds and is optional.
+ */
 export const openSnackbar = (variant, message, duration, position, style) => {
     dispatcher.dispatch({
         type: 'OPEN_SNACKBAR',

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -6,6 +6,7 @@ import Today from '@material-ui/icons/Today';
 import { saveAs } from 'file-saver';
 import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
+import { openSnackbar } from '../../actions/AppStoreActions';
 import { termData } from '../../termData';
 
 // TODO(chase): support summer sessions
@@ -250,6 +251,7 @@ class ExportCalendarButton extends PureComponent {
                 // Download the .ics file
                 var blob = new Blob([val], { type: 'text/plain;charset=utf-8' });
                 saveAs(blob, 'schedule.ics');
+                openSnackbar('success', 'Schedule downloaded! Make sure your calendar is in PST.', 5);
             } else {
                 console.log(err);
             }

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -253,6 +253,7 @@ class ExportCalendarButton extends PureComponent {
                 saveAs(blob, 'schedule.ics');
                 openSnackbar('success', 'Schedule downloaded! Make sure your calendar is in PST.', 5);
             } else {
+                openSnackbar('error', 'Something went wrong! Unable to download schedule.', 5);
                 console.log(err);
             }
         });


### PR DESCRIPTION
## Summary
The export calendar button now shows a snackbar on success and includes a message about making sure your calendar is in PST.
![aa-download-schedule](https://user-images.githubusercontent.com/48658337/163928298-d8fac170-7391-414f-97e9-45846b4c3a7c.gif)

## Test Plan
Press the export calendar button.
## Issues
Closes #324