### PR TITLE
Resolved Custom Event Day Selector Bug

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -9,49 +9,48 @@ const normal_days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Fr
 const abbreviated_days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
 
 interface DaySelectorProps {
-  days?: boolean[];
-  onSelectDay: (days: boolean[]) => void;
+    days?: boolean[];
+    onSelectDay: (days: boolean[]) => void;
 }
 
 const DaySelector: React.FC<DaySelectorProps> = ({
-  days = [false, false, false, false, false, false, false],
-  onSelectDay,
+    days = [false, false, false, false, false, false, false],
+    onSelectDay,
 }) => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const [selectedDays, setSelectedDays] = useState(days);
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const [selectedDays, setSelectedDays] = useState(days);
 
-  useEffect(() => {
-    onSelectDay(selectedDays);
-  }, [selectedDays]);
+    useEffect(() => {
+        onSelectDay(selectedDays);
+    }, [selectedDays]);
 
-  const handleChange = (dayIndex: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedDays(prevDays => {
-      prevDays[dayIndex] = event.target.checked;
-      return prevDays
-    });
-  };
+    const handleChange = (dayIndex: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
+        const newSelectedDays = [...selectedDays];
+        newSelectedDays[dayIndex] = event.target.checked;
+        setSelectedDays(newSelectedDays);
+    };
 
-  const dayNames = isMobile ? abbreviated_days : normal_days;
+    const dayNames = isMobile ? abbreviated_days : normal_days;
 
-  return (
-    <FormGroup row>
-      {dayNames.map((day, index) => (
-        <FormControlLabel
-          key={index}
-          control={
-            <Checkbox
-              checked={selectedDays[index]}
-              onChange={handleChange(index)}
-              value={index}
-              color="primary"
-            />
-          }
-          label={day}
-        />
-      ))}
-    </FormGroup>
-  );
+    return (
+        <FormGroup row>
+            {dayNames.map((day, index) => (
+                <FormControlLabel
+                    key={index}
+                    control={
+                        <Checkbox
+                            checked={selectedDays[index]}
+                            onChange={handleChange(index)}
+                            value={index}
+                            color="primary"
+                        />
+                    }
+                    label={day}
+                />
+            ))}
+        </FormGroup>
+    );
 };
 
 export default DaySelector;


### PR DESCRIPTION
## Summary
The custom day selector now works and updates properly when it's being used.

Previously the `handleChange` / `setSelectedDays` function was doing something which I don't 100% understand, but now it just directly calls `setSelectedDays` and updates DaySelector properly.

_I believe the result of the old implementation was that the `checked` prop of `<Checkbox>` would not update when `handleChange` was called, resulting in a state where the `days?: boolean[]` was accurate, but not being displayed._

![Clicky Clicky Worky](https://github.com/icssc/AntAlmanac/assets/100006999/e88b794a-d5a6-449d-9548-98866bd061b6)

## Test Plan
All functionality is the same.

## Issues
Closes #607 
