### PR TITLE
Fix for Unremoved Markers - Unique Keys for Children

### DIFF
--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -430,8 +430,8 @@ export default class UCIMap extends PureComponent {
             const courses = pins[buildingCode];
             for (let index = courses.length - 1; index >= 0; index--) {
                 const [event, eventIndex] = courses[index];
-                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg} : ${event.sectionCode} @ ${event.term}`;
                 if (locationData === undefined) return;
+                const key = `${event.title} ${event.sectionType} @ ${event.bldg} : ${event.sectionCode} @ ${event.term}`;
 
                 // Acronym, if it exists, is in between parentheses
                 const acronym = locationData.name.substring(
@@ -441,7 +441,7 @@ export default class UCIMap extends PureComponent {
 
                 markers.push(
                     <MapMarker
-                        key={courseString}
+                        key={key}
                         image={locationData.imageURLs[0]}
                         markerColor={event.color}
                         location={locationData.name}

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -430,7 +430,7 @@ export default class UCIMap extends PureComponent {
             const courses = pins[buildingCode];
             for (let index = courses.length - 1; index >= 0; index--) {
                 const [event, eventIndex] = courses[index];
-                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg} : ${event.sectionCode}`;
+                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg} : ${event.sectionCode} @ ${event.term}`;
                 if (locationData === undefined) return;
 
                 // Acronym, if it exists, is in between parentheses

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -430,7 +430,7 @@ export default class UCIMap extends PureComponent {
             const courses = pins[buildingCode];
             for (let index = courses.length - 1; index >= 0; index--) {
                 const [event, eventIndex] = courses[index];
-                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg}`;
+                const courseString = `${event.title} ${event.sectionType} @ ${event.bldg} : ${event.sectionCode}`;
                 if (locationData === undefined) return;
 
                 // Acronym, if it exists, is in between parentheses


### PR DESCRIPTION
## Summary
Following #568 , the map would now not remove markers that had duplicate keys. For instance, if two STATS 67 LEC were in the calendar, the second of the two event markers would not be removed due to their duplicate keys. 

To resolve this, sectionCode & term was added to the key generator:

Before:

![Duplicate Marker Nonsense](https://user-images.githubusercontent.com/100006999/238760905-10315d6b-6586-4469-b029-bdbea34b64dd.gif)

After:
![Fixed Marker Nonsense](https://github.com/icssc/AntAlmanac/assets/100006999/7a57a19c-043c-4a14-853d-d681488b1b63)

## Test Plan
- As far as I can tell, `key` is only used here as an identifier, so no issues should arise elsewhere.
- Checked functionality for multiple courses & combinations

## Issues
~~Frankly, I've got no idea how courses end up working term to term, in the context of AntAlmanac and this key, so... _theoretically could there be some edge case where **the same class with the same section code** BUT **in different terms** appear on the same calendar? Would that create this bug again?_~~
Solved in commit 996ffbff9246eb7f60daeddbf6cf14bf104f1f09 by incorporating terms into the key!

<sub> 99 little bugs in the code, 99 little bugs in the code. Take one down, patch it around 117 little bugs in the code. <sub>

Closes #575 