### PR TITLE
Expand ICSSC acronym in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AntAlmanac is a schedule planner website for classes at UC Irvine. Here are some
 
 ### Tech Stack
 
-Our site is a React single page application bootstrapped with create-react-app and hosted on Github Pages. We use the Material UI component library for most of our styling. The site gets its course data from the [PeterPortal API](https://api.peterportal.org/), which is also maintained by ICSSC.
+Our site is a React single page application bootstrapped with create-react-app and hosted on Github Pages. We use the Material UI component library for most of our styling. The site gets its course data from the [PeterPortal API](https://api.peterportal.org/), which is also maintained by ICS Student Council (ICSSC).
 
 ### History
 


### PR DESCRIPTION
## Summary
The README mentions ICSSC without ever saying what the acronym means. This PR changes it to ICS Student Council (ICSSC)
![image](https://github.com/icssc/AntAlmanac/assets/48658337/9d50ad5d-9472-4ebf-96c2-11fa9dc0beb8)
