### PR TITLE
Added toggle for upper div classes

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -24,42 +24,33 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
     };
 
     handleChange = (name: string) => (event: ChangeEvent<HTMLInputElement>) => {
+        const url = new URL(window.location.href);
+        const urlParam = new URLSearchParams(url.search);
+        urlParam.delete('courseNumber');
+
         if (name === 'upper') {
             if (event.target.checked) {
                 this.setState({ courseNumber: '100-199' });
                 RightPaneStore.updateFormValue('courseNumber', '100-199');
-                const url = new URL(window.location.href);
-                const urlParam = new URLSearchParams(url.search);
-                urlParam.delete('courseNumber');
-
                 urlParam.append('courseNumber', '100-199');
-                const param = urlParam.toString();
-                const new_url = `${param.trim() ? '?' : ''}${param}`;
-                history.replaceState({ url: 'url' }, 'url', '/' + new_url);
             } else {
                 this.setState({ courseNumber: '' });
                 RightPaneStore.updateFormValue('courseNumber', '');
-                const url = new URL(window.location.href);
-                const urlParam = new URLSearchParams(url.search);
                 urlParam.delete('courseNumber');
-
-                const param = urlParam.toString();
-                const new_url = `${param.trim() ? '?' : ''}${param}`;
-                history.replaceState({ url: 'url' }, 'url', '/' + new_url);
             }
-        } else {
+        }
+
+        if (name === 'number') {
             this.setState({ courseNumber: event.target.value });
             RightPaneStore.updateFormValue('courseNumber', event.target.value);
-            const url = new URL(window.location.href);
-            const urlParam = new URLSearchParams(url.search);
-            urlParam.delete('courseNumber');
             if (event.target.value) {
                 urlParam.append('courseNumber', event.target.value);
             }
-            const param = urlParam.toString();
-            const new_url = `${param.trim() ? '?' : ''}${param}`;
-            history.replaceState({ url: 'url' }, 'url', '/' + new_url);
         }
+
+        const param = urlParam.toString();
+        const new_url = `${param.trim() ? '?' : ''}${param}`;
+        history.replaceState({ url: 'url' }, 'url', '/' + new_url);
     };
 
     componentDidMount() {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -1,7 +1,6 @@
 import { FormControlLabel, Switch, TextField } from '@material-ui/core';
 import { ChangeEvent, PureComponent } from 'react';
 
-import { Box } from '@mui/material';
 import RightPaneStore from '../../RightPaneStore';
 
 interface CourseNumberSearchBarState {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -23,29 +23,27 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
         courseNumber: this.getCourseNumber(),
     };
 
-    handleChange = (name: string) => (event: ChangeEvent<HTMLInputElement>) => {
+    handleUpperDivChange = (event: ChangeEvent<HTMLInputElement>) => {
+        if (event.target.checked) {
+            this.handleCourseNumbers('100-199');
+        } else {
+            this.handleCourseNumbers('');
+        }
+    };
+
+    handleNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
+        this.handleCourseNumbers(event.target.value);
+    };
+
+    handleCourseNumbers = (eventCourseNumbers: string) => {
         const url = new URL(window.location.href);
         const urlParam = new URLSearchParams(url.search);
         urlParam.delete('courseNumber');
 
-        if (name === 'upper') {
-            if (event.target.checked) {
-                this.setState({ courseNumber: '100-199' });
-                RightPaneStore.updateFormValue('courseNumber', '100-199');
-                urlParam.append('courseNumber', '100-199');
-            } else {
-                this.setState({ courseNumber: '' });
-                RightPaneStore.updateFormValue('courseNumber', '');
-                urlParam.delete('courseNumber');
-            }
-        }
-
-        if (name === 'number') {
-            this.setState({ courseNumber: event.target.value });
-            RightPaneStore.updateFormValue('courseNumber', event.target.value);
-            if (event.target.value) {
-                urlParam.append('courseNumber', event.target.value);
-            }
+        this.setState({ courseNumber: eventCourseNumbers });
+        RightPaneStore.updateFormValue('courseNumber', eventCourseNumbers);
+        if (eventCourseNumbers !== '') {
+            urlParam.append('courseNumber', eventCourseNumbers);
         }
 
         const param = urlParam.toString();
@@ -72,14 +70,14 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                     label="Course Number(s)"
                     type="search"
                     value={this.state.courseNumber}
-                    onChange={this.handleChange('number')}
+                    onChange={this.handleNumberChange}
                     helperText="ex. 6B, 17, 30-40"
                 />
 
                 <FormControlLabel
                     control={
                         <Switch
-                            onChange={this.handleChange('upper')}
+                            onChange={this.handleUpperDivChange}
                             value="100-199"
                             color="primary"
                             checked={this.state.courseNumber === '100-199'}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -31,7 +31,7 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
         }
     };
 
-    handleNumbersChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleNumbersChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
         this.handleCourseNumbers(event.target.value);
     };
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -31,7 +31,7 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
         }
     };
 
-    handleNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleNumbersChange = (event: ChangeEvent<HTMLInputElement>) => {
         this.handleCourseNumbers(event.target.value);
     };
 
@@ -70,7 +70,7 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                     label="Course Number(s)"
                     type="search"
                     value={this.state.courseNumber}
-                    onChange={this.handleNumberChange}
+                    onChange={this.handleNumbersChange}
                     helperText="ex. 6B, 17, 30-40"
                 />
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -1,6 +1,7 @@
-import { TextField } from '@material-ui/core';
+import { FormControlLabel, Switch, TextField } from '@material-ui/core';
 import { ChangeEvent, PureComponent } from 'react';
 
+import { Box } from '@mui/material';
 import RightPaneStore from '../../RightPaneStore';
 
 interface CourseNumberSearchBarState {
@@ -14,27 +15,52 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
     }
 
     getCourseNumber() {
-      return RightPaneStore.getUrlCourseNumValue().trim() 
-        ? this.updateCourseNumAndGetFormData() 
-        : RightPaneStore.getFormData().courseNumber;
+        return RightPaneStore.getUrlCourseNumValue().trim()
+            ? this.updateCourseNumAndGetFormData()
+            : RightPaneStore.getFormData().courseNumber;
     }
 
     state = {
         courseNumber: this.getCourseNumber(),
     };
 
-    handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-        this.setState({ courseNumber: event.target.value });
-        RightPaneStore.updateFormValue('courseNumber', event.target.value);
-        const url = new URL(window.location.href);
-        const urlParam = new URLSearchParams(url.search);
-        urlParam.delete('courseNumber');
-        if (event.target.value) {
-            urlParam.append('courseNumber', event.target.value);
+    handleChange = (name: string) => (event: ChangeEvent<HTMLInputElement>) => {
+        if (name === 'upper') {
+            if (event.target.checked) {
+                this.setState({ courseNumber: '100-199' });
+                RightPaneStore.updateFormValue('courseNumber', '100-199');
+                const url = new URL(window.location.href);
+                const urlParam = new URLSearchParams(url.search);
+                urlParam.delete('courseNumber');
+
+                urlParam.append('courseNumber', '100-199');
+                const param = urlParam.toString();
+                const new_url = `${param.trim() ? '?' : ''}${param}`;
+                history.replaceState({ url: 'url' }, 'url', '/' + new_url);
+            } else {
+                this.setState({ courseNumber: '' });
+                RightPaneStore.updateFormValue('courseNumber', '');
+                const url = new URL(window.location.href);
+                const urlParam = new URLSearchParams(url.search);
+                urlParam.delete('courseNumber');
+
+                const param = urlParam.toString();
+                const new_url = `${param.trim() ? '?' : ''}${param}`;
+                history.replaceState({ url: 'url' }, 'url', '/' + new_url);
+            }
+        } else {
+            this.setState({ courseNumber: event.target.value });
+            RightPaneStore.updateFormValue('courseNumber', event.target.value);
+            const url = new URL(window.location.href);
+            const urlParam = new URLSearchParams(url.search);
+            urlParam.delete('courseNumber');
+            if (event.target.value) {
+                urlParam.append('courseNumber', event.target.value);
+            }
+            const param = urlParam.toString();
+            const new_url = `${param.trim() ? '?' : ''}${param}`;
+            history.replaceState({ url: 'url' }, 'url', '/' + new_url);
         }
-        const param = urlParam.toString();
-        const new_url = `${param.trim() ? '?' : ''}${param}`;
-        history.replaceState({ url: 'url' }, 'url', '/' + new_url);
     };
 
     componentDidMount() {
@@ -51,15 +77,28 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
 
     render() {
         return (
-            <div>
+            <>
                 <TextField
                     label="Course Number(s)"
                     type="search"
                     value={this.state.courseNumber}
-                    onChange={this.handleChange}
+                    onChange={this.handleChange('number')}
                     helperText="ex. 6B, 17, 30-40"
                 />
-            </div>
+
+                <FormControlLabel
+                    control={
+                        <Switch
+                            onChange={this.handleChange('upper')}
+                            value="100-199"
+                            color="primary"
+                            checked={this.state.courseNumber === '100-199'}
+                        />
+                    }
+                    labelPlacement="top"
+                    label="Upper Div Only"
+                />
+            </>
         );
     }
 }


### PR DESCRIPTION
## Summary
Added toggle to display only upper-level courses by having it input 100-199 into the Course Code manual search input. 

_If we want to include graduate level, we can just change it to 100-999_

![Toggle Functionality](https://github.com/icssc/AntAlmanac/assets/100006999/aab6cd2a-58a4-49b5-adc7-f2628f9c4dde)

## Test Plan
- Displays only courses between 100-199, including ones like STATS 120A. 
- When toggled on/off the url is also updated properly.

## Issues
Closes #597 

## Future Followup
Currently, I have the Upper Div toggle with `labelPlacement='top'`, but the Online toggle is defaulted to `'labelPlacement='end'`. I changed the positioning for UI reasons (it looks too cramped otherwise), but this might be worth changing to maintain a consistent style.

<img width="666" alt="Different Label Placement" src="https://github.com/icssc/AntAlmanac/assets/100006999/ca4027bb-2bdd-4a75-b79f-ec2901e229ac">


