### PR TITLE
Close calendar event popups with [esc]

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -3,6 +3,7 @@ import { Theme, withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { Delete } from '@material-ui/icons';
 import { Event } from 'react-big-calendar';
+import { useEffect, useRef } from 'react'; 
 
 import RightPaneStore, { BuildingFocusInfo } from '../RightPane/RightPaneStore';
 import CustomEventDialog from './Toolbar/CustomEventDialog/CustomEventDialog';
@@ -116,12 +117,33 @@ interface CourseCalendarEventProps {
 }
 
 const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
+
+    const isShown = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      const handleKeyDown = (event: { keyCode: number; }) => {
+        if (event.keyCode === 27) {
+          if(isShown.current)
+                isShown.current.style.display = 'none';
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+    }, []);
+    
     const { classes, courseInMoreInfo } = props;
     if (!courseInMoreInfo.isCustomEvent) {
         const { term, instructors, sectionCode, title, finalExam, bldg, sectionType } = courseInMoreInfo;
 
         return (
-            <Paper className={classes.courseContainer}>
+            <Paper 
+                className={classes.courseContainer}
+                ref={isShown}
+            >
                 <div className={classes.titleBar}>
                     <span className={classes.title}>{`${title} ${sectionType}`}</span>
                     <Tooltip title="Delete">
@@ -202,7 +224,10 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     } else {
         const { title, customEventID } = courseInMoreInfo;
         return (
-            <Paper className={classes.customEventContainer}>
+            <Paper 
+                className={classes.customEventContainer}
+                ref={isShown}
+            >
                 <div className={classes.title}>{title}</div>
                 <div className={classes.buttonBar}>
                     <div className={`${classes.colorPicker}`}>

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -122,6 +122,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
     useEffect(() => {
       const handleKeyDown = (event: { keyCode: number; }) => {
+        //event.keyCode === 27 reads for the "escape" key
         if (event.keyCode === 27) {
           if(isShown.current)
                 isShown.current.style.display = 'none';

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -118,14 +118,14 @@ interface CourseCalendarEventProps {
 
 const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
-    const isShown = useRef<HTMLInputElement>(null);
+    const paperRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
       const handleKeyDown = (event: { keyCode: number; }) => {
         //event.keyCode === 27 reads for the "escape" key
         if (event.keyCode === 27) {
-          if(isShown.current)
-                isShown.current.style.display = 'none';
+          if(paperRef.current)
+                paperRef.current.style.display = 'none';
         }
       };
 
@@ -143,7 +143,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         return (
             <Paper 
                 className={classes.courseContainer}
-                ref={isShown}
+                ref={paperRef}
             >
                 <div className={classes.titleBar}>
                     <span className={classes.title}>{`${title} ${sectionType}`}</span>
@@ -227,7 +227,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         return (
             <Paper 
                 className={classes.customEventContainer}
-                ref={isShown}
+                ref={paperRef}
             >
                 <div className={classes.title}>{title}</div>
                 <div className={classes.buttonBar}>


### PR DESCRIPTION
## Summary
<sub> _Because I'm very shaky on React Hooks, I made a new branch with just the changes to `CourseCalendarEvent.tsx` for review and feedback specifically on this, since it isn't a Dialog & `onClick`!_ <sub>

- Previously, you had to click out of Calendar Event popups (which may cover other events). 
- Implemented React Hooks that listens for the "escape" keyCode and sets the visibility of the `Paper` popup to `'none'`.

![Escape Functionality](https://github.com/icssc/AntAlmanac/assets/100006999/9c87dbc6-0322-4c8a-a817-87ba615d8e2f)

## Test Plan
Checked that on "escape", the Paper/popup disappears.

## Issues
Extends upon #579 which resulted from #551 