### PR TITLE
Added [esc] functionality for Map Markers

### DIFF
--- a/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
@@ -94,6 +94,19 @@ const MapMarker = ({
         if (openPopup) _openPopup(markerRef);
     }, [markerRef, openPopup, lat, lng, location]);
 
+    function handleKeyPress(event: { key: string; }) {
+        if(event.key === 'Escape' && markerRef.current){
+            markerRef.current.leafletElement.closePopup();
+        }
+        return () => {
+            document.removeEventListener('keydown', handleKeyPress)
+        };
+    }
+
+    function escListener () {
+        document.addEventListener('keydown', handleKeyPress)
+    }
+
     return (
         <Marker
             position={[lat, lng]}
@@ -105,6 +118,7 @@ const MapMarker = ({
                     category: analyticsEnum.map.title,
                     action: analyticsEnum.map.actions.CLICK_PIN,
                 });
+                escListener();
             }}
         >
             <Popup>

--- a/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
@@ -24,7 +24,7 @@ interface MapMarkerProps {
     openPopup?: boolean;
 }
 
-type MarkerRef = React.MutableRefObject<Marker | null >;
+type MarkerRef = React.MutableRefObject<Marker | null>;
 
 const MapMarker = ({
     index,

--- a/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMarker.tsx
@@ -24,7 +24,7 @@ interface MapMarkerProps {
     openPopup?: boolean;
 }
 
-type MarkerRef = React.MutableRefObject<Marker | null>;
+type MarkerRef = React.MutableRefObject<Marker | null >;
 
 const MapMarker = ({
     index,
@@ -79,7 +79,7 @@ const MapMarker = ({
     } else {
         locationLinkElement = location;
     }
-
+    
     const markerRef = useState(useRef(null))[0];
 
     function _openPopup(_markerRef: MarkerRef) {
@@ -96,15 +96,16 @@ const MapMarker = ({
 
     function handleKeyPress(event: { key: string; }) {
         if(event.key === 'Escape' && markerRef.current){
+            //@ts-ignore
             markerRef.current.leafletElement.closePopup();
         }
         return () => {
-            document.removeEventListener('keydown', handleKeyPress)
+            document.removeEventListener('keydown', handleKeyPress, false)
         };
     }
 
     function escListener () {
-        document.addEventListener('keydown', handleKeyPress)
+        document.addEventListener('keydown', handleKeyPress, false)
     }
 
     return (


### PR DESCRIPTION
## Summary
- Allows for the escape key to be used to close map markers.

![Escape on Map Marker](https://github.com/icssc/AntAlmanac/assets/100006999/c42378b3-5610-42b4-84b9-aeefb449edd6)

## Test Plan
- Checked that the escape functionality works on markers, even when schedules, dates, and events are removed.

## Issues
Extends upon #579 and comes from #551 

## Additional Notes
- #563 and it doesn't appear to have an escape functionality for the map markers in `apps/antalmanac/src/components/Map/Marker.tsx` (which as far as I can tell, haven't been changed much), but I decided to PR this separately just in case (and because of some bumps I ran into)!
- My implementation might be wonky, and frankly I don't like how I used `onClick` to call `escListener()` to call `handleKeyPress`. Input & tips much appreciated
- Utilizing `markerRef.current.leafletElement.closePopup()` returns a problem on `.leafletElement`, saying `Property 'leafletElement' does not exist on type 'never'.ts(2339)`. I threw it a `@ts-ignore` for now...
- I'm currently using Google Chrome's dev tools Event Listener and it seems to be indicating that my eventListeners (one per marker, once initially clicked) are not being removed, but I can't figure out why that's happening 😵‍💫. 
