### PR TITLE
Fix month indexing for Winter '23

### DIFF
--- a/src/termData.js
+++ b/src/termData.js
@@ -10,7 +10,7 @@ function Term(shortName, longName, startDate) {
 // Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2022-2023/quarterly22-23.html
 // Note: months are 0-indexed
 const termData = [
-    new Term('2023 Winter', '2023 Winter Quarter', [2023, 0, 4]),
+    new Term('2023 Winter', '2023 Winter Quarter', [2023, 0, 9]),
     new Term('2022 Fall', '2022 Fall Quarter', [2022, 8, 22]),
     new Term('2022 Summer2', '2022 Summer Session 2', [2022, 7, 1]),
     new Term('2022 Summer10wk', '2022 10-wk Summer', [2022, 5, 20]), // nominal start date for SS1 and SS10wk

--- a/src/termData.js
+++ b/src/termData.js
@@ -10,7 +10,7 @@ function Term(shortName, longName, startDate) {
 // Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2022-2023/quarterly22-23.html
 // Note: months are 0-indexed
 const termData = [
-    new Term('2023 Winter', '2023 Winter Quarter', [2023, 1, 4]),
+    new Term('2023 Winter', '2023 Winter Quarter', [2023, 0, 4]),
     new Term('2022 Fall', '2022 Fall Quarter', [2022, 8, 22]),
     new Term('2022 Summer2', '2022 Summer Session 2', [2022, 7, 1]),
     new Term('2022 Summer10wk', '2022 10-wk Summer', [2022, 5, 20]), // nominal start date for SS1 and SS10wk


### PR DESCRIPTION
## Summary
Months are 0-indexed, so January should `0` instead of `1`

## Test Plan
n/a

## Issues
https://discord.com/channels/772739905981644850/780316580819107860/1041810791034277930

## Future Followup  
Maybe add a map transformation to automatically decrement indexes, so `1` is actually January?
