### PR TITLE
Calendar Popups close when Events are clicked again

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -209,11 +209,11 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
         e.stopPropagation();
 
         if (event.isCustomEvent || event.sectionType !== 'Fin') {
-            this.setState({
-                anchorEl: currentTarget,
+            this.setState((prevState) => ({
+                anchorEl: prevState.anchorEl === currentTarget ? null : currentTarget,
                 courseInMoreInfo: event,
                 calendarEventKey: Math.random(),
-            });
+            }));
         }
     };
 


### PR DESCRIPTION
## Summary
Added in a prevState to allow for AnchorEl to be sent to `null` when the popup is already open and to `currentTarget` if it's not already open for business.

![Clicky Clicky](https://github.com/icssc/AntAlmanac/assets/100006999/57dc3619-16ee-43a3-8e5e-849be4aa6351)

## Test Plan
Functionality looks clean to me.

## Issues
Closes #601 
