### PR TITLE
Fix ColorPicker not showing section color right after adding.

### DIFF
--- a/src/actions/AppStoreActions.ts
+++ b/src/actions/AppStoreActions.ts
@@ -38,7 +38,7 @@ export const addCourse = (
         section: { ...section, color: '' },
     };
 
-    AppStore.addCourse(newCourse, scheduleIndex);
+    return AppStore.addCourse(newCourse, scheduleIndex);
 };
 /**
  * @param variant usually 'info', 'error', 'warning', or 'success'

--- a/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -85,7 +85,8 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
                     action: analyticsEnum.classSearch.actions.ADD_SPECIFIC,
                 });
             }
-            section.color = addCourse(section, courseDetails, term, scheduleIndex).section.color;
+            const newCourse = addCourse(section, courseDetails, term, scheduleIndex);
+            section.color = newCourse.section.color;
         }
     };
 

--- a/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -85,7 +85,7 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
                     action: analyticsEnum.classSearch.actions.ADD_SPECIFIC,
                 });
             }
-            section.color = addCourse(section, courseDetails, term, scheduleIndex);
+            section.color = addCourse(section, courseDetails, term, scheduleIndex).section.color;
         }
     };
 

--- a/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -85,7 +85,7 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
                     action: analyticsEnum.classSearch.actions.ADD_SPECIFIC,
                 });
             }
-            addCourse(section, courseDetails, term, scheduleIndex);
+            section.color = addCourse(section, courseDetails, term, scheduleIndex);
         }
     };
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -66,15 +66,15 @@ class AppStore extends EventEmitter {
     }
 
     addCourse(newCourse: ScheduleCourse, scheduleIndex: number = this.schedule.getCurrentScheduleIndex()) {
-        let color: string;
+        let addedCourse: ScheduleCourse;
         if (scheduleIndex === this.schedule.getNumberOfSchedules()) {
-            color = this.schedule.addCourseToAllSchedules(newCourse);
+            addedCourse = this.schedule.addCourseToAllSchedules(newCourse);
         } else {
-            color = this.schedule.addCourse(newCourse);
+            addedCourse = this.schedule.addCourse(newCourse);
         }
         this.unsavedChanges = true;
         this.emit('addedCoursesChange');
-        return color;
+        return addedCourse;
     }
 
     getEventsInCalendar() {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -66,13 +66,15 @@ class AppStore extends EventEmitter {
     }
 
     addCourse(newCourse: ScheduleCourse, scheduleIndex: number = this.schedule.getCurrentScheduleIndex()) {
+        let color: string;
         if (scheduleIndex === this.schedule.getNumberOfSchedules()) {
-            this.schedule.addCourseToAllSchedules(newCourse);
+            color = this.schedule.addCourseToAllSchedules(newCourse);
         } else {
-            this.schedule.addCourse(newCourse);
+            color = this.schedule.addCourse(newCourse);
         }
         this.unsavedChanges = true;
         this.emit('addedCoursesChange');
+        return color;
     }
 
     getEventsInCalendar() {

--- a/src/stores/Schedules.ts
+++ b/src/stores/Schedules.ts
@@ -164,6 +164,7 @@ export class Schedules {
      * Sets color to an unused color in set, also will not add class if already exists
      * @param scheduleIndex Defaults to current schedule
      * @param addUndoState Defaults to true
+     * @returns The course object that was added.
      */
     addCourse(newCourse: ScheduleCourse, scheduleIndex: number = this.getCurrentScheduleIndex(), addUndoState = true) {
         if (addUndoState) {
@@ -199,19 +200,19 @@ export class Schedules {
             this.schedules[scheduleIndex].courses.push(courseToAdd);
         }
 
-        return color;
+        return courseToAdd;
     }
 
     /**
      * Adds a course to every schedule
+     * @returns the course object that was added
      */
     addCourseToAllSchedules(newCourse: ScheduleCourse) {
         this.addUndoState();
-        let color: string;
         for (let i = 0; i < this.getNumberOfSchedules(); i++) {
-            color = this.addCourse(newCourse, i, false);
+            this.addCourse(newCourse, i, false);
         }
-        return color;
+        return newCourse;
     }
 
     /**

--- a/src/stores/Schedules.ts
+++ b/src/stores/Schedules.ts
@@ -170,8 +170,8 @@ export class Schedules {
             this.addUndoState();
         }
         let courseToAdd = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
+        let color: string | undefined = undefined;
         if (courseToAdd === undefined) {
-            let color: string | undefined = undefined;
             for (const course of this.getCurrentCourses()) {
                 if (course.courseTitle === newCourse.courseTitle) {
                     color = course.section.color;
@@ -191,11 +191,15 @@ export class Schedules {
                     color,
                 },
             };
+        } else {
+            color = courseToAdd.section.color;
         }
 
         if (!this.doesCourseExistInSchedule(newCourse.section.sectionCode, newCourse.term, scheduleIndex)) {
             this.schedules[scheduleIndex].courses.push(courseToAdd);
         }
+
+        return color;
     }
 
     /**
@@ -203,9 +207,11 @@ export class Schedules {
      */
     addCourseToAllSchedules(newCourse: ScheduleCourse) {
         this.addUndoState();
+        let color: string;
         for (let i = 0; i < this.getNumberOfSchedules(); i++) {
-            this.addCourse(newCourse, i, false);
+            color = this.addCourse(newCourse, i, false);
         }
+        return color;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes a bug where the colorpicker in the sectiontable wouldn't immediately change to the color of an added course.

I figured this one out by re-reading the diff for #457 and looking specifically at the logic around addCourse. This long return chain is how we did it before and it feels kinda janky but I would rather have a patch out than spend a bunch of time architecting a more elegant solution.

## Test Plan
Verify that courses colors are displayed correctly on the color picker immediately after they're added.
## Issues

Closes #510