### PR TITLE
Escape Dialog Fix #2

### DIFF
--- a/apps/antalmanac/src/components/AppBar/AboutPage.tsx
+++ b/apps/antalmanac/src/components/AppBar/AboutPage.tsx
@@ -8,6 +8,18 @@ class AboutPage extends PureComponent {
     state: { isOpen: boolean } = {
         isOpen: false,
     };
+
+    handleClose = (wasCancelled: boolean) => {
+        if(wasCancelled)
+            this.setState({ isOpen: false}, () => {
+                document.removeEventListener('keydown', this.enterEvent, false); //this.enterEvent seems like nonsense
+                this.setState({ userID: '' })
+            });
+    }
+    
+    enterEvent = (event: KeyboardEvent) => {
+    };
+
     render() {
         return (
             <>
@@ -24,7 +36,7 @@ class AboutPage extends PureComponent {
                 >
                     About
                 </Button>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
                     <DialogTitle>About</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/AboutPage.tsx
+++ b/apps/antalmanac/src/components/AppBar/AboutPage.tsx
@@ -9,16 +9,9 @@ class AboutPage extends PureComponent {
         isOpen: false,
     };
 
-    handleClose = (wasCancelled: boolean) => {
-        if(wasCancelled)
-            this.setState({ isOpen: false}, () => {
-                document.removeEventListener('keydown', this.enterEvent, false); //this.enterEvent seems like nonsense
-                this.setState({ userID: '' })
-            });
-    }
-    
-    enterEvent = (event: KeyboardEvent) => {
-    };
+    // handleClose = () => {
+    //     this.setState({ isOpen: false })
+    // }
 
     render() {
         return (
@@ -36,7 +29,7 @@ class AboutPage extends PureComponent {
                 >
                     About
                 </Button>
-                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
+                <Dialog open={this.state.isOpen} onClose={() => this.setState({ isOpen: false })}>
                     <DialogTitle>About</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/AboutPage.tsx
+++ b/apps/antalmanac/src/components/AppBar/AboutPage.tsx
@@ -9,10 +9,6 @@ class AboutPage extends PureComponent {
         isOpen: false,
     };
 
-    // handleClose = () => {
-    //     this.setState({ isOpen: false })
-    // }
-
     render() {
         return (
             <>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -120,6 +120,13 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
         });
     };
 
+    handleEscClose = () => {
+        this.setState({ isOpen: false }, async () => {
+            document.removeEventListener('keydown', this.enterEvent, false);
+            this.setState({ studyListText: '' });
+        });
+    }
+
     enterEvent = (event: KeyboardEvent) => {
         const charCode = event.which ? event.which : event.keyCode;
         // enter (13) or newline (10)
@@ -147,7 +154,7 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         Import
                     </Button>
                 </Tooltip>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleEscClose}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -120,13 +120,6 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
         });
     };
 
-    handleEscClose = () => {
-        this.setState({ isOpen: false }, async () => {
-            document.removeEventListener('keydown', this.enterEvent, false);
-            this.setState({ studyListText: '' });
-        });
-    }
-
     enterEvent = (event: KeyboardEvent) => {
         const charCode = event.which ? event.which : event.keyCode;
         // enter (13) or newline (10)
@@ -154,7 +147,7 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         Import
                     </Button>
                 </Tooltip>
-                <Dialog open={this.state.isOpen} onClose={this.handleEscClose}>
+                <Dialog open={this.state.isOpen} onClose={() => this.setState({ isOpen: false, studyListText: '' })}>
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
+++ b/apps/antalmanac/src/components/AppBar/ImportStudyList.tsx
@@ -147,7 +147,13 @@ class ImportStudyList extends PureComponent<ImportStudyListProps, ImportStudyLis
                         Import
                     </Button>
                 </Tooltip>
-                <Dialog open={this.state.isOpen} onClose={() => this.setState({ isOpen: false, studyListText: '' })}>
+                <Dialog 
+                    open={this.state.isOpen} 
+                    onClose={() => this.setState(
+                        { isOpen: false, studyListText: ''}, 
+                        async () => {document.removeEventListener('keydown', this.enterEvent, false)}
+                    )}
+                >
                     <DialogTitle>Import Schedule</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/AppBar/LoadSaveFunctionality.tsx
+++ b/apps/antalmanac/src/components/AppBar/LoadSaveFunctionality.tsx
@@ -94,7 +94,7 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
                 >
                     {this.props.actionName}
                 </LoadingButton>
-                <Dialog open={this.state.isOpen}>
+                <Dialog open={this.state.isOpen} onClose={this.handleClose}>
                     <DialogTitle>{this.props.actionName}</DialogTitle>
                     <DialogContent>
                         <DialogContentText>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -161,7 +161,7 @@ class CustomEventDialog extends PureComponent<CustomEventDialogProps, CustomEven
                         </Button>
                     </Tooltip>
                 )}
-                <Dialog open={this.state.open} maxWidth={'lg'}>
+                <Dialog open={this.state.open} onClose={this.handleClose} maxWidth={'lg'}>
                     <DialogContent>
                         <FormControl>
                             <InputLabel htmlFor="EventNameInput">Event Name</InputLabel>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
@@ -39,7 +39,7 @@ const DeleteScheduleDialog = (props: DeleteScheduleDialogProps) => {
             <MenuItem onClick={handleOpen} disabled={AppStore.schedule.getNumberOfSchedules() === 1}>
                 Delete Schedule
             </MenuItem>
-            <Dialog open={isOpen}>
+            <Dialog open={isOpen} onClose={handleClose}>
                 <DialogTitle>Delete Schedule</DialogTitle>
                 <DialogContent>
                     <DialogContentText>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -58,6 +58,9 @@ const ScheduleNameDialog = (props: ScheduleNameDialogProps) => {
         if (event.key === 'Enter') {
             submitName();
         }
+        if (event.key === 'Escape') {
+            setIsOpen(false);
+        }
     };
 
     const submitName = () => {
@@ -88,6 +91,7 @@ const ScheduleNameDialog = (props: ScheduleNameDialogProps) => {
                 open={isOpen}
                 onKeyDown={handleKeyDown}
                 onClick={(event: React.MouseEvent<Element, MouseEvent>) => event.stopPropagation()}
+                onClose={() => setIsOpen(false)}
             >
                 <DialogTitle>{rename ? 'Rename Schedule' : 'Add a New Schedule'}</DialogTitle>
                 <DialogContent>


### PR DESCRIPTION
## Summary
- Added in the capability to use the escape key and/or click out of the Dialogs in the AppBar & the Add Custom Event dialog. 
- Edit (5/19): Virtually all popups/dialogs that I can find have escape functionality now 
    - Includes add, rename, delete schedule popups
 
![Escape Dialog Responsiveness](https://github.com/icssc/AntAlmanac/assets/100006999/811dfb60-d36a-46a0-9ca6-2b4c99298ac9)

## Test Plan
- Tested `AppBar`'s Save, Load, Import, and About dialogs for responsiveness on Esc and clicks outside.
- Also tested the `CustomEventDialog` button for the same
- Tested Add & Rename Schedule Dialogs for the same

## Issues
Closes #551 


## Additional Notes
- For the Add/Rename Schedule Dialogs, it currently retains the last inputted strings before `onClose`. Not sure what the "best practice" behavior would be for it, so leaving it up to y'alls input! _It does clear itself when the initial popup (eg the initial rename/delete schedule popup) fully closes though!_

![Current Input Behavior](https://github.com/icssc/AntAlmanac/assets/100006999/681b61d8-8fda-4cea-8c43-23a159834842)

<sub> I have no doubt there's some implementation of mine that isn't ~~best practice~~ idiomatic 😵‍💫. Would love pointers on how to improve 💖 <sub>

## Future Followup
- Schedule Index/Schedule Selection (in the top left) popups <-- Don't want this to hold up the PR (and quite frankly `FormGroup` is driving me nuts) so I'm gonna let this simmer