### PR TITLE
Adjusted min-width to include tablet screens

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -9,7 +9,7 @@ import MobileHome from './MobileHome';
 import DateFnsUtils from '@date-io/date-fns';
 
 const Home = () => {
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/src/components/RightPane/SectionTable/CourseInfoBar.js
+++ b/src/components/RightPane/SectionTable/CourseInfoBar.js
@@ -121,7 +121,7 @@ const CourseInfoBar = (props) => {
         }
     };
 
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     return (
         <>

--- a/src/components/RightPane/SectionTable/CourseInfoButton.js
+++ b/src/components/RightPane/SectionTable/CourseInfoButton.js
@@ -14,7 +14,7 @@ const styles = {
 
 function CourseInfoButton({ classes, text, icon, redirectLink, popupContent, analyticsAction, analyticsCategory }) {
     const [popupAnchor, setPopupAnchor] = useState(null);
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
     return (
         <>
             <Button

--- a/src/components/RightPane/SectionTable/SectionTable.js
+++ b/src/components/RightPane/SectionTable/SectionTable.js
@@ -68,7 +68,7 @@ const SectionTable = (props) => {
     const { classes, courseDetails, term, colorAndDelete, highlightAdded, scheduleNames, analyticsCategory } = props;
     const courseId = courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     const encodedDept = encodeURIComponent(courseDetails.deptCode);
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     return (
         <>

--- a/src/components/RightPane/SectionTable/SectionTableBody.js
+++ b/src/components/RightPane/SectionTable/SectionTableBody.js
@@ -104,7 +104,7 @@ const CourseCodeCell = withStyles(styles)((props) => {
 
 const SectionDetailsCell = withStyles(styles)((props) => {
     const { classes, sectionType, sectionNum, units } = props;
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     return (
         <NoPaddingTableCell className={classes.cell} style={isMobileScreen ? { textAlign: 'center' } : {}}>

--- a/src/components/RightPane/SectionTable/SectionTableButtons.js
+++ b/src/components/RightPane/SectionTable/SectionTableButtons.js
@@ -19,7 +19,7 @@ const styles = {
 
 export const ColorAndDelete = withStyles(styles)((props) => {
     const { sectionCode, color, classes, term } = props;
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     return (
         <TableCell padding="none">
@@ -55,7 +55,7 @@ export const ColorAndDelete = withStyles(styles)((props) => {
 export const ScheduleAddCell = withStyles(styles)((props) => {
     const { classes, section, courseDetails, term, scheduleNames } = props;
     const popupState = usePopupState({ variant: 'popover' });
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const isMobileScreen = useMediaQuery('(max-width: 960px)');
 
     const closeAndAddCourse = (scheduleIndex, specificSchedule) => {
         popupState.close();


### PR DESCRIPTION
## Summary
Between window widths of 750px - 960px, the page is stuck on the calendar and doesn't show the Calendar and Search tabs on the top. I didn't touch the AppBar because it seems fine to me at that width, although the elements are slightly clipping each other.
<img src="https://user-images.githubusercontent.com/65209258/210202011-c7a37166-e9af-42f8-afca-f0e8f0c93170.png" height="500" />

## Test Plan
I checked various screen widths, to see when the bug occurs.

## Issues
Closes #250 

## Future Followup  
I adjusted the breakpoint for mobile view to include the buggy widths. A future change could be a different design on tablet widths.