### PR TITLE
Highlight first entry in autocomplete

### DIFF
--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -22,14 +22,6 @@ class FuzzySearch extends PureComponent {
         value: '',
     };
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        if (!prevState.open && this.state.open) {
-            document.addEventListener('keydown', this.enterEvent, false);
-        } else if (prevState.open && !this.state.open) {
-            document.removeEventListener('keydown', this.enterEvent, false);
-        }
-    }
-
     doSearch = (value) => {
         if (!value) return;
         const emoji = value.slice(0, 2);
@@ -78,14 +70,6 @@ class FuzzySearch extends PureComponent {
                 break;
         }
         this.props.toggleSearch();
-    };
-
-    enterEvent = (event) => {
-        if (event.key === 'Enter') {
-            event.preventDefault();
-            this.onClose();
-            this.doSearch(this.getOptionLabel(Object.keys(this.state.results)[0]));
-        }
     };
 
     filterOptions = (options) => options;
@@ -153,6 +137,7 @@ class FuzzySearch extends PureComponent {
                 renderInput={(params) => (
                     <TextField {...params} inputRef={(input) => input} fullWidth label={'Search'} />
                 )}
+                autoHighlight={true}
                 filterOptions={this.filterOptions}
                 getOptionLabel={this.getOptionLabel}
                 getOptionSelected={this.getOptionSelected}
@@ -162,7 +147,6 @@ class FuzzySearch extends PureComponent {
                 onInputChange={this.onInputChange}
                 open={this.state.open}
                 popupIcon={''}
-                autoHighlight={true}
             />
         );
     }

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -162,6 +162,7 @@ class FuzzySearch extends PureComponent {
                 onInputChange={this.onInputChange}
                 open={this.state.open}
                 popupIcon={''}
+                autoHighlight={true}
             />
         );
     }


### PR DESCRIPTION
## Summary
Automatically select the first entry in the autocomplete drop down as it (in my opinion) conveys the functionality more accurately and also removes the need to double down arrow to effectively move only one entry down. Prop from https://mui.com/material-ui/api/autocomplete/#props. 

## Test Plan
![image](https://user-images.githubusercontent.com/53128285/166346222-2aca2fda-f510-4865-aa73-8bdb7f83cd4a.png)

