### PR TITLE
Fix selected term getting cleared on fuzzy search

### DIFF
--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -3,6 +3,7 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import search from 'websoc-fuzzy-search';
 import { updateFormValue, resetFormValues } from '../../actions/RightPaneActions';
+import RightPaneStore from '../../stores/RightPaneStore';
 
 const emojiMap = {
     GE_CATEGORY: '🏫', // U+1F3EB :school:
@@ -72,7 +73,9 @@ class FuzzySearch extends PureComponent {
                 if (!value) return;
                 const emoji = value.slice(0, 2);
                 const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');
+                const term = RightPaneStore.getFormData().term;
                 resetFormValues();
+                updateFormValue('term', term);
                 switch (emoji) {
                     case emojiMap.GE_CATEGORY:
                         updateFormValue(


### PR DESCRIPTION
## Summary
Fixes a regression introduced in #343 where the `RightPaneStore` was reset to default when triggering a fuzzy search, in order to make sure that all relevant fields would be clear. This had the unintended side effect of also resetting the selected term to the current default term, which meant that fuzzy searches for classes in other terms would not actually be possible.

## Test Plan
Ensure that searches for terms other than the current default actually return matching courses from that term.