### PR TITLE
Add Google Analytics v4 to Calendar Pane and Navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "react-color": "^2.18.1",
                 "react-dom": "^16.13.1",
                 "react-ga": "^2.7.0",
+                "react-ga4": "^1.4.1",
                 "react-input-mask": "^2.0.4",
                 "react-lazyload": "^3.1.0",
                 "react-leaflet": "^2.7.0",
@@ -16538,6 +16539,11 @@
                 "prop-types": "^15.6.0",
                 "react": "^15.6.2 || ^16.0"
             }
+        },
+        "node_modules/react-ga4": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+            "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
         },
         "node_modules/react-input-mask": {
             "version": "2.0.4",
@@ -34377,6 +34383,11 @@
             "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
             "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==",
             "requires": {}
+        },
+        "react-ga4": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+            "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
         },
         "react-input-mask": {
             "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "react-color": "^2.18.1",
         "react-dom": "^16.13.1",
         "react-ga": "^2.7.0",
+        "react-ga4": "^1.4.1",
         "react-input-mask": "^2.0.4",
         "react-lazyload": "^3.1.0",
         "react-leaflet": "^2.7.0",

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -104,6 +104,12 @@ export const openSnackbar = (variant, message, duration, position, style) => {
 };
 
 export const saveSchedule = async (userID, rememberMe) => {
+    ReactGA4.event({
+        category: 'Navbar',
+        action: 'Save Schedule',
+        label: userID,
+        value: rememberMe,
+    });
     if (userID != null) {
         userID = userID.replace(/\s+/g, '');
 
@@ -153,6 +159,12 @@ export const saveSchedule = async (userID, rememberMe) => {
 };
 
 export const loadSchedule = async (userID, rememberMe) => {
+    ReactGA4.event({
+        category: 'Navbar',
+        action: 'Load Schedule',
+        label: userID,
+        value: rememberMe,
+    });
     if (
         userID != null &&
         (!AppStore.hasUnsavedChanges() ||

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -1,6 +1,7 @@
 import dispatcher from '../dispatcher';
 import AppStore from '../stores/AppStore';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 import {
     amber,
     blue,
@@ -392,5 +393,10 @@ export const toggleTheme = (radioGroupEvent) => {
     ReactGA.event({
         category: 'antalmanac-rewrite',
         action: 'toggle theme',
+    });
+    ReactGA4.event({
+        category: 'Navbar',
+        action: 'Toggle Theme',
+        label: radioGroupEvent.target.value,
     });
 };

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -1,8 +1,7 @@
 import dispatcher from '../dispatcher';
 import AppStore from '../stores/AppStore';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../analytics';
 import {
     amber,
     blue,
@@ -105,7 +104,7 @@ export const openSnackbar = (variant, message, duration, position, style) => {
 };
 
 export const saveSchedule = async (userID, rememberMe) => {
-    ReactGA4.event({
+    logAnalytics({
         category: analyticsEnum.nav.title,
         action: analyticsEnum.nav.actions.SAVE_SCHEDULE,
         label: userID,
@@ -160,7 +159,7 @@ export const saveSchedule = async (userID, rememberMe) => {
 };
 
 export const loadSchedule = async (userID, rememberMe) => {
-    ReactGA4.event({
+    logAnalytics({
         category: analyticsEnum.nav.title,
         action: analyticsEnum.nav.actions.LOAD_SCHEDULE,
         label: userID,
@@ -407,7 +406,7 @@ export const toggleTheme = (radioGroupEvent) => {
         category: 'antalmanac-rewrite',
         action: 'toggle theme',
     });
-    ReactGA4.event({
+    logAnalytics({
         category: analyticsEnum.nav.title,
         action: analyticsEnum.nav.actions.CHANGE_THEME,
         label: radioGroupEvent.target.value,

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -2,6 +2,7 @@ import dispatcher from '../dispatcher';
 import AppStore from '../stores/AppStore';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../analyticsEnum';
 import {
     amber,
     blue,
@@ -105,8 +106,8 @@ export const openSnackbar = (variant, message, duration, position, style) => {
 
 export const saveSchedule = async (userID, rememberMe) => {
     ReactGA4.event({
-        category: 'Navbar',
-        action: 'Save Schedule',
+        category: analyticsEnum.nav.title,
+        action: analyticsEnum.nav.actions.SAVE_SCHEDULE,
         label: userID,
         value: rememberMe,
     });
@@ -160,8 +161,8 @@ export const saveSchedule = async (userID, rememberMe) => {
 
 export const loadSchedule = async (userID, rememberMe) => {
     ReactGA4.event({
-        category: 'Navbar',
-        action: 'Load Schedule',
+        category: analyticsEnum.nav.title,
+        action: analyticsEnum.nav.actions.LOAD_SCHEDULE,
         label: userID,
         value: rememberMe,
     });
@@ -407,8 +408,8 @@ export const toggleTheme = (radioGroupEvent) => {
         action: 'toggle theme',
     });
     ReactGA4.event({
-        category: 'Navbar',
-        action: 'Toggle Theme',
+        category: analyticsEnum.nav.title,
+        action: analyticsEnum.nav.actions.CHANGE_THEME,
         label: radioGroupEvent.target.value,
     });
 };

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -28,7 +28,7 @@ const analyticsEnum = {
             CLICK_NOTIFICATIONS: 'Click Notifications',
             CLICK_ABOUT: 'Click About Page',
             CHANGE_THEME: 'Change Theme', // Label is the theme changed to
-            IMPORT_STUDY_LIST: 'Import Study List', // Value is percentage course imported
+            IMPORT_STUDY_LIST: 'Import Study List', // Value is the percentage of courses successfully imported (decimal value)
             LOAD_SCHEDULE: 'Load Schedule',
             SAVE_SCHEDULE: 'Save Schedule',
             CLICK_NEWS: 'Click News',

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -29,8 +29,8 @@ const analyticsEnum = {
             CLICK_ABOUT: 'Click About Page',
             CHANGE_THEME: 'Change Theme', // Label is the theme changed to
             IMPORT_STUDY_LIST: 'Import Study List', // Value is the percentage of courses successfully imported (decimal value)
-            LOAD_SCHEDULE: 'Load Schedule',
-            SAVE_SCHEDULE: 'Save Schedule',
+            LOAD_SCHEDULE: 'Load Schedule', // Value is 1 if the user checked "remember me", 0 otherwise
+            SAVE_SCHEDULE: 'Save Schedule', // Value is 1 if the user checked "remember me", 0 otherwise
             CLICK_NEWS: 'Click News',
         },
     },

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,3 +1,4 @@
+import ReactGA4 from 'react-ga4';
 /**
  * This is an enum that stores all the
  * possible category names and associated actions
@@ -36,3 +37,14 @@ const analyticsEnum = {
 };
 
 export default analyticsEnum;
+
+/**
+ * This is just a wrapper around ReactGA4.event so we don't have to import it everywhere
+ * @param {string} category required
+ * @param {string} action required
+ * @param {string} label optional
+ * @param {number} value optional
+ */
+export function logAnalytics({ category, action, label, value }) {
+    ReactGA4.event({ category, action, label, value });
+}

--- a/src/analyticsEnum.js
+++ b/src/analyticsEnum.js
@@ -3,7 +3,7 @@
  * possible category names and associated actions
  * for Google Analytics
  */
-export default {
+const analyticsEnum = {
     calendar: {
         title: 'Calendar Pane',
         actions: {
@@ -18,13 +18,14 @@ export default {
             DISPLAY_FINALS: 'Display Finals',
             CHANGE_SCHEDULE: 'Change Schedule',
             UNDO: 'Undo',
+            DOWNLOAD: 'Download Schedule',
         },
     },
     nav: {
         title: 'Navbar',
         actions: {
             CLICK_NOTIFICATIONS: 'Click Notifications',
-            VIEW_ABOUT: 'View About Page',
+            CLICK_ABOUT: 'Click About Page',
             CHANGE_THEME: 'Change Theme', // Label is the theme changed to
             IMPORT_STUDY_LIST: 'Import Study List', // Value is percentage course imported
             LOAD_SCHEDULE: 'Load Schedule',
@@ -33,3 +34,5 @@ export default {
         },
     },
 };
+
+export default analyticsEnum;

--- a/src/analyticsEnum.js
+++ b/src/analyticsEnum.js
@@ -1,0 +1,35 @@
+/**
+ * This is an enum that stores all the
+ * possible category names and associated actions
+ * for Google Analytics
+ */
+export default {
+    calendar: {
+        title: 'Calendar Pane',
+        actions: {
+            DELETE_COURSE: 'Delete Course',
+            CHANGE_COURSE_COLOR: 'Change Course Color',
+            COPY_COURSE_CODE: 'Copy Course Code',
+            CLICK_CUSTOM_EVENT: 'Click Custom Event Button',
+            ADD_CUSTOM_EVENT: 'Add Custom Event',
+            DELETE_CUSTOM_EVENT: 'Delete Custom Event',
+            SCREENSHOT: 'Screenshot',
+            CLEAR_SCHEDULE: 'Clear Schedule',
+            DISPLAY_FINALS: 'Display Finals',
+            CHANGE_SCHEDULE: 'Change Schedule',
+            UNDO: 'Undo',
+        },
+    },
+    nav: {
+        title: 'Navbar',
+        actions: {
+            CLICK_NOTIFICATIONS: 'Click Notifications',
+            VIEW_ABOUT: 'View About Page',
+            CHANGE_THEME: 'Change Theme', // Label is the theme changed to
+            IMPORT_STUDY_LIST: 'Import Study List', // Value is percentage course imported
+            LOAD_SCHEDULE: 'Load Schedule',
+            SAVE_SCHEDULE: 'Save Schedule',
+            CLICK_NEWS: 'Click News',
+        },
+    },
+};

--- a/src/components/App/AboutPage.js
+++ b/src/components/App/AboutPage.js
@@ -2,8 +2,7 @@ import React, { PureComponent } from 'react';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Link } from '@material-ui/core';
 import { Info } from '@material-ui/icons';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 class AboutPage extends PureComponent {
     state = {
@@ -19,7 +18,7 @@ class AboutPage extends PureComponent {
                             category: 'antalmanac-rewrite',
                             action: 'Click "About"',
                         });
-                        ReactGA4.event({
+                        logAnalytics({
                             category: analyticsEnum.nav.title,
                             action: analyticsEnum.nav.actions.CLICK_ABOUT,
                         });

--- a/src/components/App/AboutPage.js
+++ b/src/components/App/AboutPage.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Link } from '@material-ui/core';
 import { Info } from '@material-ui/icons';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 
 class AboutPage extends PureComponent {
     state = {
@@ -15,6 +16,10 @@ class AboutPage extends PureComponent {
                         this.setState({ isOpen: true });
                         ReactGA.event({
                             category: 'antalmanac-rewrite',
+                            action: 'Click "About"',
+                        });
+                        ReactGA4.event({
+                            category: 'Navbar',
                             action: 'Click "About"',
                         });
                     }}

--- a/src/components/App/AboutPage.js
+++ b/src/components/App/AboutPage.js
@@ -3,6 +3,7 @@ import { Button, Dialog, DialogActions, DialogContent, DialogContentText, Dialog
 import { Info } from '@material-ui/icons';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 class AboutPage extends PureComponent {
     state = {
@@ -19,8 +20,8 @@ class AboutPage extends PureComponent {
                             action: 'Click "About"',
                         });
                         ReactGA4.event({
-                            category: 'Navbar',
-                            action: 'Click "About"',
+                            category: analyticsEnum.nav.title,
+                            action: analyticsEnum.nav.actions.CLICK_ABOUT,
                         });
                     }}
                     color="inherit"

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import ReactGA from 'react-ga';
 import { undoDelete } from '../../actions/AppStoreActions';
@@ -36,7 +36,7 @@ class App extends PureComponent {
     }
 
     render() {
-        const theme = createMuiTheme({
+        const theme = createTheme({
             overrides: {
                 MuiCssBaseline: {
                     '@global': {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { createTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 import { undoDelete } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
@@ -29,6 +30,8 @@ class App extends PureComponent {
 
         ReactGA.initialize('UA-133683751-1');
         ReactGA.pageview('/homepage');
+        ReactGA4.initialize('G-30HVJXC2Y4');
+        ReactGA4.send('pageview');
     };
 
     componentWillUnmount() {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -30,7 +30,7 @@ class App extends PureComponent {
 
         ReactGA.initialize('UA-133683751-1');
         ReactGA.pageview('/homepage');
-        ReactGA4.initialize('G-TLR7V1NYRD');
+        ReactGA4.initialize('G-30HVJXC2Y4');
         ReactGA4.send('pageview');
     };
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -30,7 +30,7 @@ class App extends PureComponent {
 
         ReactGA.initialize('UA-133683751-1');
         ReactGA.pageview('/homepage');
-        ReactGA4.initialize('G-30HVJXC2Y4');
+        ReactGA4.initialize('G-TLR7V1NYRD');
         ReactGA4.send('pageview');
     };
 

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -6,8 +6,7 @@ import { SketchPicker } from 'react-color';
 import { changeCourseColor, changeCustomEventColor } from '../../actions/AppStoreActions';
 import { ColorLens } from '@material-ui/icons';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 class ColorPicker extends PureComponent {
     state = {
@@ -42,7 +41,7 @@ class ColorPicker extends PureComponent {
             category: 'antalmanac-rewrite',
             action: 'Change Course Color',
         });
-        ReactGA4.event({
+        logAnalytics({
             category: this.props.analyticsCategory || 'Right Pane',
             action: analyticsEnum.calendar.actions.CHANGE_COURSE_COLOR,
         });

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -7,6 +7,7 @@ import { changeCourseColor, changeCustomEventColor } from '../../actions/AppStor
 import { ColorLens } from '@material-ui/icons';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 class ColorPicker extends PureComponent {
     state = {
@@ -43,7 +44,7 @@ class ColorPicker extends PureComponent {
         });
         ReactGA4.event({
             category: this.props.analyticsCategory || 'Right Pane',
-            action: 'Change Course Color',
+            action: analyticsEnum.calendar.actions.CHANGE_COURSE_COLOR,
         });
     };
     updateColor = (color) => {

--- a/src/components/App/ColorPicker.js
+++ b/src/components/App/ColorPicker.js
@@ -6,6 +6,7 @@ import { SketchPicker } from 'react-color';
 import { changeCourseColor, changeCustomEventColor } from '../../actions/AppStoreActions';
 import { ColorLens } from '@material-ui/icons';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 
 class ColorPicker extends PureComponent {
     state = {
@@ -38,6 +39,10 @@ class ColorPicker extends PureComponent {
     handleColorChangeComplete = () => {
         ReactGA.event({
             category: 'antalmanac-rewrite',
+            action: 'Change Course Color',
+        });
+        ReactGA4.event({
+            category: this.props.analyticsCategory || 'Right Pane',
             action: 'Change Course Color',
         });
     };

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -17,6 +17,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
 import TermSelector from '../SearchForm/TermSelector';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 const styles = {
     inputLabel: {
@@ -85,8 +86,8 @@ class ImportStudyList extends PureComponent {
                         currSchedule
                     );
                     ReactGA4.event({
-                        category: 'Navbar',
-                        action: 'Import Study List',
+                        category: analyticsEnum.nav.title,
+                        action: analyticsEnum.nav.actions.IMPORT_STUDY_LIST,
                         value: sectionsAdded / (sectionCodes.length || 1),
                     });
                     if (sectionsAdded === sectionCodes.length) {

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -87,7 +87,7 @@ class ImportStudyList extends PureComponent {
                     ReactGA4.event({
                         category: 'Navbar',
                         action: 'Import Study List',
-                        value: sectionsAdded,
+                        value: sectionsAdded / (sectionCodes.length || 1),
                     });
                     if (sectionsAdded === sectionCodes.length) {
                         openSnackbar('success', `Successfully imported ${sectionsAdded} of ${sectionsAdded} classes!`);

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -16,8 +16,7 @@ import { PostAdd } from '@material-ui/icons';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
 import TermSelector from '../SearchForm/TermSelector';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 const styles = {
     inputLabel: {
@@ -85,7 +84,7 @@ class ImportStudyList extends PureComponent {
                         this.state.selectedTerm,
                         currSchedule
                     );
-                    ReactGA4.event({
+                    logAnalytics({
                         category: analyticsEnum.nav.title,
                         action: analyticsEnum.nav.actions.IMPORT_STUDY_LIST,
                         value: sectionsAdded / (sectionCodes.length || 1),

--- a/src/components/App/ImportStudyList.js
+++ b/src/components/App/ImportStudyList.js
@@ -16,6 +16,7 @@ import { PostAdd } from '@material-ui/icons';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
 import TermSelector from '../SearchForm/TermSelector';
+import ReactGA4 from 'react-ga4';
 
 const styles = {
     inputLabel: {
@@ -83,6 +84,11 @@ class ImportStudyList extends PureComponent {
                         this.state.selectedTerm,
                         currSchedule
                     );
+                    ReactGA4.event({
+                        category: 'Navbar',
+                        action: 'Import Study List',
+                        value: sectionsAdded,
+                    });
                     if (sectionsAdded === sectionCodes.length) {
                         openSnackbar('success', `Successfully imported ${sectionsAdded} of ${sectionsAdded} classes!`);
                     } else if (sectionsAdded !== 0) {

--- a/src/components/App/News.js
+++ b/src/components/App/News.js
@@ -142,7 +142,7 @@ class News extends PureComponent {
                 <Tooltip title="See latest updates">
                     <Badge
                         variant="dot"
-                        overlap="circle"
+                        overlap="circular"
                         color="error"
                         invisible={!this.state.showDot}
                         classes={{

--- a/src/components/App/News.js
+++ b/src/components/App/News.js
@@ -16,6 +16,7 @@ import { NEWS_ENDPOINT } from '../../api/endpoints';
 import { Skeleton } from '@material-ui/lab';
 import moment from 'moment-timezone';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 const styles = (theme) => ({
     list: {
@@ -125,8 +126,8 @@ class News extends PureComponent {
 
     openPopup = (e) => {
         ReactGA4.event({
-            category: 'Navbar',
-            action: 'Click "News"',
+            category: analyticsEnum.nav.title,
+            action: analyticsEnum.nav.actions.CLICK_NEWS,
         });
         this.setState({ anchorEl: e.currentTarget });
 

--- a/src/components/App/News.js
+++ b/src/components/App/News.js
@@ -15,8 +15,7 @@ import { RssFeed } from '@material-ui/icons';
 import { NEWS_ENDPOINT } from '../../api/endpoints';
 import { Skeleton } from '@material-ui/lab';
 import moment from 'moment-timezone';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 const styles = (theme) => ({
     list: {
@@ -125,7 +124,7 @@ class News extends PureComponent {
     };
 
     openPopup = (e) => {
-        ReactGA4.event({
+        logAnalytics({
             category: analyticsEnum.nav.title,
             action: analyticsEnum.nav.actions.CLICK_NEWS,
         });

--- a/src/components/App/News.js
+++ b/src/components/App/News.js
@@ -15,6 +15,7 @@ import { RssFeed } from '@material-ui/icons';
 import { NEWS_ENDPOINT } from '../../api/endpoints';
 import { Skeleton } from '@material-ui/lab';
 import moment from 'moment-timezone';
+import ReactGA4 from 'react-ga4';
 
 const styles = (theme) => ({
     list: {
@@ -123,6 +124,10 @@ class News extends PureComponent {
     };
 
     openPopup = (e) => {
+        ReactGA4.event({
+            category: 'Navbar',
+            action: 'Click "News"',
+        });
         this.setState({ anchorEl: e.currentTarget });
 
         if (typeof Storage !== 'undefined') {

--- a/src/components/App/NotificationHub.js
+++ b/src/components/App/NotificationHub.js
@@ -10,6 +10,7 @@ import {
 } from '@material-ui/core';
 import { Notifications } from '@material-ui/icons';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 import { LOOKUP_NOTIFICATIONS_ENDPOINT } from '../../api/endpoints';
 
 class NotificationHub extends PureComponent {
@@ -52,6 +53,10 @@ class NotificationHub extends PureComponent {
                             this.getNotificationLists();
                             ReactGA.event({
                                 category: 'antalmanac-rewrite',
+                                action: 'Click "Notifications"',
+                            });
+                            ReactGA4.event({
+                                category: 'Navbar',
                                 action: 'Click "Notifications"',
                             });
                         }}

--- a/src/components/App/NotificationHub.js
+++ b/src/components/App/NotificationHub.js
@@ -10,9 +10,8 @@ import {
 } from '@material-ui/core';
 import { Notifications } from '@material-ui/icons';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
 import { LOOKUP_NOTIFICATIONS_ENDPOINT } from '../../api/endpoints';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 class NotificationHub extends PureComponent {
     state = {
@@ -56,7 +55,7 @@ class NotificationHub extends PureComponent {
                                 category: 'antalmanac-rewrite',
                                 action: 'Click "Notifications"',
                             });
-                            ReactGA4.event({
+                            logAnalytics({
                                 category: analyticsEnum.nav.title,
                                 action: analyticsEnum.nav.actions.CLICK_NOTIFICATIONS,
                             });

--- a/src/components/App/NotificationHub.js
+++ b/src/components/App/NotificationHub.js
@@ -12,6 +12,7 @@ import { Notifications } from '@material-ui/icons';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import { LOOKUP_NOTIFICATIONS_ENDPOINT } from '../../api/endpoints';
+import analyticsEnum from '../../analyticsEnum';
 
 class NotificationHub extends PureComponent {
     state = {
@@ -56,8 +57,8 @@ class NotificationHub extends PureComponent {
                                 action: 'Click "Notifications"',
                             });
                             ReactGA4.event({
-                                category: 'Navbar',
-                                action: 'Click "Notifications"',
+                                category: analyticsEnum.nav.title,
+                                action: analyticsEnum.nav.actions.CLICK_NOTIFICATIONS,
                             });
                         }}
                         color="inherit"

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -13,6 +13,7 @@ import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import ConditionalWrapper from '../App/ConditionalWrapper';
+import analyticsEnum from '../../analyticsEnum';
 
 const styles = {
     toolbar: {
@@ -46,8 +47,8 @@ const CalendarPaneToolbar = (props) => {
 
     const handleScheduleChange = (event) => {
         ReactGA4.event({
-            category: 'Calendar Pane',
-            action: 'Change Schedule',
+            category: analyticsEnum.calendar.title,
+            action: analyticsEnum.calendar.actions.CHANGE_SCHEDULE,
         });
         changeCurrentSchedule(event.target.value);
     };
@@ -83,8 +84,8 @@ const CalendarPaneToolbar = (props) => {
                     variant={props.showFinalsSchedule ? 'contained' : 'outlined'}
                     onClick={() => {
                         ReactGA4.event({
-                            category: 'Calendar Pane',
-                            action: 'Display Finals',
+                            category: analyticsEnum.calendar.title,
+                            action: analyticsEnum.calendar.actions.DISPLAY_FINALS,
                         });
                         props.toggleDisplayFinalsSchedule();
                     }}
@@ -101,8 +102,8 @@ const CalendarPaneToolbar = (props) => {
                 <IconButton
                     onClick={() => {
                         ReactGA4.event({
-                            category: 'Calendar Pane',
-                            label: 'Click Undo Button',
+                            category: analyticsEnum.calendar.title,
+                            label: analyticsEnum.calendar.actions.UNDO,
                         });
                         undoDelete(null);
                     }}
@@ -126,8 +127,8 @@ const CalendarPaneToolbar = (props) => {
                                 label: 'Calendar Pane Toolbar',
                             });
                             ReactGA4.event({
-                                category: 'Calendar Pane',
-                                action: 'Click Clear Button',
+                                category: analyticsEnum.calendar.title,
+                                action: analyticsEnum.calendar.actions.CLEAR_SCHEDULE,
                             });
                         }
                     }}
@@ -155,8 +156,8 @@ const CalendarPaneToolbar = (props) => {
                     <ScreenshotButton
                         onTakeScreenshot={() => {
                             ReactGA4.event({
-                                category: 'Calendar Pane',
-                                action: 'Screenshot',
+                                category: analyticsEnum.calendar.title,
+                                action: analyticsEnum.calendar.actions.SCREENSHOT,
                             });
                             props.onTakeScreenshot();
                         }}

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -11,9 +11,8 @@ import ExportCalendar from './ExportCalendar';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
 import ConditionalWrapper from '../App/ConditionalWrapper';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 const styles = {
     toolbar: {
@@ -46,7 +45,7 @@ const CalendarPaneToolbar = (props) => {
     const { classes } = props;
 
     const handleScheduleChange = (event) => {
-        ReactGA4.event({
+        logAnalytics({
             category: analyticsEnum.calendar.title,
             action: analyticsEnum.calendar.actions.CHANGE_SCHEDULE,
         });
@@ -83,7 +82,7 @@ const CalendarPaneToolbar = (props) => {
                     id="finalButton"
                     variant={props.showFinalsSchedule ? 'contained' : 'outlined'}
                     onClick={() => {
-                        ReactGA4.event({
+                        logAnalytics({
                             category: analyticsEnum.calendar.title,
                             action: analyticsEnum.calendar.actions.DISPLAY_FINALS,
                         });
@@ -101,7 +100,7 @@ const CalendarPaneToolbar = (props) => {
             <Tooltip title="Undo last deleted course">
                 <IconButton
                     onClick={() => {
-                        ReactGA4.event({
+                        logAnalytics({
                             category: analyticsEnum.calendar.title,
                             label: analyticsEnum.calendar.actions.UNDO,
                         });
@@ -126,7 +125,7 @@ const CalendarPaneToolbar = (props) => {
                                 action: 'Click Clear button',
                                 label: 'Calendar Pane Toolbar',
                             });
-                            ReactGA4.event({
+                            logAnalytics({
                                 category: analyticsEnum.calendar.title,
                                 action: analyticsEnum.calendar.actions.CLEAR_SCHEDULE,
                             });
@@ -155,7 +154,7 @@ const CalendarPaneToolbar = (props) => {
                     <ExportCalendar />,
                     <ScreenshotButton
                         onTakeScreenshot={() => {
-                            ReactGA4.event({
+                            logAnalytics({
                                 category: analyticsEnum.calendar.title,
                                 action: analyticsEnum.calendar.actions.SCREENSHOT,
                             });

--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -11,6 +11,7 @@ import ExportCalendar from './ExportCalendar';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 import ConditionalWrapper from '../App/ConditionalWrapper';
 
 const styles = {
@@ -44,6 +45,10 @@ const CalendarPaneToolbar = (props) => {
     const { classes } = props;
 
     const handleScheduleChange = (event) => {
+        ReactGA4.event({
+            category: 'Calendar Pane',
+            action: 'Change Schedule',
+        });
         changeCurrentSchedule(event.target.value);
     };
 
@@ -76,7 +81,13 @@ const CalendarPaneToolbar = (props) => {
                 <Button
                     id="finalButton"
                     variant={props.showFinalsSchedule ? 'contained' : 'outlined'}
-                    onClick={props.toggleDisplayFinalsSchedule}
+                    onClick={() => {
+                        ReactGA4.event({
+                            category: 'Calendar Pane',
+                            action: 'Display Finals',
+                        });
+                        props.toggleDisplayFinalsSchedule();
+                    }}
                     size="small"
                     color={props.showFinalsSchedule ? 'primary' : 'default'}
                 >
@@ -87,7 +98,15 @@ const CalendarPaneToolbar = (props) => {
             <div className={classes.spacer} />
 
             <Tooltip title="Undo last deleted course">
-                <IconButton onClick={() => undoDelete(null)}>
+                <IconButton
+                    onClick={() => {
+                        ReactGA4.event({
+                            category: 'Calendar Pane',
+                            label: 'Click Undo Button',
+                        });
+                        undoDelete(null);
+                    }}
+                >
                     <Undo fontSize="small" />
                 </IconButton>
             </Tooltip>
@@ -105,6 +124,10 @@ const CalendarPaneToolbar = (props) => {
                                 category: 'antalmanac-rewrite',
                                 action: 'Click Clear button',
                                 label: 'Calendar Pane Toolbar',
+                            });
+                            ReactGA4.event({
+                                category: 'Calendar Pane',
+                                action: 'Click Clear Button',
                             });
                         }
                     }}
@@ -129,7 +152,15 @@ const CalendarPaneToolbar = (props) => {
             >
                 {[
                     <ExportCalendar />,
-                    <ScreenshotButton onTakeScreenshot={props.onTakeScreenshot} />,
+                    <ScreenshotButton
+                        onTakeScreenshot={() => {
+                            ReactGA4.event({
+                                category: 'Calendar Pane',
+                                action: 'Screenshot',
+                            });
+                            props.onTakeScreenshot();
+                        }}
+                    />,
                     <CustomEventsDialog editMode={false} currentScheduleIndex={props.currentScheduleIndex} />,
                 ].map((element, index) => (
                     <ConditionalWrapper

--- a/src/components/Calendar/CourseCalendarEvent.js
+++ b/src/components/Calendar/CourseCalendarEvent.js
@@ -10,8 +10,7 @@ import CustomEventDialog from '../CustomEvents/CustomEventDialog';
 import AppStore from '../../stores/AppStore';
 import { clickToCopy } from '../../helpers';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum.js';
+import analyticsEnum, { logAnalytics } from '../../analytics.js';
 
 const styles = {
     courseContainer: {
@@ -95,7 +94,7 @@ const CourseCalendarEvent = (props) => {
                                     action: 'Click Delete Course',
                                     label: 'Course Calendar Event',
                                 });
-                                ReactGA4.event({
+                                logAnalytics({
                                     category: analyticsEnum.calendar.title,
                                     action: analyticsEnum.calendar.actions.DELETE_COURSE,
                                 });
@@ -112,7 +111,7 @@ const CourseCalendarEvent = (props) => {
                             <Tooltip title="Click to copy course code" placement="right">
                                 <td
                                     onClick={(e) => {
-                                        ReactGA4.event({
+                                        logAnalytics({
                                             category: analyticsEnum.calendar.title,
                                             action: analyticsEnum.calendar.actions.COPY_COURSE_CODE,
                                         });
@@ -196,7 +195,7 @@ const CourseCalendarEvent = (props) => {
                                     action: 'Click Delete Custom Event',
                                     label: 'Course Calendar Event',
                                 });
-                                ReactGA4.event({
+                                logAnalytics({
                                     category: analyticsEnum.calendar.title,
                                     action: analyticsEnum.calendar.actions.DELETE_CUSTOM_EVENT,
                                 });

--- a/src/components/Calendar/CourseCalendarEvent.js
+++ b/src/components/Calendar/CourseCalendarEvent.js
@@ -11,6 +11,7 @@ import AppStore from '../../stores/AppStore';
 import { clickToCopy } from '../../helpers';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum.js';
 
 const styles = {
     courseContainer: {
@@ -95,8 +96,8 @@ const CourseCalendarEvent = (props) => {
                                     label: 'Course Calendar Event',
                                 });
                                 ReactGA4.event({
-                                    category: 'Calendar Pane',
-                                    action: 'Delete Course',
+                                    category: analyticsEnum.calendar.title,
+                                    action: analyticsEnum.calendar.actions.DELETE_COURSE,
                                 });
                             }}
                         >
@@ -112,8 +113,8 @@ const CourseCalendarEvent = (props) => {
                                 <td
                                     onClick={(e) => {
                                         ReactGA4.event({
-                                            category: 'Calendar Pane',
-                                            action: 'Copy Course Code',
+                                            category: analyticsEnum.calendar.title,
+                                            action: analyticsEnum.calendar.actions.COPY_COURSE_CODE,
                                         });
                                         clickToCopy(e, sectionCode);
                                     }}
@@ -156,7 +157,7 @@ const CourseCalendarEvent = (props) => {
                                     customEventID={courseInMoreInfo.customEventID}
                                     sectionCode={courseInMoreInfo.sectionCode}
                                     term={courseInMoreInfo.term}
-                                    analyticsCategory="Calendar Pane"
+                                    analyticsCategory={analyticsEnum.calendar.title}
                                 />
                             </td>
                         </tr>
@@ -175,7 +176,7 @@ const CourseCalendarEvent = (props) => {
                             color={courseInMoreInfo.color}
                             isCustomEvent={true}
                             customEventID={courseInMoreInfo.customEventID}
-                            analyticsCategory="Calendar Pane"
+                            analyticsCategory={analyticsEnum.calendar.title}
                         />
                     </div>
                     <CustomEventDialog
@@ -196,8 +197,8 @@ const CourseCalendarEvent = (props) => {
                                     label: 'Course Calendar Event',
                                 });
                                 ReactGA4.event({
-                                    category: 'Calendar Pane',
-                                    action: 'Click Delete Custom Event',
+                                    category: analyticsEnum.calendar.title,
+                                    action: analyticsEnum.calendar.actions.DELETE_CUSTOM_EVENT,
                                 });
                             }}
                         >

--- a/src/components/Calendar/CourseCalendarEvent.js
+++ b/src/components/Calendar/CourseCalendarEvent.js
@@ -10,6 +10,7 @@ import CustomEventDialog from '../CustomEvents/CustomEventDialog';
 import AppStore from '../../stores/AppStore';
 import { clickToCopy } from '../../helpers';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 
 const styles = {
     courseContainer: {
@@ -93,6 +94,10 @@ const CourseCalendarEvent = (props) => {
                                     action: 'Click Delete Course',
                                     label: 'Course Calendar Event',
                                 });
+                                ReactGA4.event({
+                                    category: 'Calendar Pane',
+                                    action: 'Delete Course',
+                                });
                             }}
                         >
                             <Delete fontSize="inherit" />
@@ -104,7 +109,16 @@ const CourseCalendarEvent = (props) => {
                         <tr>
                             <td className={classes.alignToTop}>Section code</td>
                             <Tooltip title="Click to copy course code" placement="right">
-                                <td onClick={(e) => clickToCopy(e, sectionCode)} className={classes.rightCells}>
+                                <td
+                                    onClick={(e) => {
+                                        ReactGA4.event({
+                                            category: 'Calendar Pane',
+                                            action: 'Copy Course Code',
+                                        });
+                                        clickToCopy(e, sectionCode);
+                                    }}
+                                    className={classes.rightCells}
+                                >
                                     <u>{sectionCode}</u>
                                 </td>
                             </Tooltip>
@@ -142,6 +156,7 @@ const CourseCalendarEvent = (props) => {
                                     customEventID={courseInMoreInfo.customEventID}
                                     sectionCode={courseInMoreInfo.sectionCode}
                                     term={courseInMoreInfo.term}
+                                    analyticsCategory="Calendar Pane"
                                 />
                             </td>
                         </tr>
@@ -160,6 +175,7 @@ const CourseCalendarEvent = (props) => {
                             color={courseInMoreInfo.color}
                             isCustomEvent={true}
                             customEventID={courseInMoreInfo.customEventID}
+                            analyticsCategory="Calendar Pane"
                         />
                     </div>
                     <CustomEventDialog
@@ -178,6 +194,10 @@ const CourseCalendarEvent = (props) => {
                                     category: 'antalmanac-rewrite',
                                     action: 'Click Delete Custom Event',
                                     label: 'Course Calendar Event',
+                                });
+                                ReactGA4.event({
+                                    category: 'Calendar Pane',
+                                    action: 'Click Delete Custom Event',
                                 });
                             }}
                         >

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -8,8 +8,7 @@ import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
 import { openSnackbar } from '../../actions/AppStoreActions';
 import { termData } from '../../termData';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 const quarterStartDates = termData
     .filter((term) => term.startDate !== undefined)
@@ -258,7 +257,7 @@ const exportCalendar = () => {
     // Convert the events into a vcalendar
     // Callback function triggers a download of the .ics file
     createEvents(events, (err, val) => {
-        ReactGA4.event({
+        logAnalytics({
             category: 'Calendar Pane',
             action: analyticsEnum.calendar.actions.DOWNLOAD,
         });

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -8,6 +8,7 @@ import { createEvents } from 'ics';
 import AppStore from '../../stores/AppStore';
 import { openSnackbar } from '../../actions/AppStoreActions';
 import { termData } from '../../termData';
+import ReactGA4 from 'react-ga4';
 
 // TODO(chase): support summer sessions
 const quarterStartDates = termData
@@ -247,6 +248,10 @@ class ExportCalendarButton extends PureComponent {
         // Convert the events into a vcalendar
         // Callback function triggers a download of the .ics file
         createEvents(events, (err, val) => {
+            ReactGA4.event({
+                category: 'Calendar Pane',
+                action: 'Download Schedule',
+            });
             if (!err) {
                 // Download the .ics file
                 var blob = new Blob([val], { type: 'text/plain;charset=utf-8' });

--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -9,6 +9,7 @@ import AppStore from '../../stores/AppStore';
 import { openSnackbar } from '../../actions/AppStoreActions';
 import { termData } from '../../termData';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 const quarterStartDates = termData
     .filter((term) => term.startDate !== undefined)
@@ -259,7 +260,7 @@ const exportCalendar = () => {
     createEvents(events, (err, val) => {
         ReactGA4.event({
             category: 'Calendar Pane',
-            action: 'Download Schedule',
+            action: analyticsEnum.calendar.actions.DOWNLOAD,
         });
         if (!err) {
             // Download the .ics file

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import { addCustomEvent, editCustomEvent } from '../../actions/AppStoreActions';
 import ScheduleSelector from './ScheduleSelector';
 import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 
 const styles = () => ({
     container: {
@@ -46,10 +47,18 @@ class CustomEventDialog extends PureComponent {
             category: 'antalmanac-rewrite',
             action: 'Click Custom Event button',
         });
+        ReactGA4.event({
+            category: 'Calendar Pane',
+            action: 'Click Custom Event Button',
+        });
     };
 
     handleClose = (cancel) => {
         if (!cancel) {
+            ReactGA4.event({
+                category: 'Calendar Pane',
+                action: 'Add Custom Event',
+            });
             if (this.props.onDialogClose) this.props.onDialogClose();
             this.handleAddToCalendar();
         }

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -18,8 +18,7 @@ import PropTypes from 'prop-types';
 import { addCustomEvent, editCustomEvent } from '../../actions/AppStoreActions';
 import ScheduleSelector from './ScheduleSelector';
 import ReactGA from 'react-ga';
-import ReactGA4 from 'react-ga4';
-import analyticsEnum from '../../analyticsEnum';
+import analyticsEnum, { logAnalytics } from '../../analytics';
 
 const styles = () => ({
     container: {
@@ -48,7 +47,7 @@ class CustomEventDialog extends PureComponent {
             category: 'antalmanac-rewrite',
             action: 'Click Custom Event button',
         });
-        ReactGA4.event({
+        logAnalytics({
             category: analyticsEnum.calendar.title,
             action: analyticsEnum.calendar.actions.CLICK_CUSTOM_EVENT,
         });
@@ -56,7 +55,7 @@ class CustomEventDialog extends PureComponent {
 
     handleClose = (cancel) => {
         if (!cancel) {
-            ReactGA4.event({
+            logAnalytics({
                 category: analyticsEnum.calendar.title,
                 action: analyticsEnum.calendar.actions.ADD_CUSTOM_EVENT,
             });

--- a/src/components/CustomEvents/CustomEventDialog.js
+++ b/src/components/CustomEvents/CustomEventDialog.js
@@ -19,6 +19,7 @@ import { addCustomEvent, editCustomEvent } from '../../actions/AppStoreActions';
 import ScheduleSelector from './ScheduleSelector';
 import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
+import analyticsEnum from '../../analyticsEnum';
 
 const styles = () => ({
     container: {
@@ -48,16 +49,16 @@ class CustomEventDialog extends PureComponent {
             action: 'Click Custom Event button',
         });
         ReactGA4.event({
-            category: 'Calendar Pane',
-            action: 'Click Custom Event Button',
+            category: analyticsEnum.calendar.title,
+            action: analyticsEnum.calendar.actions.CLICK_CUSTOM_EVENT,
         });
     };
 
     handleClose = (cancel) => {
         if (!cancel) {
             ReactGA4.event({
-                category: 'Calendar Pane',
-                action: 'Add Custom Event',
+                category: analyticsEnum.calendar.title,
+                action: analyticsEnum.calendar.actions.ADD_CUSTOM_EVENT,
             });
             if (this.props.onDialogClose) this.props.onDialogClose();
             this.handleAddToCalendar();

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import App from './components/App/App';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
 import { unregister } from './registerServiceWorker';
 import { SnackbarProvider } from 'notistack';
 // import whyDidYouRender from '@welldone-software/why-did-you-render';
@@ -11,7 +11,7 @@ import { SnackbarProvider } from 'notistack';
 //         trackAllPureComponents: true,
 //     });
 // // }
-const theme = createMuiTheme({
+const theme = createTheme({
     typography: {
         htmlFontSize: parseInt(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'), 10),
         fontSize: parseInt(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'), 10) * 0.9,


### PR DESCRIPTION
## Summary
Added the `react-ga4` library and added events according to this doc (view with UCI account): https://docs.google.com/document/d/1ik9cjG3RqQZuwZGgXtKnFsrXzr6BHm7vZ6vsvnyC9ds/edit?usp=sharing

## Test Plan
Opening a draft PR so I can deploy this and see if the dashboard actually receives events.
## Issues
Closes #337
## Future Followup (Optional)
- Add Right Pane events
- Eventually remove the GA v3 library, `react-ga`