### PR TITLE
Added Tooltip to Import

### DIFF
--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -142,9 +142,11 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
         return (
             <>
                 {/* TODO after mui v5 migration: change icon to ContentPasteGo */}
-                <Button onClick={this.handleOpen} color="inherit" startIcon={<PostAdd />}>
-                    Import
-                </Button>
+                <Tooltip title="Import a schedule from your Study List">
+                    <Button onClick={this.handleOpen} color="inherit" startIcon={<PostAdd />}>
+                        Import
+                    </Button>
+                </Tooltip>
                 <Dialog open={this.state.isOpen}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
@@ -178,11 +180,9 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         <Button onClick={() => this.handleClose(false)} color="primary">
                             Cancel
                         </Button>
-                        <Tooltip title="Import a schedule from your Study List">
                             <Button onClick={() => this.handleClose(true)} color="primary">
                                 Import
                             </Button>
-                        </Tooltip>
                     </DialogActions>
                 </Dialog>
             </>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -180,9 +180,9 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         <Button onClick={() => this.handleClose(false)} color="primary">
                             Cancel
                         </Button>
-                            <Button onClick={() => this.handleClose(true)} color="primary">
-                                Import
-                            </Button>
+                        <Button onClick={() => this.handleClose(true)} color="primary">
+                            Import
+                        </Button>
                     </DialogActions>
                 </Dialog>
             </>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -6,6 +6,7 @@ import {
     DialogContentText,
     DialogTitle,
     TextField,
+    Tooltip,
 } from '@material-ui/core';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
@@ -177,9 +178,11 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         <Button onClick={() => this.handleClose(false)} color="primary">
                             Cancel
                         </Button>
-                        <Button onClick={() => this.handleClose(true)} color="primary">
-                            Import
-                        </Button>
+                        <Tooltip title="Import a schedule from your Study List">
+                            <Button onClick={() => this.handleClose(true)} color="primary">
+                                Import
+                            </Button>
+                        </Tooltip>
                     </DialogActions>
                 </Dialog>
             </>


### PR DESCRIPTION
## Summary
Added a Tooltip to the Import Button ("Import a schedule from your Study List")

<img width="623" alt="Import Tooltip" src="https://github.com/icssc/AntAlmanac/assets/100006999/fbb6c78a-a1fc-4e1a-8e5b-f9fba8e117d8">

## Test Plan
Verified that on hover, the tooltip with the appropriate message appears.

## Additional Notes

- Resolves some of my messy business from #567 (original pull request) & #568 
_Atomic Commits 🤩_
- Was previously tested in #568 

Closes #414 