### PR TITLE
Update websoc-fuzzy-search to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,22 +37,13 @@
                 "react-router-dom": "^6.2.1",
                 "react-scripts": "^3.4.1",
                 "recharts": "^1.8.5",
-                "websoc-fuzzy-search": "^0.7.4"
+                "websoc-fuzzy-search": "^0.8.1"
             },
             "devDependencies": {
                 "gh-pages": "^3.2.3",
                 "husky": "^4.3.6",
                 "lint-staged": "^10.5.3",
                 "prettier": "^2.2.1"
-            }
-        },
-        "../websoc-fuzzy-search": {
-            "version": "0.7.2",
-            "extraneous": true,
-            "license": "MIT",
-            "devDependencies": {
-                "prettier": "^2.6.2",
-                "typescript": "^4.6.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -21091,9 +21082,9 @@
             }
         },
         "node_modules/websoc-fuzzy-search": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.4.tgz",
-            "integrity": "sha512-YAXSLHNhxhFCK2WdmH2IwkHsVr27bae15+xhlR7/mfLgD+Ya7fLmWsQ8oAogRqSIYHhW3VenHG9Ofo6f1sLmPA=="
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.8.1.tgz",
+            "integrity": "sha512-Iwj2Z4f82fwFXRPEo9GGc6foKcMagzzcwFqpyUremBLXUK/foEuWcDVWHRU4TqSiXYV4YV5z5N1PZk8w4cuNrw=="
         },
         "node_modules/websocket-driver": {
             "version": "0.6.5",
@@ -38020,9 +38011,9 @@
             }
         },
         "websoc-fuzzy-search": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.7.4.tgz",
-            "integrity": "sha512-YAXSLHNhxhFCK2WdmH2IwkHsVr27bae15+xhlR7/mfLgD+Ya7fLmWsQ8oAogRqSIYHhW3VenHG9Ofo6f1sLmPA=="
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/websoc-fuzzy-search/-/websoc-fuzzy-search-0.8.1.tgz",
+            "integrity": "sha512-Iwj2Z4f82fwFXRPEo9GGc6foKcMagzzcwFqpyUremBLXUK/foEuWcDVWHRU4TqSiXYV4YV5z5N1PZk8w4cuNrw=="
         },
         "websocket-driver": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^3.4.1",
         "recharts": "^1.8.5",
-        "websoc-fuzzy-search": "^0.7.4"
+        "websoc-fuzzy-search": "^0.8.1"
     },
     "devDependencies": {
         "gh-pages": "^3.2.3",

--- a/src/components/SearchForm/FuzzySearch.js
+++ b/src/components/SearchForm/FuzzySearch.js
@@ -48,7 +48,7 @@ class FuzzySearch extends PureComponent {
                     }
                 }
                 if (!deptLabel) {
-                    const deptSearch = search(deptValue.toLowerCase());
+                    const deptSearch = search({ query: deptValue.toLowerCase(), numResults: 1 });
                     deptLabel = deptSearch[deptValue].name;
                     this.setState({
                         cache: {
@@ -107,18 +107,19 @@ class FuzzySearch extends PureComponent {
             this.setState(
                 { open: value.length >= 2, value: value.slice(-1) === ' ' ? value.slice(0, -1) : value },
                 () => {
+                    if (value.length < 2) return;
                     if (this.state.cache[this.state.value]) {
                         this.setState({ results: this.state.cache[this.state.value] });
                     } else {
                         try {
-                            const result = search(this.state.value);
+                            const result = search({ query: this.state.value, numResults: 10 });
                             this.setState({
                                 cache: { ...this.state.cache, [this.state.value]: result },
                                 results: result,
                             });
                         } catch (e) {
                             this.setState({ results: {} });
-                            if (!(e instanceof TypeError)) console.error(e);
+                            console.error(e);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Update to the latest version of websoc-fuzzy-search, which implements better searching for GEs and actually returns the requested number of entries (why 0.8.0 got skipped over).

This version also has the new writing course numbers in the index thanks to Eric (see icssc/websoc-fuzzy-search#15 for more details), which does break any queries with the old pre-Fall 2022 course numbers, but should be fine.

## Test Plan
1. Verify that searches for a GE category returns that category and all courses that fulfill it.
2. Verify that the fuzzy search dropdown has a maximum of 10 entries, instead of 9.
3. Verify that all other functionality still works as intended.

## Future Followup
Put out a proper release over summer (or whenever the catalogue updates) so the manual changes aren't just a stopgap.
