### PR TITLE
Manual Search mobile fixes

### DIFF
--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -31,7 +31,6 @@ class FuzzySearch extends PureComponent {
     }
 
     doSearch = (value) => {
-        console.log(value);
         if (!value) return;
         const emoji = value.slice(0, 2);
         const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -31,6 +31,7 @@ class FuzzySearch extends PureComponent {
     }
 
     doSearch = (value) => {
+        console.log(value);
         if (!value) return;
         const emoji = value.slice(0, 2);
         const ident = emoji === emojiMap.INSTRUCTOR ? value.slice(3) : value.slice(3).split(':');
@@ -151,7 +152,7 @@ class FuzzySearch extends PureComponent {
                 style={{ width: '100%' }}
                 options={Object.keys(this.state.results)}
                 renderInput={(params) => (
-                    <TextField {...params} inputRef={(input) => input && input.focus()} fullWidth label={'Search'} />
+                    <TextField {...params} inputRef={(input) => input} fullWidth label={'Search'} />
                 )}
                 filterOptions={this.filterOptions}
                 getOptionLabel={this.getOptionLabel}


### PR DESCRIPTION
## Summary
Currently manual search does not work on mobile because the fuzzy search bar doesn't lose focus properly—this PR (hopefully) resolves that issue.

## Test Plan
1. Test on mobile that manual search works again (requires deploy)

## Issues
![image](https://user-images.githubusercontent.com/89349085/166123382-3505b1a6-1682-48ac-a04c-382bdeee0949.png)
