### PR TITLE
Dark Mode Screenshots Bug

### DIFF
--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -9,6 +9,7 @@ import './calendar.css';
 import CalendarPaneToolbar from './CalendarPaneToolbar';
 import CourseCalendarEvent from './CourseCalendarEvent';
 import AppStore from '../../stores/AppStore';
+import { isDarkMode } from '../../helpers';
 
 const localizer = momentLocalizer(moment);
 
@@ -168,15 +169,25 @@ class ScheduleCalendar extends PureComponent {
         // Fetch the canvas and calendarHeader
         const canvas = document.getElementById('screenshot');
         const calendarHeader = ReactDOM.findDOMNode(this).getElementsByClassName('rbc-time-header')[0];
-
         // Save the current styling, so we can add it back afterwards
         const oldColor = canvas.style.color;
         const oldMargin = calendarHeader.style.marginRight;
-
         // Update the canvas and calendar header for the picture
         canvas.style.color = 'black';
         calendarHeader.style.marginRight = '0px';
 
+        // Set each rbc header and time slot text color to white if the theme is dark
+        let rbc_headers = document.getElementsByClassName('rbc-header');
+        let rbc_time_slots = document.getElementsByClassName('rbc-label');
+        console.log(rbc_headers);
+        if (isDarkMode()) {
+            for (let i = 0; i < rbc_headers.length; i++) {
+                rbc_headers[i].className = 'rbc-header dark-mode';
+            }
+            for (let i = 0; i < rbc_time_slots.length; i++) {
+                rbc_time_slots[i].className = 'rbc-label dark-mode';
+            }
+        }
         this.setState({ screenshotting: true }, async () => {
             // Take the picture
             await html2CanvasScreenshot();
@@ -184,6 +195,18 @@ class ScheduleCalendar extends PureComponent {
             // Revert the temporary changes to the canvas and calendar
             canvas.style.color = oldColor;
             calendarHeader.style.marginRight = oldMargin;
+
+            // Set text color back
+            if (!isDarkMode()) {
+                for (let i = 0; i < rbc_headers.length; i++) {
+                    // delete rbc_headers[i].style;
+                    rbc_headers[i].className = 'rbc-header';
+                }
+                for (let i = 0; i < rbc_time_slots.length; i++) {
+                    // delete rbc_time_slots[i].style;
+                    rbc_time_slots[i].className = 'rbc-label';
+                }
+            }
 
             this.setState({ screenshotting: false });
         });

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -177,10 +177,11 @@ class ScheduleCalendar extends PureComponent {
         calendarHeader.style.marginRight = '0px';
 
         // Set each rbc header and time slot text color to white if the theme is dark
+        // TODO: If theme is auto, by default set to light theme. Need solution
         let rbc_headers = document.getElementsByClassName('rbc-header');
         let rbc_time_slots = document.getElementsByClassName('rbc-label');
-        console.log(rbc_headers);
-        if (isDarkMode()) {
+        const theme = window.localStorage.getItem('theme');
+        if (theme === 'dark' && theme !== 'auto') {
             for (let i = 0; i < rbc_headers.length; i++) {
                 rbc_headers[i].className = 'rbc-header dark-mode';
             }
@@ -197,7 +198,8 @@ class ScheduleCalendar extends PureComponent {
             calendarHeader.style.marginRight = oldMargin;
 
             // Set text color back
-            if (!isDarkMode()) {
+            // TODO: If theme is auto, by default set to light theme. Need solution
+            if (theme !== 'dark' && theme !== 'auto') {
                 for (let i = 0; i < rbc_headers.length; i++) {
                     // delete rbc_headers[i].style;
                     rbc_headers[i].className = 'rbc-header';

--- a/src/components/Calendar/ScheduleCalendar.js
+++ b/src/components/Calendar/ScheduleCalendar.js
@@ -177,11 +177,10 @@ class ScheduleCalendar extends PureComponent {
         calendarHeader.style.marginRight = '0px';
 
         // Set each rbc header and time slot text color to white if the theme is dark
-        // TODO: If theme is auto, by default set to light theme. Need solution
         let rbc_headers = document.getElementsByClassName('rbc-header');
         let rbc_time_slots = document.getElementsByClassName('rbc-label');
-        const theme = window.localStorage.getItem('theme');
-        if (theme === 'dark' && theme !== 'auto') {
+        // const theme = window.localStorage.getItem('theme');
+        if (isDarkMode()) {
             for (let i = 0; i < rbc_headers.length; i++) {
                 rbc_headers[i].className = 'rbc-header dark-mode';
             }
@@ -198,8 +197,7 @@ class ScheduleCalendar extends PureComponent {
             calendarHeader.style.marginRight = oldMargin;
 
             // Set text color back
-            // TODO: If theme is auto, by default set to light theme. Need solution
-            if (theme !== 'dark' && theme !== 'auto') {
+            if (!isDarkMode()) {
                 for (let i = 0; i < rbc_headers.length; i++) {
                     // delete rbc_headers[i].style;
                     rbc_headers[i].className = 'rbc-header';

--- a/src/components/Calendar/ScreenshotButton.js
+++ b/src/components/Calendar/ScreenshotButton.js
@@ -9,7 +9,7 @@ class ScreenshotButton extends PureComponent {
     handleClick = () => {
         html2canvas(document.getElementById('screenshot'), {
             scale: 2.5,
-            backgroundColor: window.localStorage.getItem('theme') === 'light' ? '#fafafa' : '#303030',
+            backgroundColor: window.localStorage.getItem('theme') === 'dark' ? '#303030' : '#fafafa',
         }).then((canvas) => {
             const img = canvas.toDataURL('image/png');
             const lnk = document.createElement('a');

--- a/src/components/Calendar/ScreenshotButton.js
+++ b/src/components/Calendar/ScreenshotButton.js
@@ -4,12 +4,13 @@ import html2canvas from 'html2canvas';
 import { Panorama } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@material-ui/core';
+import { isDarkMode } from '../../helpers';
 
 class ScreenshotButton extends PureComponent {
     handleClick = () => {
         html2canvas(document.getElementById('screenshot'), {
             scale: 2.5,
-            backgroundColor: window.localStorage.getItem('theme') === 'dark' ? '#303030' : '#fafafa',
+            backgroundColor: isDarkMode() ? '#303030' : '#fafafa',
         }).then((canvas) => {
             const img = canvas.toDataURL('image/png');
             const lnk = document.createElement('a');

--- a/src/components/Calendar/ScreenshotButton.js
+++ b/src/components/Calendar/ScreenshotButton.js
@@ -9,6 +9,7 @@ class ScreenshotButton extends PureComponent {
     handleClick = () => {
         html2canvas(document.getElementById('screenshot'), {
             scale: 2.5,
+            backgroundColor: window.localStorage.getItem('theme') === 'light' ? '#fafafa' : '#303030',
         }).then((canvas) => {
             const img = canvas.toDataURL('image/png');
             const lnk = document.createElement('a');

--- a/src/components/Calendar/calendar.css
+++ b/src/components/Calendar/calendar.css
@@ -6,6 +6,14 @@
     justify-content: center;
 }
 
+.rbc-header.dark-mode {
+    border-bottom: none;
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .rbc-header + .rbc-header {
     border: none;
 }
@@ -34,6 +42,11 @@
 
 .rbc-label {
     font-size: 0.9rem;
+}
+
+.rbc-label.dark-mode {
+    font-size: 0.9rem;
+    color: white;
 }
 
 @media (min-resolution: 96dpi) {


### PR DESCRIPTION
## Summary
I fixed the Dark Mode Screenshots Bug by 
1) Setting the backgroundColor parameter to dark color in the html2canvas options. 
2) Creating dark mode CSS style for rbc-headers and rbc-timeslot labels, and using them if it is in dark mode.
## Test Plan
I set the theme to light and dark and took screenshots separately.
## Issues
Closes https://github.com/icssc/AntAlmanac/issues/442
## Future Followup  
~~When the auto mode is turned on, the screenshot will, by default, apply a light theme.
This might not be good for users using auto mode (they may be using the dark theme on their devices).~~ Solved
