### PR TITLE
Set notification term to default term

### DIFF
--- a/src/components/SectionTable/SectionTableBody.js
+++ b/src/components/SectionTable/SectionTableBody.js
@@ -11,6 +11,7 @@ import AppStore from '../../stores/AppStore';
 import { ColorAndDelete, ScheduleAddCell } from './SectionTableButtons';
 import classNames from 'classnames';
 import { clickToCopy, isDarkMode } from '../../helpers';
+import { defaultTerm, termData } from '../../termData';
 
 const styles = (theme) => ({
     popover: {
@@ -257,7 +258,7 @@ const DayAndTimeCell = withStyles(styles)((props) => {
 const StatusCell = withStyles(styles)((props) => {
     const { sectionCode, term, courseTitle, courseNumber, status, classes } = props;
 
-    if (term === '2022 Spring' && (status === 'NewOnly' || status === 'FULL')) {
+    if (term === termData[defaultTerm].shortName && (status === 'NewOnly' || status === 'FULL')) {
         return (
             <NoPaddingTableCell className={`${classes[status.toLowerCase()]} ${classes.cell}`}>
                 <OpenSpotAlertPopover


### PR DESCRIPTION
## Summary
We only allow notification signups for the current term. Previously, we hardcoded the term. This PR takes advantage of defaultTerm/termData, so that the notification signups automatically get updated. 

## Test Plan
- Search for ics classes under Fall 2022.
- Verify that user can sign up for notifications.
- Search for ics classes under Spring 2022.
- Verify that users can **not** sign up for notifications. 

## Future Follow Up
Thoughts on creating a `getDefaultTerm()` function that simply returns `termData[defaultTerm]`? Seems like a common use case and it feels more clear/explicit than keying termData. [RightPaneStore](https://github.com/icssc/AntAlmanac/blob/d0672434018b548e00f2c70b20d460b966f212ee/src/stores/RightPaneStore.js#L9) also does this. Might be a good fellowship task!