### PR TITLE
Dark Mode Screenshots Bug

### DIFF
--- a/src/components/Calendar/CalendarRoot.tsx
+++ b/src/components/Calendar/CalendarRoot.tsx
@@ -9,7 +9,6 @@ import React, { PureComponent, SyntheticEvent } from 'react';
 import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calendar';
 import ReactDOM from 'react-dom';
 
-import { isDarkMode } from '../../helpers';
 import AppStore from '../../stores/AppStore';
 import CalendarToolbar from './CalendarToolbar';
 import CourseCalendarEvent, { CalendarEvent } from './CourseCalendarEvent';
@@ -204,57 +203,11 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
 
     handleTakeScreenshot = (html2CanvasScreenshot: () => void) => {
         // This function takes a screenshot of the user's schedule
-        // Before we take the screenshot, we need to make some adjustments to the canvas:
-        //  - Set the color to black, so that the weekdays/times still appear when Dark Mode is on
-        //  - Remove the right margin on the calendar header, so the extra area for the scrollbar is removed
 
-        // Fetch the canvas and calendarHeader
-        const canvas = document.getElementById('screenshot') as HTMLElement;
-
-        // this disable only works because this isn't a functional component. It's kinda a hack
-        // eslint-disable-next-line react/no-find-dom-node
-        const headerNode = ReactDOM.findDOMNode(this) as Element;
-        const calendarHeader = headerNode.getElementsByClassName('rbc-time-header')[0] as HTMLElement;
-
-        // Save the current styling, so we can add it back afterwards
-        const oldColor = canvas.style.color;
-        const oldMargin = calendarHeader.style.marginRight;
-
-        // Update the canvas and calendar header for the picture
-        canvas.style.color = 'black';
-        calendarHeader.style.marginRight = '0px';
-
-        // Set each rbc header and time slot text color to white if the theme is dark
-        const rbc_headers = document.getElementsByClassName('rbc-header');
-        const rbc_time_slots = document.getElementsByClassName('rbc-label');
-
-        if (isDarkMode()) {
-            for (let i = 0; i < rbc_headers.length; i++) {
-                rbc_headers[i].className = 'rbc-header dark-mode';
-            }
-            for (let i = 0; i < rbc_time_slots.length; i++) {
-                rbc_time_slots[i].className = 'rbc-label dark-mode';
-            }
-        }
         this.setState({ screenshotting: true }, () => {
             // Take the picture
             html2CanvasScreenshot();
 
-            // Revert the temporary changes to the canvas and calendar
-            canvas.style.color = oldColor;
-            calendarHeader.style.marginRight = oldMargin;
-
-            // Set text color back
-            if (isDarkMode()) {
-                for (let i = 0; i < rbc_headers.length; i++) {
-                    // delete rbc_headers[i].style;
-                    rbc_headers[i].className = 'rbc-header';
-                }
-                for (let i = 0; i < rbc_time_slots.length; i++) {
-                    // delete rbc_time_slots[i].style;
-                    rbc_time_slots[i].className = 'rbc-label';
-                }
-            }
             this.setState({ screenshotting: false });
         });
     };

--- a/src/components/Calendar/CalendarRoot.tsx
+++ b/src/components/Calendar/CalendarRoot.tsx
@@ -3,12 +3,13 @@ import './calendar.css';
 
 import { Popper } from '@material-ui/core';
 import { Theme, withStyles } from '@material-ui/core/styles';
-import { ClassNameMap,Styles  } from '@material-ui/core/styles/withStyles';
+import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import moment from 'moment';
 import React, { PureComponent, SyntheticEvent } from 'react';
 import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calendar';
 import ReactDOM from 'react-dom';
 
+import { isDarkMode } from '../../helpers';
 import AppStore from '../../stores/AppStore';
 import CalendarToolbar from './CalendarToolbar';
 import CourseCalendarEvent, { CalendarEvent } from './CourseCalendarEvent';
@@ -223,6 +224,18 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
         canvas.style.color = 'black';
         calendarHeader.style.marginRight = '0px';
 
+        // Set each rbc header and time slot text color to white if the theme is dark
+        const rbc_headers = document.getElementsByClassName('rbc-header');
+        const rbc_time_slots = document.getElementsByClassName('rbc-label');
+
+        if (isDarkMode()) {
+            for (let i = 0; i < rbc_headers.length; i++) {
+                rbc_headers[i].className = 'rbc-header dark-mode';
+            }
+            for (let i = 0; i < rbc_time_slots.length; i++) {
+                rbc_time_slots[i].className = 'rbc-label dark-mode';
+            }
+        }
         this.setState({ screenshotting: true }, () => {
             // Take the picture
             html2CanvasScreenshot();
@@ -231,6 +244,17 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
             canvas.style.color = oldColor;
             calendarHeader.style.marginRight = oldMargin;
 
+            // Set text color back
+            if (isDarkMode()) {
+                for (let i = 0; i < rbc_headers.length; i++) {
+                    // delete rbc_headers[i].style;
+                    rbc_headers[i].className = 'rbc-header';
+                }
+                for (let i = 0; i < rbc_time_slots.length; i++) {
+                    // delete rbc_time_slots[i].style;
+                    rbc_time_slots[i].className = 'rbc-label';
+                }
+            }
             this.setState({ screenshotting: false });
         });
     };

--- a/src/components/Calendar/CalendarRoot.tsx
+++ b/src/components/Calendar/CalendarRoot.tsx
@@ -7,7 +7,6 @@ import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import moment from 'moment';
 import React, { PureComponent, SyntheticEvent } from 'react';
 import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calendar';
-import ReactDOM from 'react-dom';
 
 import AppStore from '../../stores/AppStore';
 import CalendarToolbar from './CalendarToolbar';

--- a/src/components/Calendar/Toolbar/ScreenshotButton.tsx
+++ b/src/components/Calendar/Toolbar/ScreenshotButton.tsx
@@ -6,6 +6,7 @@ import html2canvas from 'html2canvas';
 import React, { PureComponent } from 'react';
 
 import analyticsEnum, { logAnalytics } from '../../../analytics';
+import { isDarkMode } from '../../../helpers';
 
 interface ScreenshotButtonProps {
     onTakeScreenshot: (html2CanvasScreenshot: () => void) => void; // the function in an ancestor component that wraps ScreenshotButton.handleClick to perform canvas transformations before and after downloading the screenshot.
@@ -19,6 +20,7 @@ class ScreenshotButton extends PureComponent<ScreenshotButtonProps> {
         });
         void html2canvas(document.getElementById('screenshot') as HTMLElement, {
             scale: 2.5,
+            backgroundColor: isDarkMode() ? '#303030' : '#fafafa',
         }).then((canvas) => {
             const imgRaw = canvas.toDataURL('image/png');
             saveAs(imgRaw, 'Schedule.png');

--- a/src/components/Calendar/calendar.css
+++ b/src/components/Calendar/calendar.css
@@ -7,11 +7,7 @@
 }
 
 .rbc-header.dark-mode {
-    border-bottom: none;
     color: white;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
 }
 
 .rbc-header + .rbc-header {
@@ -45,7 +41,6 @@
 }
 
 .rbc-label.dark-mode {
-    font-size: 0.9rem;
     color: white;
 }
 

--- a/src/components/Calendar/calendar.css
+++ b/src/components/Calendar/calendar.css
@@ -6,6 +6,14 @@
     justify-content: center;
 }
 
+.rbc-header.dark-mode {
+    border-bottom: none;
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .rbc-header + .rbc-header {
     border: none;
 }
@@ -34,6 +42,11 @@
 
 .rbc-label {
     font-size: 0.9rem;
+}
+
+.rbc-label.dark-mode {
+    font-size: 0.9rem;
+    color: white;
 }
 
 @media (min-resolution: 96dpi) {

--- a/src/components/Calendar/calendar.css
+++ b/src/components/Calendar/calendar.css
@@ -6,10 +6,6 @@
     justify-content: center;
 }
 
-.rbc-header.dark-mode {
-    color: white;
-}
-
 .rbc-header + .rbc-header {
     border: none;
 }
@@ -38,10 +34,6 @@
 
 .rbc-label {
     font-size: 0.9rem;
-}
-
-.rbc-label.dark-mode {
-    color: white;
 }
 
 @media (min-resolution: 96dpi) {


### PR DESCRIPTION
## Summary
I fixed the Dark Mode Screenshots Bug by 
1) Setting the backgroundColor parameter to dark color in the html2canvas options. 
2) Creating dark mode CSS style for rbc-headers and rbc-timeslot labels, and using them if it is in dark mode.
3) Fixing bug in my previous PR https://github.com/icssc/AntAlmanac/pull/461
## Test Plan
I set the theme to light and dark and took screenshots separately.
## Issues
Closes https://github.com/icssc/AntAlmanac/issues/442
## Note
This PR is a re-open version of my previous PR https://github.com/icssc/AntAlmanac/pull/461 because of the TS codebase conversion.

