### PR TITLE
Fix broken review links involving special characters

### DIFF
--- a/src/components/RightPane/SectionTable/SectionTable.js
+++ b/src/components/RightPane/SectionTable/SectionTable.js
@@ -66,6 +66,7 @@ const styles = {
 
 const SectionTable = (props) => {
     const { classes, courseDetails, term, colorAndDelete, highlightAdded, scheduleNames, analyticsCategory } = props;
+    const courseId = courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     const encodedDept = encodeURIComponent(courseDetails.deptCode);
     const isMobileScreen = useMediaQuery('(max-width: 750px)');
 
@@ -102,7 +103,7 @@ const SectionTable = (props) => {
                     analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
                     text="Reviews"
                     icon={<RateReview />}
-                    redirectLink={`https://peterportal.org/course/${encodedDept}${courseDetails.courseNumber}`}
+                    redirectLink={`https://peterportal.org/course/${courseId}`}
                 />
                 <CourseInfoButton
                     analyticsCategory={analyticsCategory}


### PR DESCRIPTION
## Summary
When viewing course details in search results or in the added classes tab, clicking the “reviews” button would redirect to PeterPortal but with an invalid link. The problem was caused because the course department was URL encoded (`https://peterportal.org/course/I%26C%20SCI33`), but PeterPortal expected a URL with raw characters and no spaces within the department name (`https://peterportal.org/course/I&CSCI33`). This format mirrors the `id` response parameter of the `/courses` endpoint of the PeterPortal API.

## Test Plan
I tested out the reviews button with a few classes containing special characters and some that don’t, and they all work now.

## Future Followup  
Right now my fix is a band-aid fix on the front-end that creates a courseId based on the department and course number; ideally, we should modify the `/schedule/soc` endpoint of the API (which is what AntAlmanac uses) to add a course ID to the request response, and use that in the front-end, for better reusability and front-end/back-end separation.
