### PR TITLE
Removed onClose from Menu, adjusted function accordingly

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -83,16 +83,14 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
             }
         }
 
-        if (scheduleIndex !== -1) {
-            if (specificSchedule) {
-                logAnalytics({
-                    category: analyticsEnum.classSearch.title,
-                    action: analyticsEnum.classSearch.actions.ADD_SPECIFIC,
-                });
-            }
-            const newCourse = addCourse(section, courseDetails, term, scheduleIndex);
-            section.color = newCourse.section.color;
+        if (specificSchedule) {
+            logAnalytics({
+                category: analyticsEnum.classSearch.title,
+                action: analyticsEnum.classSearch.actions.ADD_SPECIFIC,
+            });
         }
+        const newCourse = addCourse(section, courseDetails, term, scheduleIndex);
+        section.color = newCourse.section.color;
     };
 
     const addCourseHandler = () => {
@@ -125,7 +123,7 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
                 <IconButton {...bindTrigger(popupState)}>
                     <ArrowDropDown fontSize="small" />
                 </IconButton>
-                <Menu {...bindMenu(popupState)} onClose={() => closeAndAddCourse(-1)}>
+                <Menu {...bindMenu(popupState)} >
                     {scheduleNames.map((name, index) => (
                         <MenuItem key={index} onClick={() => closeAndAddCourse(index, true)}>
                             Add to {name}


### PR DESCRIPTION
## Summary
Bug fix to prevent snackbar popup when clicking out of the Add Course menu

Before:
![Before](https://github.com/icssc/AntAlmanac/assets/100006999/8352b34d-83f5-448a-885f-33a82bb94df0)

After:
![After](https://github.com/icssc/AntAlmanac/assets/100006999/bcdf32ca-f0f1-4d25-8f5f-41dc97692ab5)

## Test Plan
All functionality appears to be the same, and I'm not entirely sure what the original intent was.

## Issues
Closes #602 