### PR TITLE
Select Component for Course Level Selection

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -92,9 +92,10 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                     value={this.state.courseNumber}
                     onChange={this.handleNumbersChange}
                     helperText="ex. 6B, 17, 30-40"
+                    style={{ marginRight: 15 }}
                 />
 
-                <FormControl style={{ marginLeft: 15, marginRight: 15, width: 125 }}>
+                <FormControl style={{ minWidth: 75 }}>
                     <InputLabel>Course Level</InputLabel>
                     <Select
                         value={this.state.courseLevel}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -1,10 +1,18 @@
-import { FormControlLabel, Switch, TextField } from '@material-ui/core';
+import { FormControl, InputLabel, ListItemText, MenuItem, Select, TextField } from '@material-ui/core';
 import { ChangeEvent, PureComponent } from 'react';
 
 import RightPaneStore from '../../RightPaneStore';
 
+const courseLevelList: { level: string; label: string }[] = [
+    { level: '0', label: 'Any Course Division' },
+    { level: '1-99', label: 'Lower Division Only' },
+    { level: '100-199', label: 'Upper Division Only' },
+    { level: '200-999', label: 'Graduate/Professional Only' },
+];
+
 interface CourseNumberSearchBarState {
     courseNumber: string;
+    courseLevel: string;
 }
 
 class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseNumberSearchBarState> {
@@ -21,14 +29,26 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
 
     state = {
         courseNumber: this.getCourseNumber(),
+        courseLevel: '',
     };
 
-    handleUpperDivChange = (event: ChangeEvent<HTMLInputElement>) => {
-        if (event.target.checked) {
-            this.handleCourseNumbers('100-199');
-        } else {
-            this.handleCourseNumbers('');
-        }
+    handleDivChange = (event: ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
+        this.setState({ courseLevel: event.target.value as string }, () => {
+            switch (event.target.value as string) {
+                case '0':
+                    this.handleCourseNumbers('');
+                    break;
+                case '1-99':
+                    this.handleCourseNumbers('1-99');
+                    break;
+                case '100-199':
+                    this.handleCourseNumbers('100-199');
+                    break;
+                case '200-999':
+                    this.handleCourseNumbers('200-999');
+                    break;
+            }
+        });
     };
 
     handleNumbersChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -74,18 +94,25 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                     helperText="ex. 6B, 17, 30-40"
                 />
 
-                <FormControlLabel
-                    control={
-                        <Switch
-                            onChange={this.handleUpperDivChange}
-                            value="100-199"
-                            color="primary"
-                            checked={this.state.courseNumber === '100-199'}
-                        />
-                    }
-                    labelPlacement="top"
-                    label="Upper Div Only"
-                />
+                <FormControl style={{ marginLeft: 15, marginRight: 15, width: 125 }}>
+                    <InputLabel>Course Level</InputLabel>
+                    <Select
+                        value={this.state.courseLevel}
+                        renderValue={(selected) =>
+                            courseLevelList.find((item) => item.level === selected)?.label as string
+                        }
+                        onChange={this.handleDivChange}
+                        fullWidth
+                    >
+                        {courseLevelList.map((level) => {
+                            return (
+                                <MenuItem key={level.level} value={level.level}>
+                                    <ListItemText>{level.label}</ListItemText>
+                                </MenuItem>
+                            );
+                        })}
+                    </Select>
+                </FormControl>
             </>
         );
     }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -99,7 +99,7 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                     style={{ marginRight: 15 }}
                 />
 
-                <FormControl style={{ minWidth: 75 }}>
+                <FormControl style={{ minWidth: 100 }}>
                     <InputLabel>Course Level</InputLabel>
                     <Select
                         value={this.state.courseLevel}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -47,12 +47,16 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
                 case '200-999':
                     this.handleCourseNumbers('200-999');
                     break;
+                default:
+                    this.handleCourseNumbers('');
+                    break;
             }
         });
     };
 
     handleNumbersChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
         this.handleCourseNumbers(event.target.value);
+        this.setState({ courseLevel: '0' });
     };
 
     handleCourseNumbers = (eventCourseNumbers: string) => {


### PR DESCRIPTION
## Summary
Converted the Upper Div Switch from #598 to a full Select menu for Any, Lower, Upper, and Grad. This menu will reset to Any when courseNumber is edited.

![chrome-capture-2023-5-15](https://github.com/icssc/AntAlmanac/assets/100006999/a429198e-8264-49fd-8945-4dece786aafa)

## Test Plan
URL updates correctly, searches still work fine, styling is alright on mobile and desktop (if a little cramped)

## Issues
Closes #627

## Additional Notes
1. Following commit (ef98a89a830d339b00de0d9a52b8d21f21c57c25) there's a case to be made that the courseLevel selector should be in the advanced section, seeing as it does not affect the URL and it's default state is undefined, kinda like Ends Before/After etc. Thoughts?

2. Currently, I have lower levels set to 1-99, but if there exists courses with 0, LMK and I can adjust accordingly.