### PR TITLE
Added Sat/Sun (Weekend) Functionality to Map Toolbar & Markers

### DIFF
--- a/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
@@ -66,11 +66,13 @@ class MapMenu extends PureComponent<MapMenuProps> {
                         centered
                     >
                         <StyledTab label="All" />
+                        <StyledTab label="Sun" />
                         <StyledTab label="Mon" />
                         <StyledTab label="Tue" />
                         <StyledTab label="Wed" />
                         <StyledTab label="Thu" />
                         <StyledTab label="Fri" />
+                        <StyledTab label="Sat" />
                     </StyledTabs>
                 </Paper>
 

--- a/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
@@ -1,4 +1,4 @@
-import { Paper, Tab, Tabs, TextField } from '@material-ui/core';
+import { Box, Paper, Tab, Tabs, TextField } from '@material-ui/core';
 import { styled, Theme, withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { Autocomplete } from '@material-ui/lab';
@@ -6,6 +6,7 @@ import React, { PureComponent } from 'react';
 
 import Building from './static/building';
 import buildingCatalogue from './static/buildingCatalogue';
+import AppStore from '$stores/AppStore';
 
 const styles: Styles<Theme, object> = {
     tabContainer: {
@@ -39,6 +40,7 @@ const StyledTab = styled(Tab)({
 interface MapMenuProps {
     classes: ClassNameMap;
     day: number;
+    showFinalsSchedule: boolean;
     setDay: (newDay: number) => void;
     handleSearch: (event: React.ChangeEvent<unknown>, value: Building | null) => void;
 }
@@ -50,6 +52,9 @@ class MapMenu extends PureComponent<MapMenuProps> {
 
     render() {
         const { classes } = this.props;
+
+        const events = AppStore.getEventsInCalendar();
+        const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
 
         return (
             <>
@@ -66,13 +71,13 @@ class MapMenu extends PureComponent<MapMenuProps> {
                         centered
                     >
                         <StyledTab label="All" />
-                        <StyledTab label="Sun" />
+                        {hasWeekendCourse ? <StyledTab label="Sun" /> : null}
                         <StyledTab label="Mon" />
                         <StyledTab label="Tue" />
                         <StyledTab label="Wed" />
                         <StyledTab label="Thu" />
                         <StyledTab label="Fri" />
-                        <StyledTab label="Sat" />
+                        {hasWeekendCourse ? <StyledTab label="Sat" /> : null}
                     </StyledTabs>
                 </Paper>
 

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -51,7 +51,7 @@ class LocateControl extends PureComponent<{ leaflet: LeafletContext }> {
 
 const LocateControlLeaflet = withLeaflet(LocateControl);
 
-const DAYS = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const DAYS = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const ACCESS_TOKEN = 'pk.eyJ1IjoicGVkcmljIiwiYSI6ImNsZzE0bjk2ajB0NHEzanExZGFlbGpwazIifQ.l14rgv5vmu5wIMgOUUhUXw';
 const ATTRIBUTION_MARKUP =
     '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors | Images from <a href="https://map.uci.edu/?id=463">UCI Map</a>';


### PR DESCRIPTION
## Summary
Map will now display Toolbar Tabs for Sat/Sun & associated markers when there are weekend courses in your calendar.

## Test Plan
Checked that functionality works swapping between schedules and when removing the weekend course

## Issues
Closes #588 

## Future Followup
Might be addressed in the map-rewrite, but the Finals schedule doesn't play nice with any of the markers & whatnot on the map.
