### PR TITLE
Fix RMP url scheme

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -167,7 +167,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
                 return (
                     <Box key={profName}>
                         <a
-                            href={`https://www.ratemyprofessors.com/search/professors?sid=U2Nob29sLTEwNzQ=&q=${lastName}`}
+                            href={`https://www.ratemyprofessors.com/search/professors/1074?q=${lastName}`}
                             target="_blank"
                             rel="noopener noreferrer"
                         >

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -167,7 +167,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
                 return (
                     <Box key={profName}>
                         <a
-                            href={`https://www.ratemyprofessors.com/search/teachers?sid=U2Nob29sLTEwNzQ=&query=${lastName}`}
+                            href={`https://www.ratemyprofessors.com/search/professors?sid=U2Nob29sLTEwNzQ=&q=${lastName}`}
                             target="_blank"
                             rel="noopener noreferrer"
                         >


### PR DESCRIPTION
## Summary
Change the RMP link's scheme so that RMP will take it. It doesn't automatically open the professor page anymore and just opens the search, but I don't think there's anything straightforward that we can do about that.

## Test Plan
Click on professor names and see if it works.

## Issues

Closes #593 

## Future Followup

1. This is quite some to do, but we could save RMP's professor IDs in our DB and serve that instead of the query link.
<img width="211" alt="image" src="https://github.com/icssc/AntAlmanac/assets/64875104/39533e5c-cdff-4f2c-9d4e-431f6f7346cd">

2. We link to PeterPortal because they have a professor rating feature. Unfortunately, they don't have that many ratings, which somewhat kneecaps the utility of the feature.
2. We could ask PeterPortal/API to give us an endpoint. I have suggested that they should scrape reviews from RMP such that RMP reviews are a subset of PP reviews. Otherwise, they can never get past the chiken-and-egg problem where you don't have enough reviews to be useful. Travel booking websites do this for the same reason.

