### PR TITLE
Add 2023 Summer Sessions

### DIFF
--- a/src/components/PatchNotes.tsx
+++ b/src/components/PatchNotes.tsx
@@ -34,7 +34,10 @@ const PatchNotes = () => {
                     <DialogContentText>
                         Features
                         <ul>
-                            <li>Added 2023 Spring Quarter courses</li>
+                            <li>
+                                Added 2023 Spring Quarter, 2023 Summer Session 1, 2023 10-wk Summer, and 2023 Summer
+                                Session 2 courses
+                            </li>
                             <li>
                                 Lectures/discussions/labs for the same course will now share colors when added to
                                 Calendar

--- a/src/lib/termData.ts
+++ b/src/lib/termData.ts
@@ -1,5 +1,5 @@
 // The index of the default term in termData, as per WebSOC
-const defaultTerm = 0;
+const defaultTerm = 3;
 
 class Term {
     shortName: `${string} ${string}`;
@@ -15,6 +15,9 @@ class Term {
 // Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2022-2023/quarterly22-23.html
 // Note: months are 0-indexed
 const termData = [
+    new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),
+    new Term('2023 Summer10wk', '2023 10-wk Summer', [2023, 5, 26]),
+    new Term('2023 Summer1', '2023 Summer Session 1', [2023, 5, 26]),
     new Term('2023 Spring', '2023 Spring Quarter', [2023, 3, 3]),
     new Term('2023 Winter', '2023 Winter Quarter', [2023, 0, 9]),
     new Term('2022 Fall', '2022 Fall Quarter', [2022, 8, 22]),


### PR DESCRIPTION
## Summary

- Added the ability to search for classes in any of the 2023 summer sessions.
- The default term will still be 2023 Spring Quarter.

## Test Plan
- Make sure the class search results are correct for each quarter.
- Make sure you can add/delete/save/load courses for each quarter.
- Make sure the .ics file contains the proper calendar events for each summer class.

<!-- [Optional]
## Future Followup
-->
