### PR TITLE
Add section type to calendar event popup

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -118,12 +118,12 @@ interface CourseCalendarEventProps {
 const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     const { classes, courseInMoreInfo } = props;
     if (!courseInMoreInfo.isCustomEvent) {
-        const { term, instructors, sectionCode, title, finalExam, bldg } = courseInMoreInfo;
+        const { term, instructors, sectionCode, title, finalExam, bldg, sectionType } = courseInMoreInfo;
 
         return (
             <Paper className={classes.courseContainer}>
                 <div className={classes.titleBar}>
-                    <span className={classes.title}>{title}</span>
+                    <span className={classes.title}>{`${title} ${sectionType}`}</span>
                     <Tooltip title="Delete">
                         <IconButton
                             size="small"


### PR DESCRIPTION
## Summary
Adds the section type to the title in the calendar event popup so that the user can check the section type when it's obscured in the calendar.

Before;
![image](https://user-images.githubusercontent.com/64875104/236590950-4be892e3-d20a-4426-85d9-a3bcdb98341b.png)

After:
![image](https://user-images.githubusercontent.com/64875104/236590917-131b7b42-7314-4fc0-a30f-550638017a1e.png)

## Test Plan
See if it looks good on a variety of devices

## Issues
Closes #516 