### PR TITLE
add file to remove commits from git blame.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# this file makes your git blame ignore certain commits.
+# it works with IDE features built on top of git blame like VSCode's GitLens extension (highly recommended)
+# to activate it: git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+# move /client folder to root
+d84844586d7789e8fe95f98eb9c7a8eccdf0b53b
+
+# run linter on entire project
+ca961ea5639dc3bdf9a9b9880c94ee6bb3ba7f01


### PR DESCRIPTION
## Summary
I use the GitLens extension to see who authored certain lines or functions and read the commit messages to make it easier to understand parts of our codebase. Under the hood, the extension uses `git blame`, which has a feature that lets you ignore commits. This is useful for ignoring commits like formatting or renaming files. I'll update and merge this once #411 (TypeScript rewrite) is done and merged to include the squashed commit converting all the code to TS, but I just wanted to make the team aware of this neat feature and see if there are any commits you guys want to add to the exclusion list.

## Future Followup  
If we do any large changes that aren't useful when inspecting the history, put their commit hashes in this file and write a comment describing the commit.