### PR TITLE
Fix bug where courses would appear in too many schedules

### DIFF
--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -216,10 +216,7 @@ class ScheduleCalendar extends PureComponent {
             ? this.state.finalsEventsInCalendar
             : this.state.eventsInCalendar;
 
-        return eventSet.filter(
-            (event) =>
-                event.scheduleIndices.includes(this.state.currentScheduleIndex) || event.scheduleIndices.length === 4
-        );
+        return eventSet.filter((event) => event.scheduleIndices.includes(this.state.currentScheduleIndex));
     };
 
     render() {


### PR DESCRIPTION
## Summary
One-line change in function `getEventsForCalendar` in `ScheduleCalendar.js`
```
//before:
return eventSet.filter(
            (event) =>
                event.scheduleIndices.includes(this.state.currentScheduleIndex) || event.scheduleIndices.length === 4
        );
//after:
return eventSet.filter(
            (event) =>
                event.scheduleIndices.includes(this.state.currentScheduleIndex)
        );
// just removed the  `|| event.scheduleIndices.length === 4` part
```

Fixed a bug where if you add the same course to 4 schedules, it'll always show up in any other schedules. I think this condition was there originally because previously there were only 4 total schedules. I did a project-wide grep for "4" and didn't find any more occurrences using it as a magic number so we should be safe from this class of bugs.
![image](https://user-images.githubusercontent.com/48658337/201838974-8764b501-7553-4c9c-b229-66e0f065e34a.png)

## Test Plan
Try adding a course to 4 schedules and verify it doesn't show up in the fifth.
