### PR TITLE
Calendar export: added PST timezone information to events

### DIFF
--- a/src/components/Calendar/ExportCalendar.js
+++ b/src/components/Calendar/ExportCalendar.js
@@ -262,10 +262,14 @@ const exportCalendar = () => {
             action: analyticsEnum.calendar.actions.DOWNLOAD,
         });
         if (!err) {
+            // Add timezone information to start and end times for events
+            const icsString = val
+                .replaceAll('DTSTART', 'DTSTART;TZID=America/Los_Angeles')
+                .replaceAll('DTEND', 'DTEND;TZID=America/Los_Angeles');
             // Download the .ics file
             saveAs(
                 // inject the VTIMEZONE section into the .ics file
-                new Blob([val.replace('BEGIN:VEVENT', vTimeZoneSection)], { type: 'text/plain;charset=utf-8' }),
+                new Blob([icsString.replace('BEGIN:VEVENT', vTimeZoneSection)], { type: 'text/plain;charset=utf-8' }),
                 'schedule.ics'
             );
             openSnackbar('success', 'Schedule downloaded!', 5);


### PR DESCRIPTION
## Summary
Currently our calendar events don’t have any timezone-specific information associated with them (otherwise known as “floating datetimes”). This doesn’t seem to be an issue when importing the ICS file into Google Calendar (since you can choose a timezone for the calendar itself), but when importing into iCloud calendar, the events begin and end at the same time of day no matter what timezone you’re in (I actually noticed this issue when sharing my calendar with my brother, who’s in a different timezone).

Now events will include the `America/Los_Angeles` timezone in their `DTSTART` and `DTEND` fields. I chose to go this route instead of adjusting the timezone to UTC and processing it through the ics library because converting it to UTC would remove any Daylight Savings related info from it.

## Test Plan
I tested out adding exported schedules to both my iCloud and Google calendars before and after the change, and simulating multiple timezones. The new changes properly adjust for different timezones and account for Daylight Savings time too.