### PR TITLE
fix: update fall 2023 instruction start date

### DIFF
--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -12,10 +12,11 @@ class Term {
     }
 }
 
-// Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2022-2023/quarterly22-23.html
+// Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2023-2024/quarterly23-24.html
+// The `startDate`, if available, should correspond to the instruction start date (not the quarter start date)
 // Note: months are 0-indexed
 const termData = [
-    new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 25]),
+    new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28]),
     new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),
     new Term('2023 Summer10wk', '2023 10-wk Summer', [2023, 5, 26]),
     new Term('2023 Summer1', '2023 Summer Session 1', [2023, 5, 26]),

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -12,9 +12,11 @@ class Term {
     }
 }
 
-// Quarterly Academic Calendar: https://www.reg.uci.edu/calendars/quarterly/2023-2024/quarterly23-24.html
-// The `startDate`, if available, should correspond to the instruction start date (not the quarter start date)
-// Note: months are 0-indexed
+/**
+ * Quarterly Academic Calendar {@link https://www.reg.uci.edu/calendars/quarterly/2023-2024/quarterly23-24.html}
+ * The `startDate`, if available, should correspond to the __instruction start date__ (not the quarter start date)
+ * Months are 0-indexed
+ */
 const termData = [
     new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28]),
     new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),


### PR DESCRIPTION
## Summary

Update the Fall 2023 instruction start date, since the calendar import is currently broken. Also add clarifying comments for future maintainers.

## Test Plan

Import an exported schedule into GCal and see that it isn't scuffed.

From prod:
![image](https://github.com/icssc/AntAlmanac/assets/89349085/2b579cbe-6bc6-46c9-b6f6-f6d762bffd22)

From local dev server after this patch:
![image](https://github.com/icssc/AntAlmanac/assets/89349085/216b0397-d515-4abe-af9a-917ddd843730)


## Issues

n/a
