### PR TITLE
Change cursor hover color in darkmode

### DIFF
--- a/src/components/SectionTable/SectionTableBody.js
+++ b/src/components/SectionTable/SectionTableBody.js
@@ -22,7 +22,7 @@ const styles = (theme) => ({
         display: 'inline-block',
         cursor: 'pointer',
         '&:hover': {
-            color: 'blueviolet',
+            color: isDarkMode() ? 'gold' : 'blueviolet',
             cursor: 'pointer',
         },
     },


### PR DESCRIPTION
## Summary
Change the color of cursor hover in table section body from blue violent to gold for better visibility. 

## Test Plan
- Verified that the color changes work in localhost. 

## Issues
Closes #354 