### PR TITLE
Fixed crash when attempting to filter by GE's

### DIFF
--- a/src/components/CoursePane/CourseRenderPane.js
+++ b/src/components/CoursePane/CourseRenderPane.js
@@ -106,7 +106,13 @@ const SectionTableWrapped = (index, data) => {
         );
     } else if (formData.ge !== 'ANY') {
         component = (
-            <GeDataFetchProvider term={formData.term} courseDetails={courseData[index]} colorAndDelete={false} />
+            <GeDataFetchProvider
+                term={formData.term}
+                courseDetails={courseData[index]}
+                colorAndDelete={false}
+                highlightAdded={true}
+                scheduleNames={scheduleNames}
+            />
         );
     } else {
         component = (


### PR DESCRIPTION
When filtering by GE in the manual search form, AntAlmanac crashes and displays a blank white screen. I was able to pinpoint that the issue occurred because the `SectionTableWrapped` component renders differently based on whether the GE field is specified or not:
```js
// CourseRenderPane.js:107
} else if (formData.ge !== 'ANY') {
    component = (
        <GeDataFetchProvider {…} />
    );
} else {
    component = (
        <SectionTable {…} />
    );
}
```
After looking inside the `GeDataFetchProvider` component I noticed it uses a `SectionTable` internally, and passes the props down through `{...this.props}`. The issue here is that the GeDataFetchProvider wasn’t supplied two of the necessary props for SectionTable: `highlightAdded` and `scheduleNames`! The lack of `scheduleNames` in particular was causing the crash.

To fix this, I added `highlightAdded={true}` and `scheduleNames={scheduleNames}` to the props for the GeDataFetchProvider. I made highlightAdded true since in this case, the user is searching for courses (which means the courses already added should be highlighted).