### PR TITLE
Patchnotes modal

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -7,7 +7,9 @@ import Bar from './AppBar/CustomAppBar';
 import NotificationSnackbar from './AppBar/NotificationSnackbar';
 import Calendar from './Calendar/CalendarRoot';
 import MobileHome from './MobileHome';
+import PatchNotes from './PatchNotes';
 import DesktopTabs from './RightPane/RightPaneRoot';
+
 
 const Home = () => {
     const isMobileScreen = useMediaQuery('(max-width: 750px)');
@@ -15,6 +17,7 @@ const Home = () => {
     return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
             <CssBaseline />
+            <PatchNotes />
             <Bar />
             {isMobileScreen ? (
                 <MobileHome />

--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -7,10 +7,10 @@ const PatchNotes = () => {
 
     // show modal only on first visit    
     useEffect(() => {
-        if (localStorage.getItem('visitedcount')) {
+        if (localStorage.getItem('visitedCount') == 'y') {
             setIsOpen(false);
         } else {
-            localStorage.setItem('visitedcount', '1');
+            localStorage.setItem('visitedCount', 'y');
         }
     }, []);
         
@@ -23,7 +23,7 @@ const PatchNotes = () => {
                 or by clicking outside the dialog 
                 */
                 if(reason == 'backdropClick' || reason == 'escapeKeyDown') {
-                setIsOpen(false);
+                    setIsOpen(false);
                 }
             }} open={isOpen}>
                 <DialogTitle>{"What's New - February 2023"}</DialogTitle>

--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -40,9 +40,6 @@ const PatchNotes = () => {
                             <li>Fixed issues with displaying GE-III courses</li>
                             <li>Fixed courses with multiple locations appearing as independent events</li>
                         </ul>
-                        Other
-                        <ul>
-                        </ul>
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>

--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -31,14 +31,17 @@ const PatchNotes = () => {
                     <DialogContentText>
                         Features
                         <ul>
-                            <li>Added a new feature</li>
-                            <li>Added a second new feature</li>
+                            <li>Added 2023 Spring Quarter courses</li>
+                            <li>Courses will now share colors when added to Calendar</li>
+                            <li>Added this changelog!</li>
                         </ul>
                         Bug Fixes
                         <ul>
-                            <li>Fixed a bug</li>
-                            <li>Fixed another bug</li>
-                            <li>Fixed a third bug (wow!)</li>
+                            <li>Fixed issues with displaying GE-III courses</li>
+                            <li>Fixed courses with multiple locations appearing as independent events</li>
+                        </ul>
+                        Other
+                        <ul>
                         </ul>
                     </DialogContentText>
                 </DialogContent>

--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -1,0 +1,60 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+
+// PatchNotes follows structure/layout of AboutPage.tsx
+const PatchNotes = () => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    // show modal only on first visit    
+    useEffect(() => {
+        if (localStorage.getItem('visitedcount')) {
+            setIsOpen(false);
+        } else {
+            localStorage.setItem('visitedcount', '1');
+        }
+    }, []);
+        
+    
+    return(
+        <>
+            <Dialog fullWidth={true} onClose={(event, reason) => {
+                /* 
+                allow the user to exit the modal using their keyboard 
+                or by clicking outside the dialog 
+                */
+                if(reason == 'backdropClick' || reason == 'escapeKeyDown') {
+                setIsOpen(false);
+                }
+            }} open={isOpen}>
+                <DialogTitle>{"What's New - February 2023"}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Features
+                        <ul>
+                            <li>Added a new feature</li>
+                            <li>Added a second new feature</li>
+                        </ul>
+                        Bug Fixes
+                        <ul>
+                            <li>Fixed a bug</li>
+                            <li>Fixed another bug</li>
+                            <li>Fixed a third bug (wow!)</li>
+                        </ul>
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => {
+                            setIsOpen(false);
+                        }}
+                        color="primary"
+                    >
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    )
+  }
+
+export default PatchNotes

--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -32,7 +32,8 @@ const PatchNotes = () => {
                         Features
                         <ul>
                             <li>Added 2023 Spring Quarter courses</li>
-                            <li>Courses will now share colors when added to Calendar</li>
+                            <li>Lectures/discussions/labs for the same course will now share colors when added to Calendar</li>
+                            <li>You can now resize the calendar with the blue bar in the middle of the page. </li>
                             <li>Added this changelog!</li>
                         </ul>
                         Bug Fixes
@@ -40,6 +41,8 @@ const PatchNotes = () => {
                             <li>Fixed issues with displaying GE-III courses</li>
                             <li>Fixed courses with multiple locations appearing as independent events</li>
                         </ul>
+
+                        Remember to use the <a href="https://docs.google.com/forms/d/e/1FAIpQLSe0emRHqog-Ctl8tjZfJvewY_CSGXys8ykBkFBy1EEUUUHbUw/viewform">feedback form</a> to let us know what you think!
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>


### PR DESCRIPTION
## Summary
Created a modal to let people know what we accomplished every month. Dialog is presented only on first load using localStorage.
![image](https://user-images.githubusercontent.com/71615006/218285723-cbd3ea7c-0b15-4dca-b42f-726bfa831e54.png)

## Test Plan
Ensure that dialog appears once, and can be closed by clicking outside the box, using "escape" on the keyboard, or clicking on the "close" button.

## Issues
Closes #425
Closes #373 

## Future Followup
Content will need to be updated by either hard-coding every month, or partially re-written to load dynamically, and localStorage 'visitedcount' property will need to be reset prior to deploying. Also, this seems to have a lot in common with content put in the "News" tab on the AppBar, maybe open a separate issue to allow the dialog to be brought up again through News? As of now it only appears once and never again.
