### PR TITLE
Minor UI Fix to School/Dept Cards

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -1,4 +1,3 @@
-import { isDarkMode } from '$lib/helpers';
 import { Collapse, Grid, Paper, Theme, Typography, withStyles } from '@material-ui/core';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
@@ -18,7 +17,6 @@ const styles: Styles<Theme, object> = (theme) => ({
         ...theme.mixins.gutters(),
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
-        backgroundColor: isDarkMode() ? '#515151' : '#F5F5F5',
     },
     text: {
         flexBasis: '50%',

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -17,11 +17,13 @@ const styles: Styles<Theme, object> = (theme) => ({
         ...theme.mixins.gutters(),
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
+        backgroundColor: '#515151',
     },
     text: {
         flexBasis: '50%',
         flexGrow: 1,
         display: 'inline',
+        cursor: 'pointer',
     },
     icon: {
         cursor: 'pointer',
@@ -54,6 +56,10 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
                     <Typography
                         noWrap
                         variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}
+                        onClick={() =>
+                            this.setState({
+                                commentsOpen: !this.state.commentsOpen,
+                            })}
                         className={this.props.classes.text}
                     >
                         {this.props.name}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -1,4 +1,14 @@
-import { Accordion, AccordionDetails, AccordionSummary, Box, Grid, Paper, Theme, Typography, withStyles } from '@material-ui/core';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Box,
+    Grid,
+    Paper,
+    Theme,
+    Typography,
+    withStyles,
+} from '@material-ui/core';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { ExpandMore } from '@material-ui/icons';
 import { PureComponent } from 'react';
@@ -50,20 +60,22 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
         const html = { __html: this.props.comment };
         return (
             <Grid item xs={12}>
-                <Paper elevation={1} square>
+                <Paper elevation={1} square style={{ overflow: 'hidden' }}>
                     <Accordion>
                         <AccordionSummary expandIcon={<ExpandMore />}>
-                            <Typography 
-                                variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}
-                            >
+                            <Typography variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}>
                                 {this.props.name}
                             </Typography>
                         </AccordionSummary>
                         <AccordionDetails>
-                                <Typography variant="body2">
-                                    {this.props.comment === '' ? 'No comments found' : 'Comments:'}
-                                    <Box dangerouslySetInnerHTML={html} className={this.props.classes.comments} />
-                                </Typography>
+                            <Typography variant="body2">
+                                <p>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</p>
+                                <Box
+                                    dangerouslySetInnerHTML={html}
+                                    className={this.props.classes.comments}
+                                    component="p"
+                                />
+                            </Typography>
                         </AccordionDetails>
                     </Accordion>
                 </Paper>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -50,19 +50,16 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
         const html = { __html: this.props.comment };
         return (
             <Grid item xs={12}>
-                <Paper className={this.props.classes[this.props.type]} elevation={1} square>
+                <Paper elevation={1} square>
                     <Accordion>
                         <AccordionSummary expandIcon={<ExpandMore />}>
-                            <Typography
-                                noWrap={true}
+                            <Typography 
                                 variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}
-                                
                             >
                                 {this.props.name}
                             </Typography>
                         </AccordionSummary>
                         <AccordionDetails>
-                                {this.state.commentsOpen}
                                 <Typography variant="body2">
                                     {this.props.comment === '' ? 'No comments found' : 'Comments:'}
                                     <Box dangerouslySetInnerHTML={html} className={this.props.classes.comments} />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -1,6 +1,6 @@
-import { Collapse, Grid, Paper, Theme, Typography, withStyles } from '@material-ui/core';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Grid, Paper, Theme, Typography, withStyles } from '@material-ui/core';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
-import { ExpandLess, ExpandMore } from '@material-ui/icons';
+import { ExpandMore } from '@material-ui/icons';
 import { PureComponent } from 'react';
 
 const styles: Styles<Theme, object> = (theme) => ({
@@ -48,38 +48,27 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
 
     render() {
         const html = { __html: this.props.comment };
-        const ExpandIcon = this.state.commentsOpen ? ExpandLess : ExpandMore;
         return (
             <Grid item xs={12}>
                 <Paper className={this.props.classes[this.props.type]} elevation={1} square>
-                    <Typography
-                        noWrap
-                        variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}
-                        onClick={() =>
-                            this.setState({
-                                commentsOpen: !this.state.commentsOpen,
-                            })}
-                        className={this.props.classes.text}
-                    >
-                        {this.props.name}
-                    </Typography>
-                    <>
-                        <ExpandIcon
-                            onClick={() =>
-                                this.setState({
-                                    commentsOpen: !this.state.commentsOpen,
-                                })
-                            }
-                            className={this.props.classes.icon}
-                        />
-
-                        <Collapse in={this.state.commentsOpen} className={this.props.classes.collapse}>
-                            <Typography variant="body2">
-                                {this.props.comment === '' ? 'No comments found' : 'Comments:'}
+                    <Accordion>
+                        <AccordionSummary expandIcon={<ExpandMore />}>
+                            <Typography
+                                noWrap={true}
+                                variant={this.props.type === 'school' ? 'h6' : 'subtitle1'}
+                                
+                            >
+                                {this.props.name}
                             </Typography>
-                            <div dangerouslySetInnerHTML={html} className={this.props.classes.comments} />
-                        </Collapse>
-                    </>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                                {this.state.commentsOpen}
+                                <Typography variant="body2">
+                                    {this.props.comment === '' ? 'No comments found' : 'Comments:'}
+                                    <Box dangerouslySetInnerHTML={html} className={this.props.classes.comments} />
+                                </Typography>
+                        </AccordionDetails>
+                    </Accordion>
                 </Paper>
             </Grid>
         );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -1,3 +1,4 @@
+import { isDarkMode } from '$lib/helpers';
 import { Collapse, Grid, Paper, Theme, Typography, withStyles } from '@material-ui/core';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
@@ -17,7 +18,7 @@ const styles: Styles<Theme, object> = (theme) => ({
         ...theme.mixins.gutters(),
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
-        backgroundColor: '#515151',
+        backgroundColor: isDarkMode() ? '#515151' : '#F5F5F5',
     },
     text: {
         flexBasis: '50%',


### PR DESCRIPTION
## Summary

- Comment cards on both School and Department can now be opened by clicking the text box, in addition to the already existing dropdown icon.

Before:
<img width="861" alt="Before" src="https://github.com/icssc/AntAlmanac/assets/100006999/e7569140-1b64-4b0c-9e08-11eaf1d544ff">

After:
<img width="862" alt="After" src="https://github.com/icssc/AntAlmanac/assets/100006999/e136bd2f-f15e-440a-9d70-6ae47f11c509">

## Test Plan
Make sure clicking works (it do)

## Issues
Closes #583 

## Additional Notes
It's a bit thicker now that it's an accordion, but I'm not battling the MUI gods over some love handles...