### PR TITLE
Duplicate section meetings from different locations

### DIFF
--- a/src/components/RightPane/SectionTable/SectionTableLazyWrapper.tsx
+++ b/src/components/RightPane/SectionTable/SectionTableLazyWrapper.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 
 import { SectionTableProps } from './SectionTable.types';
 
+// This should be in SectionTable.tsx, IMO
 const SectionTable = React.lazy(() => import('./SectionTable'));
 
 export default function SectionTableLazyWrapper(props: SectionTableProps) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -211,12 +211,11 @@ function removeDuplicateMeetings(websocResp: WebsocResponse): WebsocResponse {
 
                             // Add the building to existing meeting instead of creating a new one
                             if (sameDayAndTime && !sameBuilding) {
-                                const newMeeting: Meeting = {
+                                existingMeetings[i] = {
                                     days: existingMeetings[i].days,
                                     time: existingMeetings[i].time,
                                     bldg: existingMeetings[i].bldg + ' & ' + meeting.bldg,
                                 };
-                                existingMeetings[i] = newMeeting;
                                 isNewMeeting = false;
                             }
                         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -159,6 +159,12 @@ export async function queryWebsoc(params: Record<string, string>): Promise<Webso
         return websocCache[searchString];
     }
     url.search = searchString;
+
+    //The data from the API will duplicate a section if it has multiple locations.
+    //I.e., if there's a Tuesday section in two different (probably adjoined) rooms,
+    //courses[i].sections[j].meetings will have two entries, despite it being the same section.
+    //For now, I'm correcting it with removeDuplicateMeetings, but the API should handle this
+
     try {
         const response = (await fetch(url).then((r) => r.json())) as WebsocResponse;
         websocCache[searchString] = { ...response, timestamp: Date.now() };
@@ -174,8 +180,8 @@ export async function queryWebsoc(params: Record<string, string>): Promise<Webso
     }
 }
 
-// Removes duplicate meetings as a result of multiple locations from WebsocResponse
-// See CourseRenderPane::loadCourses() for more info
+// Removes duplicate meetings as a result of multiple locations from WebsocResponse.
+// See queryWebsoc for more info
 // NOTE: The separator is currently an ampersand. Maybe it should be refactored to be an array
 // TODO: Remove if and when API is fixed
 // Maybe put this into CourseRenderPane.tsx -> flattenSOCObject()


### PR DESCRIPTION
## Summary

The meeting duplication was on the API end. I just looked through the response and merged duplicate meetings (separating them with an ampersand). I think this should be fixed on the API side, but this works for now. If we stick to this fix, we should probably refactor meetings.bldg: string -> meetings.locations: string[].

Also, it seems that the map link in the event popup still works despite the mangled name.

## Test Plan

Make sure that everything renders properly in different screen sizes. 

## Issues

Closes #257 
