### PR TITLE
Fix course adding bug

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -342,6 +342,7 @@ export class Schedules {
 
         const existingSection = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
         if (existingSection) {
+            this.schedules[scheduleIndex].courses.push(existingSection);
             return existingSection;
         }
 


### PR DESCRIPTION
## Summary
When a course is already added to a schedule, adding it to another didn't do anything. The issue was literally I forgot to add the course in the code.

## Test Plan
- Adding courses in 2 schedules
- Confirm changing color in one schedule changes in both
- Adding a course for the 3rd time keeps the new colors.

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
