### PR TITLE
Expand calendar earliest time to 6 AM

### DIFF
--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -297,7 +297,7 @@ class ScheduleCalendar extends PureComponent {
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}
-                        min={new Date(2018, 0, 1, 7)}
+                        min={new Date(2018, 0, 1, 6)}
                         max={new Date(2018, 0, 1, 23)}
                         events={events}
                         eventPropGetter={ScheduleCalendar.eventStyleGetter}


### PR DESCRIPTION
## Summary
- Addresses a user feedback form request to expand the calendar view to include 6 AM
TODO:
- Since this is only useful for a handful of users, we should make the default view start at 8 AM, and show earlier times only if you scroll up.
## Test Plan
Add custom events at 6 AM and verify that it works. Also try to add course and custom events at other times to verify it didn't break any typical use cases. 
