### PR TITLE
Duplicate warning bug

### DIFF
--- a/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Theme, Tooltip } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { ClassNameMap , Styles } from '@material-ui/core/styles/withStyles';
+import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { Tune } from '@material-ui/icons';
 import React, { FormEvent, useState } from 'react';
 
@@ -64,7 +64,10 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
             <form onSubmit={onFormSubmit} className={classes.form}>
                 <div className={classes.container}>
                     <div className={classes.margin}>
-                        <TermSelector changeState={(field: string,  value: string)=>RightPaneStore.updateFormValue(field,value)} fieldName={'term'} />
+                        <TermSelector
+                            changeState={(field: string, value: string) => RightPaneStore.updateFormValue(field, value)}
+                            fieldName={'term'}
+                        />
                     </div>
 
                     <div className={classes.container}>
@@ -85,7 +88,6 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                                     category: analyticsEnum.classSearch.title,
                                     action: analyticsEnum.classSearch.actions.MANUAL_SEARCH,
                                 });
-                                toggleSearch();
                             }}
                             onReset={RightPaneStore.resetFormValues}
                         />


### PR DESCRIPTION
## Summary
Fixed the duplicate warning bug by removing one line of the excessive `toggleSearch` function.
This bug was caused by calling `toggleSearch()` twice, first time in `SearchForm.onFormSubmit` and second time in `LegacySearch.onSubmit`.
## Test Plan
I clicked the search button and only one warning showed up.
## Issues

Closes https://github.com/icssc/AntAlmanac/issues/325
