### PR TITLE
Add description to stabilize stack action

### DIFF
--- a/.github/actions/stabilize_stack/action.yaml
+++ b/.github/actions/stabilize_stack/action.yaml
@@ -1,5 +1,5 @@
 name: "Wait for Stack Stabilize"
-
+description: "Wait for all in-progress operations in the stack to complete"
 inputs:
   stack_name:
     required: true


### PR DESCRIPTION
https://github.com/icssc/AntAlmanac/pull/447#issuecomment-1328521999

Also, IDK how GitHub wasn't complaining about this before, but the GitHub Actions docs say description is a required field:
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions