### PR TITLE
Update websoc-fuzzy-search to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.7.2"
+                "websoc-fuzzy-search": "^0.7.3"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
@@ -21091,9 +21091,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.2.tgz",
-            "integrity": "sha512-D9NqnIURfdxhJ4kJlq/aTNF0Vari84AYDXsUhnHG+x+cMXkP0i0ZpR/XmqkTMQR74VszSzSkH6JBaOvqGK4TRw=="
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.3.tgz",
+            "integrity": "sha512-Usd7UYE4vKxrZpT+/dm8Az1THfcBlWKpWgan0DlT2JZdwPoMLe+dAjHnJJFy/4guaQd9agePSGE8tcQA8jZZ/A=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38020,9 +38020,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.2.tgz",
-            "integrity": "sha512-D9NqnIURfdxhJ4kJlq/aTNF0Vari84AYDXsUhnHG+x+cMXkP0i0ZpR/XmqkTMQR74VszSzSkH6JBaOvqGK4TRw=="
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.3.tgz",
+            "integrity": "sha512-Usd7UYE4vKxrZpT+/dm8Az1THfcBlWKpWgan0DlT2JZdwPoMLe+dAjHnJJFy/4guaQd9agePSGE8tcQA8jZZ/A=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.7.2"
+        "websoc-fuzzy-search": "^0.7.3"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",


### PR DESCRIPTION
## Summary
Update to the latest version of websoc-fuzzy-search, which resolves a regression introduced in v0.7.2 and unaddressed bugs from prior versions.

## Test Plan
* Verify that searching for course numbers with and without spaces return the correct results
* Verify that departments which have a substring alias (e.g. `bio` → `BIO SCI`) return the correct results when searching using the alias and the department code

## Future Followup (Optional)
Automate this process in the future?
