### PR TITLE
Escape Dialog Fix

### DIFF
--- a/apps/antalmanac/src/components/AppBar/AboutPage.tsx
+++ b/apps/antalmanac/src/components/AppBar/AboutPage.tsx
@@ -8,6 +8,18 @@ class AboutPage extends PureComponent {
     state: { isOpen: boolean } = {
         isOpen: false,
     };
+
+    handleClose = (wasCancelled: boolean) => {
+        if(wasCancelled)
+        this.setState({ isOpen: false}, () => {
+            document.removeEventListener('keydown', this.enterEvent, false); //this.enterEvent seems like nonsense
+            this.setState({ userID: '' })
+        });
+    }
+
+    enterEvent = (event: KeyboardEvent) => {
+    };
+
     render() {
         return (
             <>
@@ -24,7 +36,7 @@ class AboutPage extends PureComponent {
                 >
                     About
                 </Button>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
                     <DialogTitle>About</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -120,6 +120,13 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
         });
     };
 
+    handleEscClose = (escKeyPress: boolean) => {
+        this.setState({ isOpen: false }, async () => {
+            document.removeEventListener('keydown', this.enterEvent, false);
+            this.setState({ studyListText: '' });
+        });
+    }
+
     enterEvent = (event: KeyboardEvent) => {
         const charCode = event.which ? event.which : event.keyCode;
         // enter (13) or newline (10)
@@ -147,7 +154,7 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         Import
                     </Button>
                 </Tooltip>
-                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
+                <Dialog open={this.state.isOpen} onClose={this.handleEscClose}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -6,6 +6,7 @@ import {
     DialogContentText,
     DialogTitle,
     TextField,
+    Tooltip,
 } from '@material-ui/core';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
@@ -141,9 +142,11 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
         return (
             <>
                 {/* TODO after mui v5 migration: change icon to ContentPasteGo */}
-                <Button onClick={this.handleOpen} color="inherit" startIcon={<PostAdd />}>
-                    Import
-                </Button>
+                <Tooltip title="Import a schedule from your Study List">
+                    <Button onClick={this.handleOpen} color="inherit" startIcon={<PostAdd />}>
+                        Import
+                    </Button>
+                </Tooltip>
                 <Dialog open={this.state.isOpen}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -147,7 +147,7 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         Import
                     </Button>
                 </Tooltip>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/LoadSaveFunctionality.tsx
+++ b/apps/antalmanac/src/components/AppBar/LoadSaveFunctionality.tsx
@@ -94,7 +94,7 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
                 >
                     {this.props.actionName}
                 </LoadingButton>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
                     <DialogTitle>{this.props.actionName}</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -118,7 +118,7 @@ interface CourseCalendarEventProps {
 const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     const { classes, courseInMoreInfo } = props;
     if (!courseInMoreInfo.isCustomEvent) {
-        const { term, instructors, sectionCode, title, finalExam, bldg } = courseInMoreInfo;
+        const { term, instructors, sectionCode, title, finalExam, bldg, sectionType } = courseInMoreInfo;
 
         return (
             <Paper className={classes.courseContainer}>
@@ -178,6 +178,10 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                                     {bldg}
                                 </button>
                             </td>
+                        </tr>
+                        <tr>
+                            <td>Section type</td>
+                            <td className={classes.rightCells}>{sectionType}</td>
                         </tr>
                         <tr>
                             <td>Final</td>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -161,7 +161,7 @@ class CustomEventDialog extends PureComponent<CustomEventDialogProps, CustomEven
                         </Button>
                     </Tooltip>
                 )}
-                <Dialog open={this.state.open} maxWidth={'lg'}>
+                <Dialog open={this.state.open} maxWidth={'lg'} onClose={this.handleClose}>
                     <DialogContent>
                         <FormControl>
                             <InputLabel htmlFor="EventNameInput">Event Name</InputLabel>

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -4,7 +4,7 @@
 import 'leaflet.locatecontrol';
 
 import Leaflet, { Control, LeafletMouseEvent } from 'leaflet';
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useState } from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { LeafletContext, Map, Marker, Polyline, TileLayer, withLeaflet } from 'react-leaflet';
@@ -97,7 +97,7 @@ export default class UCIMap extends PureComponent {
             const courses = new Set();
 
             // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-            this.state.eventsInCalendar
+            AppStore.getEventsInCalendar()
                 .filter(
                     (event) =>
                         !(
@@ -395,7 +395,7 @@ export default class UCIMap extends PureComponent {
         const courses = new Set();
         // Tracks courses that have already been pinned on the map, so there are no duplicates
         // Filter out those in a different schedule or those not on a certain day (mon, tue, etc)
-        this.state.eventsInCalendar
+        AppStore.getEventsInCalendar()
             .filter(
                 (event) =>
                     !(


### PR DESCRIPTION
### Moved to #579 because I'm bad at branches

## Summary
Adding in the capability to use the escape key and/or click out of the Dialogs in the AppBar & the Add Custom Event dialog

![Escape Dialog Responsiveness](https://github.com/icssc/AntAlmanac/assets/100006999/811dfb60-d36a-46a0-9ca6-2b4c99298ac9)

## Test Plan
- Tested `AppBar`'s Save, Load, Import, and About dialogs for responsiveness on Esc and clicks outside.
- Also tested the Add Custom event button for the same

## Issues
For the Import Dialog, the onClose function also creates a Snackbar error when hitting escape/clicking out. To solve that, I created another function `handleEscClose` since I couldn't figure out how to differentiate between clicking import with an empty Study List input field.

I have no doubt there's some React jargon that describes this solution of mine as not best practice 😵‍💫

## Future Followup
Currently keeping this as a draft so that I can further investigate if Calendar event popups and Schedule Index/Schedule Selection popups can be escaped (even though they don't use dialogs)

Closes #551 
