### PR TITLE
Added Weekend Tabs to the Map

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -302,9 +302,8 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
                                 date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, 'h A', culture),
                             dayFormat: 'ddd',
                         }}
-                        defaultView={Views.WORK_WEEK}
                         views={[Views.WEEK, Views.WORK_WEEK]}
-                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        defaultView={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -245,6 +245,10 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
             },
         });
 
+        const handleOnView = () => {
+            return;
+        };
+
         return (
             <div className={classes.container} style={isMobile ? { height: 'calc(100% - 50px)' } : undefined}>
                 <CalendarToolbar
@@ -303,7 +307,9 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
                             dayFormat: 'ddd',
                         }}
                         views={[Views.WEEK, Views.WORK_WEEK]}
-                        defaultView={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        defaultView={Views.WORK_WEEK}
+                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                        onView={handleOnView}
                         step={15}
                         timeslots={2}
                         defaultDate={new Date(2018, 0, 1)}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/EditSchedule.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/EditSchedule.tsx
@@ -52,6 +52,7 @@ const EditSchedule = (props: EditScheduleProps) => {
                     vertical: 'top',
                     horizontal: 'left',
                 }}
+                getContentAnchorEl={null}
             >
                 <ScheduleNameDialog
                     scheduleNames={scheduleNames}

--- a/apps/antalmanac/src/components/ConditionalWrapper.tsx
+++ b/apps/antalmanac/src/components/ConditionalWrapper.tsx
@@ -13,7 +13,7 @@ interface ConditionalWrapperProps {
  * This uses forwardRef because at some point we got a console warning
  * about "functional components cannot be given refs" (https://github.com/icssc/AntAlmanac/pull/231/commits/bd80dd085e4f502292b4e1002fdc8fa398f375ab)
  */
-const ConditionalWrapper = forwardRef<Element, ConditionalWrapperProps>(({ condition, wrapper, children }) => {
+const ConditionalWrapper = forwardRef<Element, ConditionalWrapperProps>(({ condition, wrapper, children }, ref) => {
     return condition ? wrapper(children) : children;
 });
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -22,7 +22,12 @@ import analyticsEnum from '$lib/analytics';
 
 const styles: Styles<Theme, object> = (theme) => ({
     course: {
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
         display: 'flex',

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -17,14 +17,24 @@ const styles: Styles<Theme, object> = (theme) => ({
     school: {
         display: 'flex',
         flexWrap: 'wrap',
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
     },
     dept: {
         display: 'flex',
         flexWrap: 'wrap',
-        ...theme.mixins.gutters(),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(3),
+            paddingRight: theme.spacing(3),
+        },
         paddingTop: theme.spacing(),
         paddingBottom: theme.spacing(),
     },
@@ -68,8 +78,10 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
                             </Typography>
                         </AccordionSummary>
                         <AccordionDetails>
-                            <Typography variant="body2">
-                                <p>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</p>
+                            <Typography variant="body2" component={'span'}>
+                                {' '}
+                                {/*The default component for this seems to be <p> which is giving warnings with DOMnesting */}
+                                <Typography>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</Typography>
                                 <Box
                                     dangerouslySetInnerHTML={html}
                                     className={this.props.classes.comments}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -79,8 +79,7 @@ class SchoolDeptCard extends PureComponent<SchoolDeptCardProps> {
                         </AccordionSummary>
                         <AccordionDetails>
                             <Typography variant="body2" component={'span'}>
-                                {' '}
-                                {/*The default component for this seems to be <p> which is giving warnings with DOMnesting */}
+                                {/*The default component for the body2 typography seems to be <p> which is giving warnings with DOMnesting */}
                                 <Typography>{this.props.comment === '' ? 'No comments found' : 'Comments:'}</Typography>
                                 <Box
                                     dangerouslySetInnerHTML={html}

--- a/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/MapMenu.tsx
@@ -6,6 +6,7 @@ import React, { PureComponent } from 'react';
 
 import Building from './static/building';
 import buildingCatalogue from './static/buildingCatalogue';
+import AppStore from '$stores/AppStore';
 
 const styles: Styles<Theme, object> = {
     tabContainer: {
@@ -51,6 +52,9 @@ class MapMenu extends PureComponent<MapMenuProps> {
     render() {
         const { classes } = this.props;
 
+        const events = AppStore.getEventsInCalendar();
+        const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
+
         return (
             <>
                 <Paper elevation={0} className={classes.tabContainer}>
@@ -66,11 +70,13 @@ class MapMenu extends PureComponent<MapMenuProps> {
                         centered
                     >
                         <StyledTab label="All" />
+                        {hasWeekendCourse ? <StyledTab label="Sun" /> : null}
                         <StyledTab label="Mon" />
                         <StyledTab label="Tue" />
                         <StyledTab label="Wed" />
                         <StyledTab label="Thu" />
                         <StyledTab label="Fri" />
+                        {hasWeekendCourse ? <StyledTab label="Sat" /> : null}
                     </StyledTabs>
                 </Paper>
 

--- a/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
+++ b/apps/antalmanac/src/components/RightPane/Map/UCIMap.tsx
@@ -51,7 +51,7 @@ class LocateControl extends PureComponent<{ leaflet: LeafletContext }> {
 
 const LocateControlLeaflet = withLeaflet(LocateControl);
 
-const DAYS = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const DAYS = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const ACCESS_TOKEN = 'pk.eyJ1IjoicGVkcmljIiwiYSI6ImNsZzE0bjk2ajB0NHEzanExZGFlbGpwazIifQ.l14rgv5vmu5wIMgOUUhUXw';
 const ATTRIBUTION_MARKUP =
     '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors | Images from <a href="https://map.uci.edu/?id=463">UCI Map</a>';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -62,6 +62,10 @@ const styles = {
             width: '8%',
         },
     },
+    container: {},
+    titleRow: {},
+    clearSchedule: {},
+    scheduleNoteContainer: {},
 };
 
 const SectionTable = (props: SectionTableProps) => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -162,7 +162,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
     const { classes, instructors } = props;
 
     const getLinks = (professorNames: string[]) => {
-        return professorNames.map((profName) => {
+        return professorNames.map((profName, index) => {
             if (profName !== 'STAFF') {
                 const lastName = profName.substring(0, profName.indexOf(','));
                 return (
@@ -177,7 +177,7 @@ const InstructorsCell = withStyles(styles)((props: InstructorsCellProps) => {
                     </Box>
                 );
             } else {
-                return <Box key={profName}> {profName} </Box>;
+                return <Box key={profName + index}> {profName} </Box>; // The key should be fine as we're not changing ['STAFF, 'STAFF']
             }
         });
     };


### PR DESCRIPTION
## Summary
Map will now display Menu Tabs for Sat/Sun & associated markers when there are weekend courses in your calendar.

![Weekend Tabs](https://github.com/icssc/AntAlmanac/assets/100006999/93985f08-c58d-44ac-af25-903e8272b0bf)

## Test Plan
Checked that functionality works swapping between schedules and when removing the weekend course

## Issues
Closes #588, ported over from #589