### PR TITLE
Staging Action Improvements

### DIFF
--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -29,9 +29,11 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-
+          role-duration-seconds: 2400
+            
       - name: check if stack exists
         id: check-stack-exists
 

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -5,9 +5,14 @@ on:
     types: [closed, labeled]
     
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
   deployments: write
   repository-projects: write
 
@@ -36,6 +41,20 @@ jobs:
             
       - name: check if stack exists
         id: check-stack-exists
+        run: echo ::set-output name=stack_status::$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].Outputs[1].StackStatus" --output text)
+        continue-on-error: true
+
+      - name: wait for stack create
+        id: wait-for-stack-create
+        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'CREATE_IN_PROGRESS'
+        run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
+        continue-on-error: true
+          
+      - name: wait for stack update
+        id: wait-for-stack-update
+        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'UPDATE_IN_PROGRESS'
+        run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
+        continue-on-error: true
 
       - name: delete the stack from AWS
         if: steps.check-stack-exists.outcome == 'success'

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -15,7 +15,9 @@ jobs:
   clean-up:
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
     runs-on: ubuntu-latest
-    env: # env variables for Node.js
+    env:
+      STACK_NAME: github-actions-stack-${{ github.event.pull_request.number }}
+      # env variables for Node.js
       HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
       CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
       PR_NUM: ${{ github.event.pull_request.number }}
@@ -27,34 +29,23 @@ jobs:
       - name: set STAGE variable in environment for next steps
         run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-        
-      - name: checkout antalmanac
-        uses: actions/checkout@v3
-      
-      - name: install node dependencies cdk
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: .github/workflows/actions_stack
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
           aws-region: us-east-1
 
-      - name: make empty folder # so cdk doesn't complain
-        run: mkdir build
+      - name: check if stack exists
+        id: check-stack-exists
 
-      - name: build CDK
-        working-directory: ./.github/workflows/actions_stack
-        run: npm run build
-
-      - name: destroy the stack on AWS
-        working-directory: ./.github/workflows/actions_stack
-        run: npx cdk destroy github-actions-stack-${{ github.event.pull_request.number }} --force
+      - name: delete the stack from AWS
+        if: steps.check-stack-exists.outcome == 'success'
+        run: aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}
+        
+      - name: wait for stack delete
+        id: wait-for-stack-delete
+        if: steps.check-stack-exists.outcome == 'success'
+        run: aws cloudformation wait stack-delete-complete --stack-name ${{ env.STACK_NAME }}
 
       - name: update the github deployment status
         uses: bobheadxi/deployments@v0.5.2

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -2,9 +2,8 @@ name: "Pull Request Clean Up"
 
 on:
   pull_request:
-    types: [closed]
-    branches:
-      - main
+    types: [closed, labeled]
+    
 
 permissions:
   id-token: write
@@ -14,7 +13,7 @@ permissions:
 
 jobs:
   clean-up:
-    if: (!contains(github.event.pull_request.labels.*.name, 'no deploy'))
+    if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
     runs-on: ubuntu-latest
     env: # env variables for Node.js
       HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -23,9 +23,6 @@ jobs:
       PR_NUM: ${{ github.event.pull_request.number }}
 
     steps:
-      - name: inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
-
       - name: set STAGE variable in environment for next steps
         run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
@@ -47,17 +44,8 @@ jobs:
         if: steps.check-stack-exists.outcome == 'success'
         run: aws cloudformation wait stack-delete-complete --stack-name ${{ env.STACK_NAME }}
 
-      - name: update the github deployment status
-        uses: bobheadxi/deployments@v0.5.2
+      - name: delete staging url
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          step: deactivate-env
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.STAGE }}
-
-      # add back in the future if we change to personal access Github token
-      # - name: delete the github deployments and the corresponding environment
-      #   uses: strumwolf/delete-deployment-environment@v2
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     environment: ${{ env.STAGE }}
-      
+          header: staging url
+          delete: true

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   deployments: write
   pull-requests: write
+    
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -51,6 +55,23 @@ jobs:
       - name: build CDK
         working-directory: ./.github/workflows/actions_stack
         run: npm run build
+
+      - name: check if stack exists
+        id: check-stack-exists
+        run: echo ::set-output name=stack_status::$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].Outputs[1].StackStatus" --output text)
+        continue-on-error: true
+
+      - name: wait for stack create
+        id: wait-for-stack-create
+        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'CREATE_IN_PROGRESS'
+        run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
+        continue-on-error: true
+          
+      - name: wait for stack update
+        id: wait-for-stack-update
+        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'UPDATE_IN_PROGRESS'
+        run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
+        continue-on-error: true
 
       - name: deploy the stack to AWS
         working-directory: ./.github/workflows/actions_stack

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -40,8 +40,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.ACTIONS_IAM_ROLE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+          role-duration-seconds: 2400
       
       - name: build frontend
         run: npm run build

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -2,7 +2,7 @@ name: "Deploy Pull Request"
 
 on: 
   pull_request:
-      types: [opened, synchronize]
+      types: [opened, synchronize, unlabeled]
 
 permissions:
   id-token: write

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -8,32 +8,20 @@ permissions:
   id-token: write
   contents: read
   deployments: write
+  pull-requests: write
 
 jobs:
   deploy:
     if: (!contains(github.event.pull_request.labels.*.name, 'no deploy'))
     runs-on: ubuntu-latest
-    env: # env variables for Node.js
+    env: 
+      STACK_NAME: github-actions-stack-${{ github.event.pull_request.number }}
+      # env variables for Node.js
       HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
       CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
       PR_NUM: ${{ github.event.pull_request.number }}
 
     steps: 
-      - name: inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
-
-      - name: set STAGE variable in environment for next steps
-        run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
-
-      - name: create a github deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.STAGE }}
-          ref: ${{ github.head_ref }}
-      
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -64,14 +52,11 @@ jobs:
 
       - name: deploy the stack to AWS
         working-directory: ./.github/workflows/actions_stack
-        run: npx aws-cdk deploy github-actions-stack-${{ github.event.pull_request.number }} --require-approval never
-
-      - name: update the github deployment status
-        uses: bobheadxi/deployments@v0.5.2
-        if: always()
+        run: npx aws-cdk deploy ${{ env.STACK_NAME }} --require-approval never
+          
+      - name: comment staging url
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://staging-${{ github.event.pull_request.number }}.antalmanac.com
+          header: staging url
+          recreate: true
+          message: Deployed staging instance to https://staging-${{ github.event.pull_request.number }}.antalmanac.com


### PR DESCRIPTION
## Summary
This PR addresses some of the annoyances that have popped up while using this action. The problems and their fixes are:

- Github environments are created by the deployments are not deleted when the deployment is deleted, which means they need to be manually cleaned out. While it is possible to have the action delete environments it needs a custom Github token (which is gotten from a user and cannot be from the ICCSC org), and results in the action saying "{token's user} deployed to some environment" which just feels wrong.
    - Get rid of deployments action
    - To replace the ability to get the staging URL easily I added a comment action that will comment the URL, along with recreating every time a new commit is added so it stays near the bottom of the PR.
- Github deployments are not able to be created when pull requests come from outside the repo because their Github token does not have the correct permissions.
    - Get rid of deployments action 
- AWS permissions are not able to be assumed when pull requests come from outside the repo due to how OIDC federation works.
    - Added AWS credentials to the repo secrets and use those to assume a role in the action instead of getting credentials dynamically through OIDC
- Adding the "no deploy" label doesn't delete the staging stack if it was created, and removing the label doesn't deploy the staging stack
    - Add triggers for the actions on labeled and unlabeled

There are also some other minor changes, main one being forcing only one workflow to be run at a time along with stack status waiting to make the action more resistant to failing.

## Test Plan
Tested the action in this PR by adding and removing the no deploy label to trigger deployment and deletion. 
**Warning:** I have not tested with external PRs, but I am relatively confident it will work. If it doesn't there is another measure that we can try (using [pull request target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) as a trigger), but that gives actions run from outside repos much more permissions so I am currently trying to avoid that. 

## Issues
Closes # 

<!-- [Optional]
## Future Followup  
-->
