### PR TITLE
Update fuzzy search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.6.3"
+                "websoc-fuzzy-search": "^0.7.1"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
@@ -21076,9 +21076,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
-            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.1.tgz",
+            "integrity": "sha512-UrJc4lyhTOneIwgt3fPOHh4Eu8aaoeXmbs0fV2S4KuGIvaU1RcxkPrSb/rzSx7JwV/KAf+FKoEC64jgezwKnGQ=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38000,9 +38000,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.6.3.tgz",
-            "integrity": "sha512-YBXvT+uNCIMviJu/N7Tw6fL/pGn9DKMfVTBE6B5Bnvd3f3Afgcve8CDUteIv05dw6Nfk5FBPcVPGOo0pwmZGUQ=="
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.1.tgz",
+            "integrity": "sha512-UrJc4lyhTOneIwgt3fPOHh4Eu8aaoeXmbs0fV2S4KuGIvaU1RcxkPrSb/rzSx7JwV/KAf+FKoEC64jgezwKnGQ=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.6.3"
+        "websoc-fuzzy-search": "^0.7.1"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -31,7 +31,6 @@ class FuzzySearch extends PureComponent {
     }
 
     doSearch = (value) => {
-        console.log(value);
         if (!value) return;
         const emoji = value.slice(0, 2);
         const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');


### PR DESCRIPTION
## Summary
* Update `websoc-fuzzy-search` to latest (0.7.1)
* Remove a `console.log()` debug statement introduced in #383

## Test Plan
1. Course numbers in the fuzzy-search dropdown are properly sorted (e.g. 53 is listed before 53L)
2. Searching a comma-delimited list of course numbers works properly and shows all courses in that list in the dropdown
3. Performing a fuzzy search no longer logs the search query to the console
