### PR TITLE
Fix esc/backspace conflict w/ notification signup

### DIFF
--- a/src/components/CoursePane/RightPane.js
+++ b/src/components/CoursePane/RightPane.js
@@ -24,7 +24,10 @@ class RightPane extends PureComponent {
     };
 
     returnToSearchBarEvent = (event) => {
-        if (event.key === 'Backspace' || event.key === 'Escape') {
+        if (
+            !(RightPaneStore.getDoDisplaySearch() || RightPaneStore.getOpenSpotAlertPopoverActive()) &&
+            (event.key === 'Backspace' || event.key === 'Escape')
+        ) {
             event.preventDefault();
             dispatcher.dispatch({
                 type: 'TOGGLE_SEARCH',
@@ -33,12 +36,12 @@ class RightPane extends PureComponent {
         }
     };
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        (RightPaneStore.getDoDisplaySearch() ? document.removeEventListener : document.addEventListener)(
-            'keydown',
-            this.returnToSearchBarEvent,
-            false
-        );
+    componentDidMount() {
+        document.addEventListener('keydown', this.returnToSearchBarEvent, false);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.returnToSearchBarEvent, false);
     }
 
     refreshSearch = () => {

--- a/src/components/SectionTable/OpenSpotAlertPopover.js
+++ b/src/components/SectionTable/OpenSpotAlertPopover.js
@@ -5,6 +5,7 @@ import InputMask from 'react-input-mask';
 import { Button, Popover, TextField, Typography } from '@material-ui/core';
 import { openSnackbar } from '../../actions/AppStoreActions';
 import { REGISTER_NOTIFICATIONS_ENDPOINT } from '../../api/endpoints';
+import dispatcher from '../../dispatcher';
 
 const phoneNumberRegex = RegExp(/\d{10}/);
 
@@ -26,6 +27,17 @@ class OpenSpotAlertPopover extends PureComponent {
         invalidInput: false,
         invalidInputMessage: '',
     };
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (
+            (!prevState.anchorElement && this.state.anchorElement) ||
+            (prevState.anchorElement && !this.state.anchorElement)
+        ) {
+            dispatcher.dispatch({
+                type: 'TOGGLE_OPEN_SPOT_ALERT',
+            });
+        }
+    }
 
     handlePhoneNumberChange = (event) => {
         this.setState({ phoneNumber: event.target.value });

--- a/src/stores/RightPaneStore.js
+++ b/src/stores/RightPaneStore.js
@@ -25,6 +25,7 @@ class RightPaneStore extends EventEmitter {
         this.formData = defaultFormValues;
         this.activeTab = 0;
         this.doDisplaySearch = true;
+        this.openSpotAlertPopoverActive = false;
     }
 
     getFormData() {
@@ -37,6 +38,10 @@ class RightPaneStore extends EventEmitter {
 
     getDoDisplaySearch() {
         return this.doDisplaySearch;
+    }
+
+    getOpenSpotAlertPopoverActive() {
+        return this.openSpotAlertPopoverActive;
     }
 
     handleActions(action) {
@@ -56,6 +61,9 @@ class RightPaneStore extends EventEmitter {
             case 'TOGGLE_SEARCH':
                 this.doDisplaySearch = !this.doDisplaySearch;
                 // this.emit('searchToggle');
+                break;
+            case 'TOGGLE_OPEN_SPOT_ALERT':
+                this.openSpotAlertPopoverActive = !this.openSpotAlertPopoverActive;
                 break;
             default: //do nothing
         }


### PR DESCRIPTION
## Summary
Ensure that the keyboard shortcuts to send the user back to the search form triggers if and only if the search form is open and there are no notification signup popups open. This is done by making the `keydown` event listener persistent, with an additional condition in the event function itself determining whether to trigger the event.

Needs deployment first for testing on mobile.

## Test Plan
1. Verify that escape/backspace works in the course view, with no notification signup popups open
2. Verify that with a notification signup popup open, backspace allows the user to delete their phone number without sending them back to the search form
3. Verify that with a notification signup popup open, escape sends the user back to the search form

## Issues
Closes #379.
