### PR TITLE
Cleaned up Warnings from the console

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -302,9 +302,8 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
                                 date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, 'h A', culture),
                             dayFormat: 'ddd',
                         }}
-                        defaultView={Views.WORK_WEEK}
                         views={[Views.WEEK, Views.WORK_WEEK]}
-                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        defaultView={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -245,6 +245,10 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
             },
         });
 
+        const handleOnView = () => {
+            return;
+        };
+
         return (
             <div className={classes.container} style={isMobile ? { height: 'calc(100% - 50px)' } : undefined}>
                 <CalendarToolbar
@@ -303,7 +307,9 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
                             dayFormat: 'ddd',
                         }}
                         views={[Views.WEEK, Views.WORK_WEEK]}
-                        defaultView={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        defaultView={Views.WORK_WEEK}
+                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        onView={handleOnView}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/EditSchedule.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/EditSchedule.tsx
@@ -52,6 +52,7 @@ const EditSchedule = (props: EditScheduleProps) => {
                     vertical: 'top',
                     horizontal: 'left',
                 }}
+                getContentAnchorEl={null}
             >
                 <ScheduleNameDialog
                     scheduleNames={scheduleNames}

--- a/apps/antalmanac/src/components/ConditionalWrapper.tsx
+++ b/apps/antalmanac/src/components/ConditionalWrapper.tsx
@@ -13,7 +13,7 @@ interface ConditionalWrapperProps {
  * This uses forwardRef because at some point we got a console warning
  * about "functional components cannot be given refs" (https://github.com/icssc/AntAlmanac/pull/231/commits/bd80dd085e4f502292b4e1002fdc8fa398f375ab)
  */
-const ConditionalWrapper = forwardRef<Element, ConditionalWrapperProps>(({ condition, wrapper, children }) => {
+const ConditionalWrapper = forwardRef<Element, ConditionalWrapperProps>(({ condition, wrapper, children }, ref) => {
     return condition ? wrapper(children) : children;
 });
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -22,7 +22,12 @@ import analyticsEnum from '$lib/analytics';
 
 const styles: Styles<Theme, object> = (theme) => ({
     course: {
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
         display: 'flex',

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -17,14 +17,24 @@ const styles: Styles<Theme, object> = (theme) => ({
     school: {
         display: 'flex',
         flexWrap: 'wrap',
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
     },
     dept: {
         display: 'flex',
         flexWrap: 'wrap',
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
     },
@@ -68,8 +78,10 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
                             </Typography>
                         </AccordionSummary>
                         <AccordionDetails>
-                            <Typography variant="body2">
-                                <p>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</p>
+                            <Typography variant="body2" component={'span'}>
+                                {' '}
+                                {/*The default component for this seems to be <p> which is giving warnings with DOMnesting */}
+                                <Typography>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</Typography>
                                 <Box
                                     dangerouslySetInnerHTML={html}
                                     className={this.props.classes.comments}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -79,8 +79,7 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
                         </AccordionSummary>
                         <AccordionDetails>
                             <Typography variant="body2" component={'span'}>
-                                {' '}
-                                {/*The default component for this seems to be <p> which is giving warnings with DOMnesting */}
+                                {/*The default component for the body2 typography seems to be <p> which is giving warnings with DOMnesting */}
                                 <Typography>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</Typography>
                                 <Box
                                     dangerouslySetInnerHTML={html}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -62,6 +62,10 @@ const styles = {
             width: '8%',
         },
     },
+    container: {},
+    titleRow: {},
+    clearSchedule: {},
+    scheduleNoteContainer: {},
 };
 
 const SectionTable = (props: SectionTableProps) => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -162,7 +162,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
     const { classes, instructors } = props;
 
     const getLinks = (professorNames: string[]) => {
-        return professorNames.map((profName) => {
+        return professorNames.map((profName, index) => {
             if (profName !== 'STAFF') {
                 const lastName = profName.substring(0, profName.indexOf(','));
                 return (
@@ -177,7 +177,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
                     </Box>
                 );
             } else {
-                return <Box key={profName}> {profName} </Box>;
+                return <Box key={profName + index}> {profName} </Box>; // The key should be fine as we're not changing ['STAFF, 'STAFF']
             }
         });
     };


### PR DESCRIPTION
## Summary
Light cleanup here and there to remove some of that console clutter

**Collection of errors cleaned:**

Forward ref and view props:
<img width="878" alt="Forward ref and view props" src="https://github.com/icssc/AntAlmanac/assets/100006999/1eadaf43-0dae-4678-bc6a-4be446cbfe53">

Unpassed props to style (not entirely sure about my solution to this in `SectionTable.tsx`:
<img width="764" alt="Unpassed key to style" src="https://github.com/icssc/AntAlmanac/assets/100006999/e44d9a56-bd08-48ee-b620-3354f01f9fa4">

Gutters and text nesting:
<img width="970" alt="Gutters and text nesting" src="https://github.com/icssc/AntAlmanac/assets/100006999/8811ef3b-3b0b-4235-b14a-6dd8f1bb2bbd">

Anchor origin:
<img width="970" alt="Anchor origin" src="https://github.com/icssc/AntAlmanac/assets/100006999/b5a1cef0-cd70-4029-b5d3-7e7eced5dd5f">


## Test Plan
Functionality should still be the same, I clicked around a bunch and tested all the functionality I could think of related to changes made.

## Issues
Closes #629 

## Additional Notes
I've got no idea what to do about this warning related to `ScheduleNameDialog.tsx`
> react-dom.development.js:86 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

<img width="970" alt="forwardRef nonsense" src="https://github.com/icssc/AntAlmanac/assets/100006999/bbc9328d-1176-497b-92d3-021467361c21">
