### PR TITLE
oops killed mobile because the ellipsis icon is dislocated

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -26,10 +26,10 @@ const Home = () => {
          * the gutter is the middle bar used to resize the split pane
          * grab the ellipsis DOM node and relocate it under the gutter
          */
-        if (ellipsisRef.current) {
+        if (!isMobileScreen && ellipsisRef.current) {
             document.querySelector('.gutter')?.appendChild(ellipsisRef.current);
         }
-    }, []);
+    }, [isMobileScreen]);
 
     return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -58,17 +58,16 @@ const Home = () => {
                     <Box>
                         <Calendar isMobile={false} />
                     </Box>
+
                     <Box>
                         <DesktopTabs style={{ height: 'calc(100vh - 58px)' }} />
+
+                        {/* render an ellipsis icon and manually teleport it to the gutter */}
+                        <MoreVertIcon ref={ellipsisRef} sx={{ color: 'white' }} />
                     </Box>
                 </Split>
             )}
             <NotificationSnackbar />
-
-            {/* render an ellipsis icon and manually teleport it to the gutter */}
-            {/* disabling because it's too scuffed and will kill the app in mobile mode
-                <MoreVertIcon ref={ellipsisRef} sx={{ color: 'white' }} />
-            */}
         </MuiPickersUtilsProvider>
     );
 };

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -12,7 +12,6 @@ import MobileHome from './MobileHome';
 import PatchNotes from './PatchNotes';
 import DesktopTabs from './RightPane/RightPaneRoot';
 
-
 const Home = () => {
     const isMobileScreen = useMediaQuery('(max-width: 750px)');
     const theme = useTheme();
@@ -67,7 +66,9 @@ const Home = () => {
             <NotificationSnackbar />
 
             {/* render an ellipsis icon and manually teleport it to the gutter */}
-            <MoreVertIcon ref={ellipsisRef} sx={{ color: 'white' }} />
+            {/* disabling because it's too scuffed and will kill the app in mobile mode
+                <MoreVertIcon ref={ellipsisRef} sx={{ color: 'white' }} />
+            */}
         </MuiPickersUtilsProvider>
     );
 };


### PR DESCRIPTION
## Summary (emergency?)
Mobile is dead lol. The ellipsis icon is killing it because React is trying to unmount it but it was dislocated severely from its original DOM position. This patch should preserve it but also locate closer to where it'll be teleported, so React doesn't kill itself in its confusion

