### PR TITLE
Rewrote HelpBox to MUI, fixed overflow bug

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -17,7 +17,9 @@ interface HelpBoxProps {
 const HelpBox = ({ classes }: HelpBoxProps) => {
     return (
         <Paper variant="outlined" className={classes.container}>
-            <Typography variant="h4">Need help planning your schedule?</Typography>
+            <Typography variant="h5" fontWeight={'bold'}>
+                Need help planning your schedule?
+            </Typography>
             <Typography>
                 <ol>
                     <li>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -8,7 +8,7 @@ const HelpBox = (/*{ classes }: HelpBoxProps*/) => {
             <Typography variant="h5" fontWeight={'bold'}>
                 Need help planning your schedule?
             </Typography>
-            <List sx={{ listStyle: 'decimal', pl: 2, pb: 0 }}>
+            <List component="ol" sx={{ listStyle: 'decimal', pl: 2, pb: 0 }}>
                 <ListItem sx={{ display: 'list-item', p: 0 }}>
                     <ListItemText>
                         Browse undergraduate majors on the{' '}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -40,7 +40,7 @@ const HelpBox = ({ classes }: HelpBoxProps) => {
                     </li>
                 </ol>
             </Typography>
-            <ImageList cols={3}>
+            <ImageList gap={10} cols={3}>
                 <ImageListItem>
                     <img
                         src="/helpbox1.png"

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -1,13 +1,27 @@
-// import { withStyles } from '@material-ui/core';
-// import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Paper, ImageList, ImageListItem, Typography, Link, List, ListItemText, ListItem } from '@mui/material';
 
-const HelpBox = (/*{ classes }: HelpBoxProps*/) => {
+const images = [
+    {
+        src: '/helpbox1.png',
+        alt: 'UCI General Catalogue with "Explore Undergraduate Programs" button highlighted',
+    },
+    {
+        src: '/helpbox2.png',
+        alt: 'Undergraduate Majors and Minors page',
+    },
+    {
+        src: '/helpbox3.png',
+        alt: 'Electrical Engineering page with "REQUIREMENTS" and "SAMPLE PROGRAM" tabs highlighted',
+    },
+];
+
+function HelpBox() {
     return (
         <Paper variant="outlined" sx={{ padding: 2, marginBottom: '10px', marginRight: '5px' }}>
-            <Typography variant="h5" fontWeight={'bold'}>
+            <Typography variant="h5" fontWeight="bold">
                 Need help planning your schedule?
             </Typography>
+
             <List component="ol" sx={{ listStyle: 'decimal', pl: 2, pb: 0 }}>
                 <ListItem sx={{ display: 'list-item', p: 0 }}>
                     <ListItemText>
@@ -22,9 +36,11 @@ const HelpBox = (/*{ classes }: HelpBoxProps*/) => {
                         .
                     </ListItemText>
                 </ListItem>
+
                 <ListItem sx={{ display: 'list-item', p: 0 }}>
                     <ListItemText>Select your major.</ListItemText>
                 </ListItem>
+
                 <ListItem sx={{ display: 'list-item', p: 0 }}>
                     <ListItemText>
                         View the &quot;REQUIREMENTS&quot; and &quot;SAMPLE PROGRAM&quot; tabs to see what classes you
@@ -33,24 +49,14 @@ const HelpBox = (/*{ classes }: HelpBoxProps*/) => {
                 </ListItem>
             </List>
             <ImageList gap={10} cols={3}>
-                <ImageListItem>
-                    <img
-                        src="/helpbox1.png"
-                        alt='UCI General Catalogue with "Explore Undergraduate Programs" button highlighted'
-                    />
-                </ImageListItem>
-                <ImageListItem>
-                    <img src="/helpbox2.png" alt="Undergraduate Majors and Minors page" />
-                </ImageListItem>
-                <ImageListItem>
-                    <img
-                        src="/helpbox3.png"
-                        alt='Electrical Engineering page with "REQUIREMENTS" and "SAMPLE PROGRAM" tabs highlighted'
-                    />
-                </ImageListItem>
+                {images.map((image) => (
+                    <ImageListItem key={image.src}>
+                        <img src={image.src} alt={image.alt} />
+                    </ImageListItem>
+                ))}
             </ImageList>
         </Paper>
     );
-};
+}
 
 export default HelpBox;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -7,7 +7,7 @@ const images = [
     },
     {
         src: '/helpbox2.png',
-        alt: 'Undergraduate Majors and Minors page',
+        alt: 'Undergraduate Majors and Minors page with catalogue highlighted',
     },
     {
         src: '/helpbox3.png',

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -1,5 +1,6 @@
 import { Paper, withStyles } from '@material-ui/core';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
+import { ImageList, ImageListItem, Typography } from '@mui/material';
 
 const styles = {
     container: {
@@ -7,21 +8,8 @@ const styles = {
         marginBottom: '10px',
         marginRight: '5px',
     },
-    heading: {
-        marginTop: 2,
-    },
-    list: {
-        paddingLeft: '1.5em',
-    },
-    images: {
-        display: 'flex',
-        gap: 10,
-        overflow: 'auto',
-    },
-    image: {
-        height: 250,
-    },
 };
+
 interface HelpBoxProps {
     classes: ClassNameMap;
 }
@@ -29,34 +17,44 @@ interface HelpBoxProps {
 const HelpBox = ({ classes }: HelpBoxProps) => {
     return (
         <Paper variant="outlined" className={classes.container}>
-            <h2 className={classes.heading}>Need help planning your schedule?</h2>
-            <ol className={classes.list}>
-                <li>
-                    Browse undergraduate majors on the{' '}
-                    <a href="https://catalogue.uci.edu/undergraduatedegrees/" target="_blank" rel="noopener noreferrer">
-                        UCI Catalogue
-                    </a>
-                    .
-                </li>
-                <li>Select your major.</li>
-                <li>
-                    View the &quot;REQUIREMENTS&quot; and &quot;SAMPLE PROGRAM&quot; tabs to see what classes you should
-                    take.
-                </li>
-            </ol>
-            <div className={classes.images}>
-                <img
-                    className={classes.image}
-                    src="/helpbox1.png"
-                    alt='UCI General Catalogue with "Explore Undergraduate Programs" button highlighted'
-                />
-                <img className={classes.image} src="/helpbox2.png" alt="Undergraduate Majors and Minors page" />
-                <img
-                    className={classes.image}
-                    src="/helpbox3.png"
-                    alt='Electrical Engineering page with "REQUIREMENTS" and "SAMPLE PROGRAM" tabs highlighted'
-                />
-            </div>
+            <Typography variant="h4">Need help planning your schedule?</Typography>
+            <Typography>
+                <ol>
+                    <li>
+                        Browse undergraduate majors on the{' '}
+                        <a
+                            href="https://catalogue.uci.edu/undergraduatedegrees/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            UCI Catalogue
+                        </a>
+                        .
+                    </li>
+                    <li>Select your major.</li>
+                    <li>
+                        View the &quot;REQUIREMENTS&quot; and &quot;SAMPLE PROGRAM&quot; tabs to see what classes you
+                        should take.
+                    </li>
+                </ol>
+            </Typography>
+            <ImageList cols={3}>
+                <ImageListItem>
+                    <img
+                        src="/helpbox1.png"
+                        alt='UCI General Catalogue with "Explore Undergraduate Programs" button highlighted'
+                    />
+                </ImageListItem>
+                <ImageListItem>
+                    <img src="/helpbox2.png" alt="Undergraduate Majors and Minors page" />
+                </ImageListItem>
+                <ImageListItem>
+                    <img
+                        src="/helpbox3.png"
+                        alt='Electrical Engineering page with "REQUIREMENTS" and "SAMPLE PROGRAM" tabs highlighted'
+                    />
+                </ImageListItem>
+            </ImageList>
         </Paper>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -1,45 +1,37 @@
-import { Paper, withStyles } from '@material-ui/core';
-import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import { ImageList, ImageListItem, Typography } from '@mui/material';
+// import { withStyles } from '@material-ui/core';
+// import { ClassNameMap } from '@material-ui/core/styles/withStyles';
+import { Paper, ImageList, ImageListItem, Typography, Link, List, ListItemText, ListItem } from '@mui/material';
 
-const styles = {
-    container: {
-        padding: 12,
-        marginBottom: '10px',
-        marginRight: '5px',
-    },
-};
-
-interface HelpBoxProps {
-    classes: ClassNameMap;
-}
-
-const HelpBox = ({ classes }: HelpBoxProps) => {
+const HelpBox = (/*{ classes }: HelpBoxProps*/) => {
     return (
-        <Paper variant="outlined" className={classes.container}>
+        <Paper variant="outlined" sx={{ padding: 2, marginBottom: '10px', marginRight: '5px' }}>
             <Typography variant="h5" fontWeight={'bold'}>
                 Need help planning your schedule?
             </Typography>
-            <Typography>
-                <ol>
-                    <li>
+            <List sx={{ listStyle: 'decimal', pl: 2, pb: 0 }}>
+                <ListItem sx={{ display: 'list-item', p: 0 }}>
+                    <ListItemText>
                         Browse undergraduate majors on the{' '}
-                        <a
+                        <Link
                             href="https://catalogue.uci.edu/undergraduatedegrees/"
                             target="_blank"
                             rel="noopener noreferrer"
                         >
                             UCI Catalogue
-                        </a>
+                        </Link>
                         .
-                    </li>
-                    <li>Select your major.</li>
-                    <li>
+                    </ListItemText>
+                </ListItem>
+                <ListItem sx={{ display: 'list-item', p: 0 }}>
+                    <ListItemText>Select your major.</ListItemText>
+                </ListItem>
+                <ListItem sx={{ display: 'list-item', p: 0 }}>
+                    <ListItemText>
                         View the &quot;REQUIREMENTS&quot; and &quot;SAMPLE PROGRAM&quot; tabs to see what classes you
                         should take.
-                    </li>
-                </ol>
-            </Typography>
+                    </ListItemText>
+                </ListItem>
+            </List>
             <ImageList gap={10} cols={3}>
                 <ImageListItem>
                     <img
@@ -61,4 +53,4 @@ const HelpBox = ({ classes }: HelpBoxProps) => {
     );
 };
 
-export default withStyles(styles)(HelpBox);
+export default HelpBox;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -70,7 +70,8 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
         toggleSearch();
     };
 
-    const currentMonth = new Date().getMonth(); // 0=Jan
+    const currentMonthIndex = new Date().getMonth(); // 0=Jan
+    const activeMonthIndices = [false, false, false, false, false, false, false, true, true, false, false, false];
 
     return (
         <div className={classes.rightPane}>
@@ -108,8 +109,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                 </div>
             </form>
 
-            const activeMonthIndices = [false, false, false, false, false, false, false, true, true, false, false, false]
-            {/* activeMonthIndices[currentMonthIndex] && */ <HelpBox />}
+            {/*activeMonthIndices[currentMonthIndex] &&*/ <HelpBox />}
             <PrivacyPolicyBanner />
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -109,7 +109,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                 </div>
             </form>
 
-            {/*activeMonthIndices[currentMonthIndex] &&*/ <HelpBox />}
+            {activeMonthIndices[currentMonthIndex] && <HelpBox />}
             <PrivacyPolicyBanner />
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -51,12 +51,14 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
     const search = new URLSearchParams(window.location.search);
 
     const [showLegacySearch, setShowLegacySearch] = useState(
-      Boolean(search.get('courseCode') ||
-        search.get('courseNumber') ||
-        search.get('deptLabel') ||
-        search.get('GE') ||
-        search.get('deptValue') ||
-        search.get('term'))
+        Boolean(
+            search.get('courseCode') ||
+                search.get('courseNumber') ||
+                search.get('deptLabel') ||
+                search.get('GE') ||
+                search.get('deptValue') ||
+                search.get('term')
+        )
     );
 
     const toggleShowLegacySearch = () => {
@@ -106,7 +108,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                 </div>
             </form>
 
-            {(currentMonth === 8 || currentMonth === 9) && <HelpBox />}
+            {/*(currentMonth === 8 || currentMonth === 9) &&*/ <HelpBox />}
             <PrivacyPolicyBanner />
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -108,7 +108,8 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                 </div>
             </form>
 
-            {/*(currentMonth === 8 || currentMonth === 9) &&*/ <HelpBox />}
+            const activeMonthIndices = [false, false, false, false, false, false, false, true, true, false, false, false]
+            {/* activeMonthIndices[currentMonthIndex] && */ <HelpBox />}
             <PrivacyPolicyBanner />
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -71,7 +71,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
     };
 
     const currentMonthIndex = new Date().getMonth(); // 0=Jan
-    const activeMonthIndices = [false, false, false, false, false, false, false, true, true, false, false, false];
+    const activeMonthIndices = [false, false, false, false, false, false, false, false, true, true, false, false];
 
     return (
         <div className={classes.rightPane}>


### PR DESCRIPTION
## Summary
By rewriting it to MUI, the HelpBox overflow/sizing issues were removed. 

Before:
<img width="908" alt="Before" src="https://github.com/icssc/AntAlmanac/assets/100006999/aebb98f6-dcd9-4c0e-8194-4faa33e1c26f">

After:
<img width="898" alt="After" src="https://github.com/icssc/AntAlmanac/assets/100006999/f98a7c8a-bb39-4cd2-8898-696822b5c3e2">

## Test Plan
Resizing works fine, no overflow issues.

## Issues
Closes #452 

## Additional Notes/RFC
Currently, `SearchForm.tsx` only renders the HelpBox in September and October. Should this behavior be changed to:
1. Render in Sep/Oct AND Dec/Jan AND Mar/Apr (AND Jun/Jul)
2. Always Render
3. Remain the same :)
