### PR TITLE
Add saving and loading of named schedules from backend

### DIFF
--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -128,8 +128,9 @@ export const saveSchedule = async (userID, rememberMe) => {
 
             const addedCourses = AppStore.getAddedCourses();
             const customEvents = AppStore.getCustomEvents();
+            const scheduleNames = AppStore.getScheduleNames();
 
-            const userData = { addedCourses: [], customEvents: customEvents };
+            const userData = { addedCourses: [], scheduleNames: scheduleNames, customEvents: customEvents };
 
             userData.addedCourses = addedCourses.map((course) => {
                 return {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,6 +48,7 @@ export async function getCoursesData(userData) {
     }
     return {
         addedCourses: addedCourses,
+        scheduleNames: userData.scheduleNames,
         customEvents: userData.customEvents,
     };
 }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -196,8 +196,8 @@ class AppStore extends EventEmitter {
                 break;
             case 'LOAD_SCHEDULE':
                 // If the user already had schedules, load up four schedules
-                this.scheduleNames = ['Schedule 1', 'Schedule 2', 'Schedule 3', 'Schedule 4'];
                 this.addedCourses = action.userData.addedCourses;
+                this.scheduleNames = action.userData.scheduleNames;
                 this.updateAddedSectionCodes();
                 this.customEvents = action.userData.customEvents;
                 this.finalsEventsInCalendar = calendarizeFinals();


### PR DESCRIPTION
## Summary
Load schedule names from backend instead of creating them by default from frontend. In conjunction with https://github.com/icssc/antalmanac-backend/pull/8

## Test Plan
Tested renaming, then saving and loading schedules which works.

## Issues
The backend is deployed on the dev stack for testing, but not yet on main. This branch shouldn't be merged into main  until I deploy to the changes to main.
