### PR TITLE
Fix Kanban board link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since then, the project has continued to evolve and grow with successive generat
 | 2022 - | @EricPedley |
 ## Contributing
 We welcome open-source contributions 🤗 Here is a rough guide on how to contribute:
-1. Look through the [issue tracker](https://github.com/icssc/AntAlmanac/issues) or [Kanban board](https://github.com/icssc/AntAlmanac/wiki/About-the-Projects-Board) to find an open issue (nobody else is assigned) or create your own that describes the problem you want to fix. 
+1. Look through the [issue tracker](https://github.com/icssc/AntAlmanac/issues) or [Kanban board](https://github.com/icssc/AntAlmanac/wiki/Kanban-Board-Docs) to find an open issue (nobody else is assigned) or create your own that describes the problem you want to fix. 
 2. Fork the repository. If you're on the ICSSC Projects Committee and we've given you write access, create a branch instead of forking.
 3. [Get Setup to Develop Locally](#get-setup-to-develop-locally)
 4. Make your changes and push them. Then create a pull request from your branch or fork to `main`.


### PR DESCRIPTION
## Summary
Link now leads to https://github.com/icssc/AntAlmanac/wiki/Kanban-Board-Docs, instead of https://github.com/icssc/AntAlmanac/wiki/About-the-Projects-Board, which seems to be defunct

## Issues
Closes #435