### PR TITLE
Add recruitment banner

### DIFF
--- a/src/components/RightPane/CoursePane/CoursePaneButtonRow.js
+++ b/src/components/RightPane/CoursePane/CoursePaneButtonRow.js
@@ -10,6 +10,7 @@ const styles = {
         zIndex: 3,
         marginBottom: 8,
         position: 'absolute',
+        pointerEvents: 'none',
     },
     button: {
         backgroundColor: 'rgba(236, 236, 236, 1)',
@@ -19,6 +20,7 @@ const styles = {
         '&:hover': {
             backgroundColor: 'grey',
         },
+        pointerEvents: 'auto',
     },
 };
 

--- a/src/components/RightPane/CoursePane/CourseRenderPane.js
+++ b/src/components/RightPane/CoursePane/CourseRenderPane.js
@@ -97,7 +97,7 @@ const RecruitmentBanner = ({ className }) => (
             Join ICSSC and work on AntAlmanac and other projects!
         </a>
         <br />
-        We have positions for experienced devs and those with zero experience!
+        We have opportunities for experienced devs and those with zero experience!
     </div>
 );
 

--- a/src/components/RightPane/CoursePane/CourseRenderPane.js
+++ b/src/components/RightPane/CoursePane/CourseRenderPane.js
@@ -42,7 +42,6 @@ const styles = (theme) => ({
         height: '100%',
         overflowY: 'scroll',
         position: 'relative',
-        paddingTop: '50px',
     },
     noResultsDiv: {
         height: '100%',
@@ -57,6 +56,12 @@ const styles = (theme) => ({
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    bannerContainer: {
+        height: '50px',
+        paddingLeft: '110px',
+        display: 'flex',
+        justifyContent: 'space-around',
     },
 });
 
@@ -82,6 +87,16 @@ const flattenSOCObject = (SOCObject) => {
         return accumulator;
     }, []);
 };
+
+const RecruitmentBanner = ({ className }) => (
+    <div className={className}>
+        Have web development experience or are interested in learning?
+        <br />
+        <a href="https://forms.gle/v32Cx65vwhnmxGPv8" target="__blank" rel="noopener noreferrer">
+            Join ICSSC and work on AntAlamanc and other projects!
+        </a>
+    </div>
+);
 
 const SectionTableWrapped = (index, data) => {
     const { courseData, scheduleNames } = data;
@@ -210,6 +225,11 @@ class CourseRenderPane extends PureComponent {
 
             currentView = (
                 <div className={classes.root}>
+                    <div className={classes.bannerContainer}>
+                        {['COMPSCI', 'IN4MATX', 'I&C SCI', 'STATS'].includes(
+                            RightPaneStore.getFormData().deptValue
+                        ) && <RecruitmentBanner className={classes.banner} />}
+                    </div>
                     {this.state.courseData.length === 0 ? (
                         <div className={classes.noResultsDiv}>
                             <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />

--- a/src/components/RightPane/CoursePane/CourseRenderPane.js
+++ b/src/components/RightPane/CoursePane/CourseRenderPane.js
@@ -61,7 +61,8 @@ const styles = (theme) => ({
         height: '50px',
         paddingLeft: '110px',
         display: 'flex',
-        justifyContent: 'space-around',
+        justifyContent: 'flex-end',
+        paddingRight: '50px',
     },
 });
 
@@ -90,11 +91,13 @@ const flattenSOCObject = (SOCObject) => {
 
 const RecruitmentBanner = ({ className }) => (
     <div className={className}>
-        Have web development experience or are interested in learning?
+        Interested in web development?
         <br />
         <a href="https://forms.gle/v32Cx65vwhnmxGPv8" target="__blank" rel="noopener noreferrer">
             Join ICSSC and work on AntAlmanac and other projects!
         </a>
+        <br />
+        We have positions for experienced devs and those with zero experience!
     </div>
 );
 

--- a/src/components/RightPane/CoursePane/CourseRenderPane.js
+++ b/src/components/RightPane/CoursePane/CourseRenderPane.js
@@ -93,7 +93,7 @@ const RecruitmentBanner = ({ className }) => (
         Have web development experience or are interested in learning?
         <br />
         <a href="https://forms.gle/v32Cx65vwhnmxGPv8" target="__blank" rel="noopener noreferrer">
-            Join ICSSC and work on AntAlamanc and other projects!
+            Join ICSSC and work on AntAlmanac and other projects!
         </a>
     </div>
 );


### PR DESCRIPTION
## Summary
Add a banner above the search results for classes in the school of ICS advertising our club. I'm not too set on the specific design here so feel free to make suggestions.
![image](https://user-images.githubusercontent.com/48658337/187051285-037c923c-dc44-4d65-b9c5-fd0a97cb4c8b.png)
I also filmed a 2-hour video of myself working on this that we can use as a training video. I'm gonna edit and post it later so people don't have to sit through me fumbling with CSS for so long.
## Test Plan
Make sure the banner displays on ICS, CS, INF, and STATS classes but not other ones.
## Issues
Closes #424 

## Future Followup  
We might want to remove it at some point or comment it out after recruiting season is over for us.
