### PR TITLE
Fix bug by stripping string for condition checking

### DIFF
--- a/src/components/RightPane/Map/UCIMap.tsx
+++ b/src/components/RightPane/Map/UCIMap.tsx
@@ -1,7 +1,7 @@
 import '../../../../node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.js';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import 'leaflet.locatecontrol'
+import 'leaflet.locatecontrol';
 import React, { PureComponent } from 'react';
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
@@ -296,7 +296,7 @@ export default class UCIMap extends PureComponent {
                             !event.start.toString().includes(DAYS[day]) ||
                             courses.has(event.sectionCode) || // Remove duplicate courses that appear in the calendar
                             !courses.add(event.sectionCode) ||
-                            FAKE_LOCATIONS.includes(event.bldg)
+                            FAKE_LOCATIONS.includes(event.bldg.trim())
                         ) // Adds to the set and return false
                     )
             )

--- a/src/components/RightPane/Map/UCIMap.tsx
+++ b/src/components/RightPane/Map/UCIMap.tsx
@@ -1,11 +1,12 @@
-import '../../../../node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.js';
+import 'leaflet.locatecontrol';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import 'leaflet.locatecontrol';
 import React, { PureComponent } from 'react';
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
+
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import AppStore from '$stores/AppStore';
+
 import { CalendarEvent, CourseEvent } from '../../Calendar/CourseCalendarEvent';
 import locations from '../SectionTable/static/locations.json';
 import MapMarker from './MapMarker';


### PR DESCRIPTION
## Summary
Fix the remaining missing-way-point bug by stripping the name of the building in sections.
Predecessor: https://github.com/icssc/AntAlmanac/pull/471
## Test Plan
I tested the cases that it only has sections with real locations, it only has sections with fake locations, and mixed.
The map functions well.
## Issues

Closes https://github.com/icssc/AntAlmanac/issues/390

<!-- [Optional]
## Future Followup
-->
