### PR TITLE
Fix duplicate section code bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
             "git add"
         ]
     },
-    "proxy": "http://localhost:8080",
     "browserslist": {
         "production": [
             ">0.2%",

--- a/src/actions/AppStoreActions.js
+++ b/src/actions/AppStoreActions.js
@@ -182,19 +182,23 @@ export const loadSchedule = async (userID, rememberMe) => {
             }
 
             try {
-                const data = await fetch(LOAD_DATA_ENDPOINT, {
+                const response_data = await fetch(LOAD_DATA_ENDPOINT, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ userID: userID }),
                 });
-
-                const json = await data.json();
+                if (response_data.status === 404) {
+                    openSnackbar('error', `Couldn't find schedules for username "${userID}".`);
+                    return;
+                }
+                const json = await response_data.json();
 
                 AppStore.loadSchedule(await getCoursesData(json.userData));
 
                 openSnackbar('success', `Schedule for username "${userID}" loaded.`);
             } catch (e) {
-                openSnackbar('error', `Couldn't find schedules for username "${userID}".`);
+                console.error(e);
+                openSnackbar('error', `Unknown error loading schedule for "${userID}".`);
             }
         }
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,7 +24,7 @@ export async function getCoursesData(userData) {
     let sectionCodeToInfoMapping;
     if (userData.addedCourses.length !== 0) {
         sectionCodeToInfoMapping = userData.addedCourses.reduce((accumulator, addedCourse) => {
-            accumulator[addedCourse.sectionCode] = { ...addedCourse };
+            accumulator[`${addedCourse.sectionCode}${addedCourse.term}`] = { ...addedCourse };
             return accumulator;
         }, {});
     }
@@ -54,7 +54,7 @@ export async function getCoursesData(userData) {
 
             for (const [sectionCode, courseData] of Object.entries(getCourseInfo(jsonResp))) {
                 addedCourses.push({
-                    ...sectionCodeToInfoMapping[sectionCode],
+                    ...sectionCodeToInfoMapping[`${sectionCode}${term}`],
                     ...courseData.courseDetails,
                     section: courseData.section,
                 });


### PR DESCRIPTION
## Summary
- Fixed this user reported bug: 
![image](https://user-images.githubusercontent.com/48658337/204992077-b095864e-f829-4ad0-a4da-cd613e01dd74.png)
  The bug was caused by courses with duplicate section codes but different terms not being loaded separately.
- Added a separate error case for 404s as opposed to other errors loading schedules.
- Removed the proxy URL from our `package.json` because it was giving me errors, see screenshot below. I don't think we need it anymore since we don't run the backend locally alongside the client.
![image](https://user-images.githubusercontent.com/48658337/204993202-747b197f-7ac0-445b-8992-1d1f89e28eb1.png)


## Test Plan
To reproduce the bug, load username `dupe-test` on the [prod site](https://antalmanac.com). Try deleting one of the classes on schedule 2. It deletes both. To get there from scratch, create two different schedules, add ENGR 1A fall 22 on one, and ENGR 7B winter 23 on the other, then save the schedule and load it.

Try the same process on the staging deployment or locally and verify the bug doesn't happen. Also, try loading a username that doesn't exist to verify the error handling for the 404s works correctly. 