### PR TITLE
Update websoc-fuzzy-search to 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.7.3"
+                "websoc-fuzzy-search": "^0.7.4"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
@@ -21091,9 +21091,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.3.tgz",
-            "integrity": "sha512-Usd7UYE4vKxrZpT+/dm8Az1THfcBlWKpWgan0DlT2JZdwPoMLe+dAjHnJJFy/4guaQd9agePSGE8tcQA8jZZ/A=="
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.4.tgz",
+            "integrity": "sha512-YAXSLHNhxhFCK2WdmH2IwkHsVr27bae15+xhlR7/mfLgD+Ya7fLmWsQ8oAogRqSIYHhW3VenHG9Ofo6f1sLmPA=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38020,9 +38020,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.3.tgz",
-            "integrity": "sha512-Usd7UYE4vKxrZpT+/dm8Az1THfcBlWKpWgan0DlT2JZdwPoMLe+dAjHnJJFy/4guaQd9agePSGE8tcQA8jZZ/A=="
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.4.tgz",
+            "integrity": "sha512-YAXSLHNhxhFCK2WdmH2IwkHsVr27bae15+xhlR7/mfLgD+Ya7fLmWsQ8oAogRqSIYHhW3VenHG9Ofo6f1sLmPA=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.7.3"
+        "websoc-fuzzy-search": "^0.7.4"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",


### PR DESCRIPTION
## Summary
Update to the latest version of websoc-fuzzy-search, which fixes issues with searching suffixed course numbers without departments and hyphenated instructor names.

## Test Plan
1. Verify that searching for course numbers with a suffix and no department name returns all courses with that number (e.g. "143a" returns CS 143A etc.)
2. Verify that searching for instructors with hyphenated names works regardless of whether the hyphen is present (e.g. "wongma", "wong-ma", "wong ma" all return Prof. Wong-Ma)