### PR TITLE
Fix screenshot bug

### DIFF
--- a/src/components/Calendar/CalendarPaneToolbar.js
+++ b/src/components/Calendar/CalendarPaneToolbar.js
@@ -153,12 +153,12 @@ const CalendarPaneToolbar = (props) => {
                 {[
                     <ExportCalendar />,
                     <ScreenshotButton
-                        onTakeScreenshot={() => {
+                        onTakeScreenshot={(handleClick) => {
                             logAnalytics({
                                 category: analyticsEnum.calendar.title,
                                 action: analyticsEnum.calendar.actions.SCREENSHOT,
                             });
-                            props.onTakeScreenshot();
+                            props.onTakeScreenshot(handleClick);
                         }}
                     />,
                     <CustomEventsDialog editMode={false} currentScheduleIndex={props.currentScheduleIndex} />,


### PR DESCRIPTION
## Summary
Screenshots were broken in f19cb89308ee50878a5b3e8b3109627896729305.  
The arrow function needed to take a parameter to pass to `onTakeScreenshot`

## Test Plan
- Screenshot on desktop and iOS simulator. 
- Verify that both download successfully

