### PR TITLE
Loading spinner

### DIFF
--- a/src/components/AppBar/LoadSaveFunctionality.tsx
+++ b/src/components/AppBar/LoadSaveFunctionality.tsx
@@ -18,7 +18,7 @@ import { isDarkMode } from '$lib/helpers';
 
 interface LoadSaveButtonBaseProps {
     action: typeof saveSchedule;
-    actionName: string;
+    actionName: 'Save' | 'Load';
     disabled: boolean;
     loading: boolean;
 }

--- a/src/components/AppBar/LoadSaveFunctionality.tsx
+++ b/src/components/AppBar/LoadSaveFunctionality.tsx
@@ -137,17 +137,6 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
 }
 
 const LoadSaveScheduleFunctionality = () => {
-    useEffect(() => {
-        if (typeof Storage !== 'undefined') {
-            const savedUserID = window.localStorage.getItem('userID');
-
-            if (savedUserID != null) {
-                // this `void` is for eslint "no floating promises"
-                void loadSchedule(savedUserID, true);
-            }
-        }
-    }, []);
-
     const [loading, setLoading] = useState(false);
 
     const loadScheduleAndSetLoading = async (userID: string, rememberMe: boolean) => {
@@ -155,6 +144,17 @@ const LoadSaveScheduleFunctionality = () => {
         await loadSchedule(userID, rememberMe);
         setLoading(false);
     };
+
+    useEffect(() => {
+        if (typeof Storage !== 'undefined') {
+            const savedUserID = window.localStorage.getItem('userID');
+
+            if (savedUserID != null) {
+                // this `void` is for eslint "no floating promises"
+                void loadScheduleAndSetLoading(savedUserID, true);
+            }
+        }
+    }, []);
 
     return (
         <>

--- a/src/components/AppBar/LoadSaveFunctionality.tsx
+++ b/src/components/AppBar/LoadSaveFunctionality.tsx
@@ -10,14 +10,17 @@ import {
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { CloudDownload, Save } from '@material-ui/icons';
-import { ChangeEvent, PureComponent, useEffect } from 'react';
+import { ChangeEvent, PureComponent, useEffect, useState } from 'react';
 
+import { LoadingButton } from '@mui/lab';
 import { loadSchedule, saveSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
 
 interface LoadSaveButtonBaseProps {
     action: typeof saveSchedule;
     actionName: string;
+    disabled: boolean;
+    loading: boolean;
 }
 
 interface LoadSaveButtonBaseState {
@@ -82,13 +85,15 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
     render() {
         return (
             <>
-                <Button
+                <LoadingButton
                     onClick={this.handleOpen}
                     color="inherit"
                     startIcon={this.props.actionName === 'Save' ? <Save /> : <CloudDownload />}
+                    disabled={this.props.disabled}
+                    loading={this.props.loading}
                 >
                     {this.props.actionName}
-                </Button>
+                </LoadingButton>
                 <Dialog open={this.state.isOpen}>
                     <DialogTitle>{this.props.actionName}</DialogTitle>
                     <DialogContent>
@@ -143,10 +148,23 @@ const LoadSaveScheduleFunctionality = () => {
         }
     }, []);
 
+    const [loading, setLoading] = useState(false);
+
+    const loadScheduleAndSetLoading = async (userID: string, rememberMe: boolean) => {
+        setLoading(true);
+        await loadSchedule(userID, rememberMe);
+        setLoading(false);
+    };
+
     return (
         <>
-            <LoadSaveButtonBase actionName={'Save'} action={saveSchedule} />
-            <LoadSaveButtonBase actionName={'Load'} action={loadSchedule} />
+            <LoadSaveButtonBase actionName={'Save'} action={saveSchedule} disabled={loading} loading={false} />
+            <LoadSaveButtonBase
+                actionName={'Load'}
+                action={loadScheduleAndSetLoading}
+                disabled={false}
+                loading={loading}
+            />
         </>
     );
 };


### PR DESCRIPTION
## Summary
- Add loading spinner to the load schedule button and disable save schedule button while loading
- Helps communicate that we are actually indeed loading a schedule
- Prevents saving a schedule with messed up/no data[^1].  

## Test Plan
- Load a schedule

[^1]: Assuming the only way to trigger this bug is by saving a schedule before one finishes loading. This is the only way I've been able to reproduce it but if there is another way to cause the bug then IDK.