### PR TITLE
simplified copy to clipboard

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -353,13 +353,7 @@ export const warnMultipleTerms = (terms: Set<string>) => {
 
 export function clickToCopy(event: React.MouseEvent<HTMLElement, MouseEvent>, sectionCode: string) {
     event.stopPropagation();
-
-    const tempEventTarget = document.createElement('input');
-    document.body.appendChild(tempEventTarget);
-    tempEventTarget.setAttribute('value', sectionCode);
-    tempEventTarget.select();
-    document.execCommand('copy');
-    document.body.removeChild(tempEventTarget);
+    void navigator.clipboard.writeText(sectionCode);
     openSnackbar('success', 'Section code copied to clipboard');
 }
 


### PR DESCRIPTION
## Summary
- use navigator API instead of document

- why would you make a new DOM element to write a raw value to the clipboard????????????????????????????????????????
- caveat: navigator API only works in "secure contexts", e.g. localhost and https in production
- https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined