### PR TITLE
Missing waypoints for course section with fake locations

### DIFF
--- a/src/components/RightPane/Map/UCIMap.tsx
+++ b/src/components/RightPane/Map/UCIMap.tsx
@@ -2,7 +2,7 @@ import '../../../../node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
 import React, { PureComponent } from 'react';
-import { LeafletContext,Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
+import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
 
 import analyticsEnum, { logAnalytics } from '../../../analytics';
 import AppStore from '../../../stores/AppStore';
@@ -41,6 +41,7 @@ const ACCESS_TOKEN = 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ
 const ATTRIBUTION_MARKUP =
     '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors | Images from <a href="https://map.uci.edu/?id=463">UCI Map</a>';
 const DIRECTIONS_ENDPOINT = 'https://api.mapbox.com/directions/v5/mapbox/walking/';
+const FAKE_LOCATIONS = ['VRTL REMOTE', 'ON LINE', 'TBA'];
 
 interface UCIMapState {
     lat: number;
@@ -131,7 +132,7 @@ export default class UCIMap extends PureComponent {
                     method: 'GET',
                     headers: { 'Content-Type': 'application/json' },
                 });
-                const obj = await response.json() as MapBoxResponse;
+                const obj = (await response.json()) as MapBoxResponse;
                 const coordinates = obj['routes'][0]['geometry']['coordinates']; // The coordinates for the lines of the routes
                 const waypoints = obj['waypoints']; // The waypoints we specified in the request
                 let waypointIndex = 0;
@@ -286,7 +287,6 @@ export default class UCIMap extends PureComponent {
         const pins: typeof this.state.pins = {};
         const courses = new Set();
         // Tracks courses that have already been pinned on the map, so there are no duplicates
-
         // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
         this.state.eventsInCalendar
             .filter(
@@ -297,7 +297,8 @@ export default class UCIMap extends PureComponent {
                             !event.scheduleIndices.includes(AppStore.getCurrentScheduleIndex()) ||
                             !event.start.toString().includes(DAYS[day]) ||
                             courses.has(event.sectionCode) || // Remove duplicate courses that appear in the calendar
-                            !courses.add(event.sectionCode)
+                            !courses.add(event.sectionCode) ||
+                            FAKE_LOCATIONS.includes(event.bldg)
                         ) // Adds to the set and return false
                     )
             )


### PR DESCRIPTION
## Summary
Fixed the issue of missing waypoints with the presence of course sections with fake locations by filtering out them.
## Test Plan
I tested the cases that it only has sections with real locations, it only has sections with fake locations, and mixed.
The map functions well.
## Issues

Closes https://github.com/icssc/AntAlmanac/issues/390

<!-- [Optional]
## Future Followup
-->
