### PR TITLE
Update Map & Routes When Changing Schedules

### DIFF
--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -4,7 +4,7 @@
 import 'leaflet.locatecontrol';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useState } from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
@@ -97,7 +97,7 @@ export default class UCIMap extends PureComponent {
             const courses = new Set();
 
             // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-            this.state.eventsInCalendar
+            AppStore.getEventsInCalendar()
                 .filter(
                     (event) =>
                         !(
@@ -395,7 +395,7 @@ export default class UCIMap extends PureComponent {
         const courses = new Set();
         // Tracks courses that have already been pinned on the map, so there are no duplicates
         // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-        this.state.eventsInCalendar
+        AppStore.getEventsInCalendar()
             .filter(
                 (event) =>
                     !(

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -4,7 +4,7 @@
 import 'leaflet.locatecontrol';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import React, { PureComponent} from 'react';
+import React, { PureComponent } from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -4,7 +4,7 @@
 import 'leaflet.locatecontrol';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import React, { PureComponent, useState } from 'react';
+import React, { PureComponent} from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';


### PR DESCRIPTION
## Summary

1. Maps and routes will now update properly on both Schedule Index and Calendar Event changes. 

![Demonstrates map responsiveness to schedule change](https://github.com/icssc/AntAlmanac/assets/100006999/71787806-e78f-4189-8cfc-192749045437)

![Map responsiveness on event deletion](https://github.com/icssc/AntAlmanac/assets/100006999/baea45d3-09ec-4403-ba66-d9d1861dc5ee)

~~2. Added tooltip to Import button~~

~~<img width="623" alt="Import Tooltip" src="//https://github.com/icssc/AntAlmanac/assets/100006999/fbb6c78a-a1fc-4e1a-8e5b-f9fba8e117d8">~~

~~3. Didn't realize I left it in, but sectionType will now be shown in the pop-up. This appears to already be addressed by #559 , so mb 😅. Our implementation differs only in where it's shown (Heading vs with the other information), but I'll defer 🙇‍♂️~~

## Test Plan

1. Confirmed that when swapping between Schedules 1 and 2, the map's markers would change accordingly. The same does occur for planned routes.

~~2. Verified that on hover, the tooltip with the appropriate message appears.~~

## Issues
Map does not play nice with the finals schedule, but that appears to occur regardless of my PR

Closes #566   ~~& #414~~
