### PR TITLE
Fix Github Actions not checking status properly

### DIFF
--- a/.github/actions/stabilize_stack/action.yaml
+++ b/.github/actions/stabilize_stack/action.yaml
@@ -1,0 +1,51 @@
+name: "Wait for Stack Stabilize"
+
+inputs:
+  stack_name:
+    required: true
+  aws_access_key_id:
+    required: true
+  aws_secret_access_key:
+    required: true
+  
+outputs:
+  stack-exists: 
+    value: ${{ steps.check-stack-exists.outcome == 'success' && !steps.wait-for-stack-delete.outcome == 'success'}}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        aws-access-key-id: ${{ inputs.aws_secret_access_key_id }}
+        aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
+        aws-region: us-east-1
+        role-duration-seconds: 2400
+
+    - name: check if stack exists
+      id: check-stack-exists
+      run: echo "STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{ inputs.stack_name }} --query "Stacks[0].StackStatus" --output text)" >> $GITHUB_ENV
+      continue-on-error: true
+      shell: bash
+
+    - name: wait for stack create
+      id: wait-for-stack-create
+      if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
+      run: aws cloudformation wait stack-create-complete --stack-name ${{ inputs.stack_name }}
+      continue-on-error: true
+      shell: bash
+        
+    - name: wait for stack update
+      id: wait-for-stack-update
+      if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
+      run: aws cloudformation wait stack-update-complete --stack-name ${{ inputs.stack_name }}
+      continue-on-error: true
+      shell: bash
+
+    - name: wait for stack delete
+      id: wait-for-stack-delete
+      if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'DELETE_IN_PROGRESS'
+      run: aws cloudformation wait stack-delete-complete --stack-name ${{ inputs.stack_name }}
+      continue-on-error: true
+      shell: bash

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -28,6 +28,9 @@ jobs:
       PR_NUM: ${{ github.event.pull_request.number }}
 
     steps:
+      - name: checkout antalmanac
+        uses: actions/checkout@v3
+
       - name: set STAGE variable in environment for next steps
         run: echo "STAGE=pr-${{ github.event.pull_request.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
@@ -38,31 +41,23 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-duration-seconds: 2400
-            
-      - name: check if stack exists
-        id: check-stack-exists
-        run: echo "STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].StackStatus" --output text)" >> $GITHUB_ENV
-        continue-on-error: true
-
-      - name: wait for stack create
-        id: wait-for-stack-create
-        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
-        run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
-        continue-on-error: true
           
-      - name: wait for stack update
-        id: wait-for-stack-update
-        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
-        run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
-        continue-on-error: true
+      - name: wait for stack stabilize
+        id: stabilize-stack
+        uses: ./.github/actions/stabilize_stack
+        with: 
+          stack_name: ${{ env.STACK_NAME }}
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
       - name: delete the stack from AWS
-        if: steps.check-stack-exists.outcome == 'success'
+        id: delete-stack
+        if: steps.stabilize-stack.outputs.stack-exists
         run: aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}
+        continue-on-error: true
         
       - name: wait for stack delete
-        id: wait-for-stack-delete
-        if: steps.check-stack-exists.outcome == 'success'
+        if: steps.delete-stack.outcome == 'success'
         run: aws cloudformation wait stack-delete-complete --stack-name ${{ env.STACK_NAME }}
 
       - name: delete staging url

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -41,18 +41,18 @@ jobs:
             
       - name: check if stack exists
         id: check-stack-exists
-        run: echo ::set-output name=stack_status::$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].Outputs[1].StackStatus" --output text)
+        run: echo "STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].StackStatus" --output text)" >> $GITHUB_ENV
         continue-on-error: true
 
       - name: wait for stack create
         id: wait-for-stack-create
-        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'CREATE_IN_PROGRESS'
+        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
         run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
         continue-on-error: true
           
       - name: wait for stack update
         id: wait-for-stack-update
-        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'UPDATE_IN_PROGRESS'
+        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
         run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
         continue-on-error: true
 

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -24,6 +24,7 @@ jobs:
       HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
       CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
       PR_NUM: ${{ github.event.pull_request.number }}
+      REACT_APP_STAGING: true
 
     steps: 
       - uses: actions/setup-node@v2

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -55,23 +55,13 @@ jobs:
       - name: build CDK
         working-directory: ./.github/workflows/actions_stack
         run: npm run build
-
-      - name: check if stack exists
-        id: check-stack-exists
-        run: echo "STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].StackStatus" --output text)" >> $GITHUB_ENV
-        continue-on-error: true
-
-      - name: wait for stack create
-        id: wait-for-stack-create
-        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
-        run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
-        continue-on-error: true
           
-      - name: wait for stack update
-        id: wait-for-stack-update
-        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
-        run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
-        continue-on-error: true
+      - name: wait for stack stabilize
+        uses: ./.github/actions/stabilize_stack
+        with: 
+          stack_name: ${{ env.STACK_NAME }}
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
       - name: deploy the stack to AWS
         working-directory: ./.github/workflows/actions_stack

--- a/.github/workflows/stage_pr.yaml
+++ b/.github/workflows/stage_pr.yaml
@@ -58,18 +58,18 @@ jobs:
 
       - name: check if stack exists
         id: check-stack-exists
-        run: echo ::set-output name=stack_status::$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].Outputs[1].StackStatus" --output text)
+        run: echo "STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }} --query "Stacks[0].StackStatus" --output text)" >> $GITHUB_ENV
         continue-on-error: true
 
       - name: wait for stack create
         id: wait-for-stack-create
-        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'CREATE_IN_PROGRESS'
+        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
         run: aws cloudformation wait stack-create-complete --stack-name ${{ env.STACK_NAME }}
         continue-on-error: true
           
       - name: wait for stack update
         id: wait-for-stack-update
-        if: steps.check-stack-exists.outcome == 'success' && steps.check-stack-exists.outputs.stack_status == 'UPDATE_IN_PROGRESS'
+        if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
         run: aws cloudformation wait stack-update-complete --stack-name ${{ env.STACK_NAME }}
         continue-on-error: true
 


### PR DESCRIPTION
## Summary
The wait for stack status steps were not working due to my command to query the stack status being wrong. Also, instead of modifying the step status itself I am inserting the stack status into an environmental variable as per Github's newest recommendations.

## Test Plan
As can be seen, the step isn't skipped now (this workflow was run while a stack was currently creating)
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/53128285/202094454-ae86ff6c-97cc-41e4-ae78-377f068a637a.png">


## Issues
Closes # 

<!-- [Optional]
## Future Followup  
-->
