### PR TITLE
Remove pull_request trigger and fix delete PR action

### DIFF
--- a/.github/workflows/assign_random_reviewer.yaml
+++ b/.github/workflows/assign_random_reviewer.yaml
@@ -1,7 +1,5 @@
 name: "Assign Random Reviewer"
 on:
-  pull_request:
-    types: [opened, ready_for_review, reopened]
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 

--- a/.github/workflows/clean_up_pr.yaml
+++ b/.github/workflows/clean_up_pr.yaml
@@ -20,11 +20,13 @@ jobs:
     uses: ./.github/workflows/step_delete_stack.yaml
     with:
       stack_name: antalmanac-frontend-staging-${{ github.event.pull_request.number }}
+      secrets: inherit
 
   delete_backend_stack:
     uses: ./.github/workflows/step_delete_stack.yaml
     with:
       stack_name: antalmanac-backend-staging-${{ github.event.pull_request.number }}
+      secrets: inherit
 
   delete_staging_url:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary 
### Reviewers Action
The assign reviewers action is triggering twice because there are two triggers. I had added the `pull_request` trigger initially because it was necessary to test the action, but now that the action is in the main branch it is no longer necessary. I didn't realize that both triggers would be triggered after, I thought only one was able to. 

### Delete PR
I forgot to add pass secrets through to the delete steps so they didn't have the credentials to execute a stack delete. Decided to add to this PR because it was so small anyways.

## Test Plan
This PR only has 1 reviewer!

## Issues
