### PR TITLE
Fix wrong unit count

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -48,7 +48,6 @@ interface AddedCoursePaneProps {
 interface AddedCoursePaneState {
     courses: CourseWithTerm[];
     customEvents: RepeatingCustomEvent[];
-    totalUnits: number;
     scheduleNames: string[];
     scheduleNote: string;
 }
@@ -57,7 +56,6 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
     state: AddedCoursePaneState = {
         courses: [],
         customEvents: [],
-        totalUnits: 0,
         scheduleNames: AppStore.getScheduleNames(),
         scheduleNote: AppStore.getCurrentScheduleNote(),
     };
@@ -88,7 +86,6 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
 
     loadCourses = () => {
         const currentCourses = AppStore.schedule.getCurrentCourses();
-        let totalUnits = 0;
         const formattedCourses: CourseWithTerm[] = [];
 
         for (const course of currentCourses) {
@@ -116,8 +113,6 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                     ],
                 };
                 formattedCourses.push(formattedCourse);
-
-                if (!isNaN(Number(course.section.units))) totalUnits += Number(course.section.units);
             }
         }
         formattedCourses.forEach(function (course) {
@@ -125,7 +120,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                 return parseInt(a.sectionCode) - parseInt(b.sectionCode);
             });
         });
-        this.setState({ courses: formattedCourses, totalUnits });
+        this.setState({ courses: formattedCourses });
     };
 
     loadCustomEvents = () => {
@@ -147,9 +142,23 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
         updateScheduleNote(event.target.value, AppStore.getCurrentScheduleIndex());
     };
 
+    getTotalUnits = () => {
+        let totalUnits = 0;
+
+        for (const course of this.state.courses) {
+            for (const section of course.sections) {
+                if (!isNaN(Number(section.units))) {
+                    totalUnits += Number(section.units);
+                }
+            }
+        }
+
+        return totalUnits;
+    };
+
     getGrid = () => {
         const scheduleName = this.state.scheduleNames[AppStore.getCurrentScheduleIndex()];
-        const scheduleUnits = this.state.totalUnits;
+        const scheduleUnits = this.getTotalUnits();
         const NOTE_MAX_LEN = 5000;
 
         return (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -380,7 +380,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             <SectionDetailsCell
                 sectionType={section.sectionType as SectionType}
                 sectionNum={section.sectionNum}
-                units={parseInt(section.units)}
+                units={parseFloat(section.units)}
             />
             <InstructorsCell instructors={section.instructors} />
             <DayAndTimeCell meetings={section.meetings} />


### PR DESCRIPTION
## Summary
- Fixed the bug described in #536. When the user removes lectures and adds them back, the total unit count is correctly updated.
- Instead of having `totalUnits` as a state, we can just derive it.
- Fixed a bug found by @Voark a couple months ago where courses that had units with decimal places (like French 1BC with 7.5 units) were displayed as integers only. We just need to do `parseFloat` instead of `parseInt`.

Bug found by @Voark:
![image](https://user-images.githubusercontent.com/78244965/235230208-3c850836-5f13-472e-bb1b-3edd23848e2b.png)

Demo:

https://user-images.githubusercontent.com/78244965/235230522-224fea81-8db7-4194-8fd4-c737df381d1c.mp4



## Test Plan
- Create the schedule described in #536, remove some lectures, and add the lectures back. The total unit count should always be correct.
- Save and load the schedule, and then check if the total unit count is still correct.
- Search for French 1BC and add it to your schedule; the number of units should be 7.5 instead of 7.

## Issues

Closes #536 

<!-- [Optional]
## Future Followup
-->
