### PR TITLE
Update websoc-fuzzy-search to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,13 +36,22 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.7.1"
+                "websoc-fuzzy-search": "^0.7.2"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
                 "husky": "^4.3.6",
                 "lint-staged": "^10.5.3",
                 "prettier": "^2.2.1"
+            }
+        },
+        "../websoc-fuzzy-search": {
+            "version": "0.7.2",
+            "extraneous": true,
+            "license": "MIT",
+            "devDependencies": {
+                "prettier": "^2.6.2",
+                "typescript": "^4.6.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -21076,9 +21085,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.1.tgz",
-            "integrity": "sha512-UrJc4lyhTOneIwgt3fPOHh4Eu8aaoeXmbs0fV2S4KuGIvaU1RcxkPrSb/rzSx7JwV/KAf+FKoEC64jgezwKnGQ=="
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.2.tgz",
+            "integrity": "sha512-D9NqnIURfdxhJ4kJlq/aTNF0Vari84AYDXsUhnHG+x+cMXkP0i0ZpR/XmqkTMQR74VszSzSkH6JBaOvqGK4TRw=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38000,9 +38009,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.1.tgz",
-            "integrity": "sha512-UrJc4lyhTOneIwgt3fPOHh4Eu8aaoeXmbs0fV2S4KuGIvaU1RcxkPrSb/rzSx7JwV/KAf+FKoEC64jgezwKnGQ=="
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.2.tgz",
+            "integrity": "sha512-D9NqnIURfdxhJ4kJlq/aTNF0Vari84AYDXsUhnHG+x+cMXkP0i0ZpR/XmqkTMQR74VszSzSkH6JBaOvqGK4TRw=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.7.1"
+        "websoc-fuzzy-search": "^0.7.2"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",


### PR DESCRIPTION
## Summary
Bump to latest version of websoc-fuzzy-search to resolve issue related to departments with non-alpha characters.

## Test Plan
- Verify that the department issue is resolved

## Issues
https://github.com/icssc/websoc-fuzzy-search/issues/6

