### PR TITLE
Add "Closes #" to issue section, comment out Future Followup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,8 @@
 ## Test Plan
 
 ## Issues
+Closes # 
 
-## Future Followup (Optional)
+<!-- [Optional]
+## Future Followup  
+-->


### PR DESCRIPTION
## Summary
- Adding "Closes # "
People forget this a lot.
Without the "Closes # " before the issue number, it doesn't get closed with the PR

- Comment out Future Followup
This usually isn't necessary so this comment hides it from being rendered by default.
If they want to add a future followup, they can just delete the arrows.

## Test Plan
Verify this looks good: https://github.com/icssc/AntAlmanac/blob/165793b50516aef5d633edad7cd996de47752ab4/.github/pull_request_template.md