### PR TITLE
Add space between times

### DIFF
--- a/src/components/SectionTable/SectionTableBody.js
+++ b/src/components/SectionTable/SectionTableBody.js
@@ -246,9 +246,10 @@ const DayAndTimeCell = withStyles(styles)((props) => {
 
     return (
         <NoPaddingTableCell className={classes.cell}>
-            {meetings.map((meeting) => (
-                <div key={meeting.days + meeting.time + meeting.bldg}>{`${meeting.days} ${meeting.time}`}</div>
-            ))}
+            {meetings.map((meeting) => {
+                const timeString = meeting.time.replace(/\s/g, '').split('-').join(' - ');
+                return <div key={meeting.days + meeting.time + meeting.bldg}>{`${meeting.days} ${timeString}`}</div>;
+            })}
         </NoPaddingTableCell>
     );
 });


### PR DESCRIPTION
## Summary
![image](https://user-images.githubusercontent.com/53128285/166157402-1aa504f5-54eb-4b20-aeaa-4f18c7430e70.png)
Ever since I noticed this it has bothered me. I only changed how the text is displayed, the underlying data structure is untouched.

## Test Plan
![image](https://user-images.githubusercontent.com/53128285/166157536-73f4c83e-e2e1-4383-8651-61a822800b61.png)
Shows up in both class search and added classes section. Couldn't find a class with a TBA time but I don't see how what I did would mess that up.

## Notes
The string before for meeting time before was padded to two characters (e. g. `_9:00` assuming `_` is the space) which adds a space only for one digit hours. This means there are technically two spaces in between `${meeting.days}` and `${meeting.time}` if the time was 1 digit, however for some reason HTML(?) turns multiple spaces into one? This is why there was no issue with double spaces between the weekdays and time.