### PR TITLE
Adjusted color algorithm for the same sectionType

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -179,17 +179,14 @@ function getColorForNewSection(newSection: ScheduleCourse, sectionsInSchedule: S
     const existingSectionsType = existingSections.filter((course) => course.section.sectionType === newSection.section.sectionType)
 
     const usedColors = new Set(sectionsInSchedule.map((course) => course.section.color));
-
-    if (existingSections.length > 0) {
-        let originalColor = existingSections[0].section.color;
-
-        //if another course of the same sectionType exists, return that color
-        if (existingSectionsType.length > 0){
-            originalColor = existingSectionsType[0].section.color;
-            return originalColor;
-        }
-        return (generateCloseColor(originalColor, usedColors));
-    }
+    
+    //If the same sectionType exists, return that color
+    if(existingSectionsType.length > 0) 
+        return (existingSectionsType[0].section.color);
+        
+    //If the same courseTitle exists, but not the same sectionType, return a hue
+    if(existingSections.length > 0)
+        return (generateCloseColor(existingSections[0].section.color, usedColors));
 
     // If there are no existing sections with the same course title, generate a new color
     return defaultColors.find((materialColor) => !usedColors.has(materialColor)) || '#5ec8e0';

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -184,7 +184,7 @@ function getColorForNewSection(newSection: ScheduleCourse, sectionsInSchedule: S
     if(existingSectionsType.length > 0) 
         return (existingSectionsType[0].section.color);
         
-    //If the same courseTitle exists, but not the same sectionType, return a hue
+    //If the same courseTitle exists, but not the same sectionType, return a close color
     if(existingSections.length > 0)
         return (generateCloseColor(existingSections[0].section.color, usedColors));
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -347,7 +347,6 @@ export class Schedules {
 
         const existingSection = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
         if (existingSection) {
-            this.schedules[scheduleIndex].courses.push(existingSection);
             return existingSection;
         }
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -180,8 +180,13 @@ function getColorForNewSection(newSection: ScheduleCourse, sectionsInSchedule: S
     if (existingSections.length > 0) {
         const originalColor = existingSections[0].section.color;
 
-        // Generate a slightly different color that does not conflict with any other section in the schedule
-        return generateCloseColor(originalColor, usedColors);
+        //If the sectionType is NOT the same, generate a slightly different color that does not conflict with any other section in the schedule
+        //Otherwise, return the same color
+        return (
+            newSection.section.sectionType != existingSections[0].section.sectionType ? 
+            generateCloseColor(originalColor, usedColors): 
+            originalColor
+        )
     }
 
     // If there are no existing sections with the same course title, generate a new color
@@ -342,6 +347,7 @@ export class Schedules {
 
         const existingSection = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
         if (existingSection) {
+            this.schedules[scheduleIndex].courses.push(existingSection);
             return existingSection;
         }
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -175,18 +175,20 @@ function getColorForNewSection(newSection: ScheduleCourse, sectionsInSchedule: S
                 Math.abs(parseInt(b.section.sectionCode) - parseInt(newSection.section.sectionCode))
         );
 
+    //New array of courses that share the same sectionType & courseTitle
+    const existingSectionsType = existingSections.filter((course) => course.section.sectionType === newSection.section.sectionType)
+
     const usedColors = new Set(sectionsInSchedule.map((course) => course.section.color));
 
     if (existingSections.length > 0) {
-        const originalColor = existingSections[0].section.color;
+        let originalColor = existingSections[0].section.color;
 
-        //If the sectionType is NOT the same, generate a slightly different color that does not conflict with any other section in the schedule
-        //Otherwise, return the same color
-        return (
-            newSection.section.sectionType != existingSections[0].section.sectionType ? 
-            generateCloseColor(originalColor, usedColors): 
-            originalColor
-        )
+        //if another course of the same sectionType exists, return that color
+        if (existingSectionsType.length > 0){
+            originalColor = existingSectionsType[0].section.color;
+            return originalColor;
+        }
+        return (generateCloseColor(originalColor, usedColors));
     }
 
     // If there are no existing sections with the same course title, generate a new color


### PR DESCRIPTION
## Summary
- Duplicate classes of the same sectionCode & sectionType (ie ICS 32A LAB at 4PM or 6PM) will generate the same color.
- Additionally, an existing class of the same sectionType will generate the same color, preventing overuse of colors. 
- Currently, I'm only aware of courses with 3 total sectionTypes (ICS 51 w/ LEC LAB DIS), but the color algorithm should comfortably fit four close colors, so it should work for this case as well

<img width="1445" alt="Tentative Fix" src="https://github.com/icssc/AntAlmanac/assets/100006999/8255ba7f-b9f0-4ed1-8b29-0ba20813cf7b">

## Test Plan
- Confirmed that when selecting new courses, the same sectionType (ie ICS 32A LAB) would maintain the same color. 
- When there are 3 types (DIS, LEC, LAB), functionality is as intended
<img width="1445" alt="Three sectionTypes" src="https://github.com/icssc/AntAlmanac/assets/100006999/9cfa3c9c-24a0-4445-9d39-8643d24eb7b8">

## Issues
Follows up from #548 & #509

- Noticed previously that the "nuclear" use case of selecting all available courses of a particular course title (ie every single ICS 32A discussion course) resulted in overuse of the hue, resulting in: Pink -> Light Pink -> ... -> White -> Black

<img width="1445" alt="Issue Screenshot" src="https://github.com/icssc/AntAlmanac/assets/100006999/fb387bbb-68fd-466f-84c4-b4611ce1e3d6">

## Future Followup
Regarding UI design, I'm unsure how the behavior should be implemented for the case demonstrated by Stats 67 in which courses are the same but have different sections.

<img width="1444" alt="Stats 67 Case" src="https://github.com/icssc/AntAlmanac/assets/100006999/f26e9f4e-43c9-43d0-8b72-54220a994ec5">

1. Should identical courses but different sections (NOT sectionType, eg Section A1, A2 versus B1, B2) have the same color?
2. If the answer to 1 is yes, how should colors be implemented?
3. Is there any clean, visually clear way to distinguish classes in different sections? Event shape, borders, etc?