### PR TITLE
Fix RightPaneStore bugs without making everything static

### DIFF
--- a/src/components/RightPane/CoursePane/SearchForm/TermSelector.js
+++ b/src/components/RightPane/CoursePane/SearchForm/TermSelector.js
@@ -26,6 +26,7 @@ class TermSelector extends PureComponent {
 
     handleChange = (event) => {
         this.setState({ term: event.target.value });
+        console.log(this.props.changeState);
         this.props.changeState(this.props.fieldName, event.target.value);
     };
 

--- a/src/components/RightPane/CoursePane/SearchForm/TermSelector.js
+++ b/src/components/RightPane/CoursePane/SearchForm/TermSelector.js
@@ -26,7 +26,6 @@ class TermSelector extends PureComponent {
 
     handleChange = (event) => {
         this.setState({ term: event.target.value });
-        console.log(this.props.changeState);
         this.props.changeState(this.props.fieldName, event.target.value);
     };
 

--- a/src/components/RightPane/RightPaneStore.js
+++ b/src/components/RightPane/RightPaneStore.js
@@ -22,7 +22,7 @@ class RightPaneStore extends EventEmitter {
     constructor() {
         super();
         this.setMaxListeners(15);
-        this.formData = defaultFormValues;
+        this.formData = { ...defaultFormValues }; // creates shallow copy
         this.activeTab = 0;
         this.doDisplaySearch = true;
         this.openSpotAlertPopoverActive = false;
@@ -44,15 +44,15 @@ class RightPaneStore extends EventEmitter {
         return this.openSpotAlertPopoverActive;
     }
 
-    updateFormValue(field, value) {
+    updateFormValue = (field, value) => {
         this.formData[field] = value;
         this.emit('formDataChange');
-    }
+    };
 
-    resetFormValues() {
+    resetFormValues = () => {
         this.formData = defaultFormValues;
         this.emit('formReset');
-    }
+    };
 
     handleTabChange = (event, value) => {
         this.activeTab = value;

--- a/src/components/RightPane/RightPaneStore.js
+++ b/src/components/RightPane/RightPaneStore.js
@@ -28,21 +28,21 @@ class RightPaneStore extends EventEmitter {
         this.openSpotAlertPopoverActive = false;
     }
 
-    getFormData() {
+    getFormData = () => {
         return this.formData;
-    }
+    };
 
-    getActiveTab() {
+    getActiveTab = () => {
         return this.activeTab;
-    }
+    };
 
-    getDoDisplaySearch() {
+    getDoDisplaySearch = () => {
         return this.doDisplaySearch;
-    }
+    };
 
-    getOpenSpotAlertPopoverActive() {
+    getOpenSpotAlertPopoverActive = () => {
         return this.openSpotAlertPopoverActive;
-    }
+    };
 
     updateFormValue = (field, value) => {
         this.formData[field] = value;
@@ -50,7 +50,7 @@ class RightPaneStore extends EventEmitter {
     };
 
     resetFormValues = () => {
-        this.formData = defaultFormValues;
+        this.formData = { ...defaultFormValues }; // shallow copy again
         this.emit('formReset');
     };
 
@@ -76,13 +76,13 @@ class RightPaneStore extends EventEmitter {
         }
     };
 
-    toggleSearch() {
+    toggleSearch = () => {
         this.doDisplaySearch = !this.doDisplaySearch;
-    }
+    };
 
-    toggleOpenSpotAlert() {
+    toggleOpenSpotAlert = () => {
         this.openSpotAlertPopoverActive = !this.openSpotAlertPopoverActive;
-    }
+    };
 }
 
 const store = new RightPaneStore();


### PR DESCRIPTION
## Summary
Fixes the bugs about the reset button not working in the manual search form and the term selector not working. 

The problem was as you said on Discord, that the functions being called by SearchForm were the static versions, not the instance versions, but I fixed that without making the attributes of RightPaneStore static.

For some reason, using the arrow syntax to define the functions makes them attached to the instance while using normal function syntax makes them static, although I think JS only makes this distinction when they're being passed as a first-class object, like `{RightPaneStore.someFunction}` being passed as a prop. For calls like `RightPaneStore.someFunction()` there doesn't seem to be a problem.

This also makes it clear why AppStore doesn't have any of these problems. It's functions are all put in AppStoreActions, so they always operate on the singleton instance of AppStore and don't run the risk of making a static function call where `this` is undefined.

This undoes #417 and keeps all the RightPaneStore attributes instance level. On a higher level, I think this is the right choice because we're adhering more completely to a singleton pattern instead of some weird hybrid of having a singleton object for the emitter but then having static variables. Do let me know if you see any downsides compared to having static attributes.

## Test Plan
Verify that all the right pane actions work:

- [ ] Toggle between search and results
- [ ] Change tabs
- [ ] Update form values
- [ ] Reset the form values

## Future Followup  
Make sure to define all functions in stores as arrow functions so they aren't accidentally static.
