### PR TITLE
Expand start time before 7am

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -225,6 +225,13 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
         return this.state.showFinalsSchedule ? this.state.finalsEventsInCalendar : this.state.eventsInCalendar;
     };
 
+    getStartTime = () => {
+        const eventStartHours = this.getEventsForCalendar().map((event) => event.start.getHours());
+        // If the earliest event has an earlier start time than 7am, return its hour;
+        // otherwise, just make 7am the start time
+        return new Date(2018, 0, 1, Math.min(7, Math.min(...eventStartHours)));
+    };
+
     render() {
         const { classes, isMobile } = this.props;
         const events = this.getEventsForCalendar();
@@ -301,7 +308,7 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}
-                        min={new Date(2018, 0, 1, 7)}
+                        min={this.getStartTime()}
                         max={new Date(2018, 0, 1, 23)}
                         events={events}
                         eventPropGetter={ScheduleCalendar.eventStyleGetter}


### PR DESCRIPTION
## Summary
- If the start time of any event/course is before 7am, the calendar will now expand to support that start time.

Demo:

https://github.com/icssc/AntAlmanac/assets/78244965/e8bc0ab6-3feb-47e0-8416-ee85c4538a49



## Test Plan
- Add a custom event with a start time that is earlier than 7am; the calendar should expand.
- Remove a custom event with an early start time; the calendar should start at 7am again.
- Make sure the finals page is not affected by early custom events. 
- Make sure saving/loading early events works.

## Issues

Closes #564 