### PR TITLE
Search Keyboard Shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "file:../websoc-fuzzy-search"
+                "websoc-fuzzy-search": "^0.6.3"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
@@ -46,10 +46,12 @@
             }
         },
         "../websoc-fuzzy-search": {
-            "version": "0.6.3",
+            "version": "0.7.0",
+            "extraneous": true,
             "license": "MIT",
             "devDependencies": {
-                "prettier": "^2.6.2"
+                "prettier": "^2.6.2",
+                "typescript": "^4.6.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -21083,8 +21085,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "resolved": "../websoc-fuzzy-search",
-            "link": true
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
+            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38006,10 +38009,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "file:../websoc-fuzzy-search",
-            "requires": {
-                "prettier": "^2.6.2"
-            }
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
+            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.6.3"
+                "websoc-fuzzy-search": "file:../websoc-fuzzy-search"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
@@ -47,7 +47,6 @@
         },
         "../websoc-fuzzy-search": {
             "version": "0.6.3",
-            "extraneous": true,
             "license": "MIT",
             "devDependencies": {
                 "prettier": "^2.6.2"
@@ -21084,9 +21083,8 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
-            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
+            "resolved": "../websoc-fuzzy-search",
+            "link": true
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38008,9 +38006,10 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
-            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
+            "version": "file:../websoc-fuzzy-search",
+            "requires": {
+                "prettier": "^2.6.2"
+            }
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,15 +45,6 @@
                 "prettier": "^2.2.1"
             }
         },
-        "../websoc-fuzzy-search": {
-            "version": "0.7.0",
-            "extraneous": true,
-            "license": "MIT",
-            "devDependencies": {
-                "prettier": "^2.6.2",
-                "typescript": "^4.6.3"
-            }
-        },
         "node_modules/@ampproject/remapping": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "file:../websoc-fuzzy-search"
+        "websoc-fuzzy-search": "^0.6.3"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.6.3"
+        "websoc-fuzzy-search": "file:../websoc-fuzzy-search"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",

--- a/src/components/CoursePane/RightPane.js
+++ b/src/components/CoursePane/RightPane.js
@@ -23,20 +23,41 @@ class RightPane extends PureComponent {
         refresh: 0,
     };
 
+    returnToSearchBarEvent = (event) => {
+        if (event.key === 'Backspace' || event.key === 'Escape') {
+            event.preventDefault();
+            dispatcher.dispatch({
+                type: 'TOGGLE_SEARCH',
+            });
+            this.forceUpdate();
+        }
+    };
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        (RightPaneStore.getDoDisplaySearch() ? document.removeEventListener : document.addEventListener)(
+            'keydown',
+            this.returnToSearchBarEvent,
+            false
+        );
+    }
+
     refreshSearch = () => {
         clearCache();
         this.setState({ refresh: this.state.refresh + 1 });
     };
 
     toggleSearch = () => {
-        if(RightPaneStore.getFormData().ge !== 'ANY' || RightPaneStore.getFormData().deptValue !== 'ALL' || 
-            RightPaneStore.getFormData().sectionCode !== "" || RightPaneStore.getFormData().instructor !== ""){
+        if (
+            RightPaneStore.getFormData().ge !== 'ANY' ||
+            RightPaneStore.getFormData().deptValue !== 'ALL' ||
+            RightPaneStore.getFormData().sectionCode !== '' ||
+            RightPaneStore.getFormData().instructor !== ''
+        ) {
             dispatcher.dispatch({
                 type: 'TOGGLE_SEARCH',
             });
             this.forceUpdate();
-        }
-        else{
+        } else {
             openSnackbar(
                 'error',
                 `Please provide one of the following: Department, GE, Course Code/Range, or Instructor`

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -22,6 +22,73 @@ class FuzzySearch extends PureComponent {
         value: '',
     };
 
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (!prevState.open && this.state.open) {
+            document.addEventListener('keydown', this.enterEvent, false);
+        } else if (prevState.open && !this.state.open) {
+            document.removeEventListener('keydown', this.enterEvent, false);
+        }
+    }
+
+    doSearch = (value) => {
+        console.log(value);
+        if (!value) return;
+        const emoji = value.slice(0, 2);
+        const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');
+        const term = RightPaneStore.getFormData().term;
+        resetFormValues();
+        updateFormValue('term', term);
+        switch (emoji) {
+            case emojiMap.GE_CATEGORY:
+                updateFormValue('ge', `GE-${ident[0].split(' ')[2].replace('(', '').replace(')', '').toUpperCase()}`);
+                break;
+            case emojiMap.DEPARTMENT:
+                updateFormValue('deptValue', ident[0]);
+                updateFormValue('deptLabel', ident.join(':'));
+                break;
+            case emojiMap.COURSE:
+                const deptValue = ident[0].split(' ').slice(0, -1).join(' ');
+                let deptLabel;
+                for (const [key, value] of Object.entries(this.state.cache)) {
+                    if (Object.keys(value).includes(deptValue)) {
+                        deptLabel = this.state.cache[key][deptValue].name;
+                        break;
+                    }
+                }
+                if (!deptLabel) {
+                    const deptSearch = search(deptValue.toLowerCase());
+                    deptLabel = deptSearch[deptValue].name;
+                    this.setState({
+                        cache: {
+                            ...this.state.cache,
+                            [deptValue.toLowerCase()]: deptSearch,
+                        },
+                    });
+                }
+                updateFormValue('deptValue', deptValue);
+                updateFormValue('deptLabel', `${deptValue}: ${deptLabel}`);
+                updateFormValue('courseNumber', ident[0].split(' ').slice(-1)[0]);
+                break;
+            case emojiMap.INSTRUCTOR:
+                updateFormValue(
+                    'instructor',
+                    Object.keys(this.state.results).filter((x) => this.state.results[x].name === ident)[0]
+                );
+                break;
+            default:
+                break;
+        }
+        this.props.toggleSearch();
+    };
+
+    enterEvent = (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.onClose();
+            this.doSearch(this.getOptionLabel(Object.keys(this.state.results)[0]));
+        }
+    };
+
     filterOptions = (options) => options;
 
     getOptionLabel = (option) => {
@@ -70,56 +137,7 @@ class FuzzySearch extends PureComponent {
             );
         } else if (reason === 'reset') {
             this.setState({ open: false, value: '' }, () => {
-                if (!value) return;
-                const emoji = value.slice(0, 2);
-                const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');
-                const term = RightPaneStore.getFormData().term;
-                resetFormValues();
-                updateFormValue('term', term);
-                switch (emoji) {
-                    case emojiMap.GE_CATEGORY:
-                        updateFormValue(
-                            'ge',
-                            `GE-${ident[0].split(' ')[2].replace('(', '').replace(')', '').toUpperCase()}`
-                        );
-                        break;
-                    case emojiMap.DEPARTMENT:
-                        updateFormValue('deptValue', ident[0]);
-                        updateFormValue('deptLabel', ident.join(':'));
-                        break;
-                    case emojiMap.COURSE:
-                        const deptValue = ident[0].split(' ').slice(0, -1).join(' ');
-                        let deptLabel;
-                        for (const [key, value] of Object.entries(this.state.cache)) {
-                            if (Object.keys(value).includes(deptValue)) {
-                                deptLabel = this.state.cache[key][deptValue].name;
-                                break;
-                            }
-                        }
-                        if (!deptLabel) {
-                            const deptSearch = search(deptValue.toLowerCase());
-                            deptLabel = deptSearch[deptValue].name;
-                            this.setState({
-                                cache: {
-                                    ...this.state.cache,
-                                    [deptValue.toLowerCase()]: deptSearch,
-                                },
-                            });
-                        }
-                        updateFormValue('deptValue', deptValue);
-                        updateFormValue('deptLabel', `${deptValue}: ${deptLabel}`);
-                        updateFormValue('courseNumber', ident[0].split(' ').slice(-1)[0]);
-                        break;
-                    case emojiMap.INSTRUCTOR:
-                        updateFormValue(
-                            'instructor',
-                            Object.keys(this.state.results).filter((x) => this.state.results[x].name === ident)[0]
-                        );
-                        break;
-                    default:
-                        break;
-                }
-                this.props.toggleSearch();
+                this.doSearch(value);
             });
         }
     };

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -151,7 +151,9 @@ class FuzzySearch extends PureComponent {
             <Autocomplete
                 style={{ width: '100%' }}
                 options={Object.keys(this.state.results)}
-                renderInput={(params) => <TextField {...params} fullWidth label={'Search'} />}
+                renderInput={(params) => (
+                    <TextField {...params} inputRef={(input) => input && input.focus()} fullWidth label={'Search'} />
+                )}
                 filterOptions={this.filterOptions}
                 getOptionLabel={this.getOptionLabel}
                 getOptionSelected={this.getOptionSelected}


### PR DESCRIPTION
## Summary
Add keyboard shortcuts pertinent to search; pressing Enter now automatically submits the first result returned by fuzzy search, and pressing Backspace or Escape in the results view goes back to the search view without the user needing to click on "back."

## Test Plan
1. Pressing Enter when focused on the search bar submits the first result in the dropdown and triggers a search, as if the user had selected the first result themselves.
2. Pressing Backspace or Escape when in the course listing pane returns the user to the search pane.
3. Any keyboard input outside of these scenarios does not do anything.

NB: I didn't include the parsing improvements as part of this test plan, since it's not on npmjs yet, and I've already tested it with the driver before pushing. If you really wanted to test it with AntAlmanac you could pull the latest version from [websoc-fuzzy-search](https://github.com/icssc/websoc-fuzzy-search) and get npm to use that instead.

## Issues
Closes #357.
