### PR TITLE
Add Tabs for Sat/Sun on Map

### DIFF
--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -25,7 +25,7 @@ const url = `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{
 /**
  * empty day is alias for "All Days"
  */
-const days = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const days = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 interface MarkerContent {
     key: string;
@@ -146,6 +146,10 @@ export default function CourseMap() {
           }
         : undefined;
 
+    const hasWeekendCourse = AppStore.getCourseEventsInCalendar().some(
+        (event) => event.start.getDay() === 0 || event.start.getDay() === 6
+    );
+
     const today = days[selectedDayIndex];
 
     /**
@@ -176,13 +180,15 @@ export default function CourseMap() {
                 {/** Menu floats above the map. */}
                 <Paper sx={{ zIndex: 400, position: 'relative', my: 2, mx: 6.942, marginX: '15%', marginY: 8 }}>
                     <Tabs value={selectedDayIndex} onChange={handleChange} variant="fullWidth" sx={{ minHeight: 0 }}>
-                        {days.map((day) => (
-                            <Tab
-                                key={day}
-                                label={day || 'All'}
-                                sx={{ padding: 1, minHeight: 'auto', minWidth: '10%', p: 1 }}
-                            />
-                        ))}
+                        {days
+                            .filter((day) => hasWeekendCourse || (day !== 'Sat' && day !== 'Sun'))
+                            .map((day) => (
+                                <Tab
+                                    key={day}
+                                    label={day || 'All'}
+                                    sx={{ padding: 1, minHeight: 'auto', minWidth: '10%', p: 1 }}
+                                />
+                            ))}
                     </Tabs>
                     <Autocomplete
                         options={buildings}

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -22,6 +22,15 @@ const ATTRIBUTION_MARKUP =
 
 const url = `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${ACCESS_TOKEN}`;
 
+/**
+ * empty day is alias for "All Days"
+ * This is used in subsequent lines of code for comparison; all event days will contain an empty string,
+ * which is why it's used to represent "All". Any non-empty string will filter out certain days;
+ * filtering by "All" would literally filter out all the days since no day starts with "All".
+ */
+const workWeek = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const fullWeek = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
 interface MarkerContent {
     key: string;
     image: string;
@@ -145,10 +154,7 @@ export default function CourseMap() {
         (event) => event.start.getDay() === 0 || event.start.getDay() === 6
     );
 
-    const days = hasWeekendCourse
-        ? ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-        : ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-
+    const days = hasWeekendCourse ? fullWeek : workWeek;
     const today = days[selectedDayIndex];
 
     /**
@@ -180,7 +186,11 @@ export default function CourseMap() {
                 <Paper sx={{ zIndex: 400, position: 'relative', my: 2, mx: 6.942, marginX: '15%', marginY: 8 }}>
                     <Tabs value={selectedDayIndex} onChange={handleChange} variant="fullWidth" sx={{ minHeight: 0 }}>
                         {days.map((day) => (
-                            <Tab key={day} label={day} sx={{ padding: 1, minHeight: 'auto', minWidth: '10%', p: 1 }} />
+                            <Tab
+                                key={day}
+                                label={day || 'all'}
+                                sx={{ padding: 1, minHeight: 'auto', minWidth: '10%' }}
+                            />
                         ))}
                     </Tabs>
                     <Autocomplete

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -22,12 +22,8 @@ const ATTRIBUTION_MARKUP =
 
 const url = `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${ACCESS_TOKEN}`;
 
-/**
-* When filtering for events that occur on a specific day, every event's start datetime (string)
-* is checked if it includes the day. All strings contain an empty string, so "" is an alias for "all days".
- */
-const workWeek = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-const fullWeek = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const work_week = ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const full_week = ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 interface MarkerContent {
     key: string;
@@ -152,7 +148,7 @@ export default function CourseMap() {
         (event) => event.start.getDay() === 0 || event.start.getDay() === 6
     );
 
-    const days = hasWeekendCourse ? fullWeek : workWeek;
+    const days = hasWeekendCourse ? full_week : work_week;
     const today = days[selectedDayIndex];
 
     /**
@@ -160,7 +156,9 @@ export default function CourseMap() {
      * A duplicate section code found later in the array will have a higher index.
      */
     const markersToDisplay = Object.keys(markers)
-        .flatMap((markerKey) => markers[markerKey].filter((course) => course.start.toString().includes(today)))
+        .flatMap((markerKey) =>
+            markers[markerKey].filter((course) => today == 'All' || course.start.toString().includes(today))
+        )
         .sort((a, b) => a.start.getTime() - b.start.getTime())
         .filter(
             (a, index, array) => array.findIndex((otherCourse) => otherCourse.sectionCode === a.sectionCode) === index
@@ -184,11 +182,7 @@ export default function CourseMap() {
                 <Paper sx={{ zIndex: 400, position: 'relative', my: 2, mx: 6.942, marginX: '15%', marginY: 8 }}>
                     <Tabs value={selectedDayIndex} onChange={handleChange} variant="fullWidth" sx={{ minHeight: 0 }}>
                         {days.map((day) => (
-                            <Tab
-                                key={day}
-                                label={day || 'all'}
-                                sx={{ padding: 1, minHeight: 'auto', minWidth: '10%' }}
-                            />
+                            <Tab key={day} label={day} sx={{ padding: 1, minHeight: 'auto', minWidth: '10%' }} />
                         ))}
                     </Tabs>
                     <Autocomplete
@@ -204,7 +198,7 @@ export default function CourseMap() {
                 <UserLocator />
 
                 {/* Draw out routes if the user is viewing a specific day. */}
-                {today !== '' &&
+                {today !== 'All' &&
                     startDestPairs.map((startDestPair) => {
                         const latLngTuples = startDestPair.map((marker) => [marker.lat, marker.lng] as LatLngTuple);
                         const color = startDestPair[0]?.color;
@@ -226,7 +220,7 @@ export default function CourseMap() {
                         <Fragment key={Object.values(marker).join('')}>
                             <LocationMarker
                                 {...marker}
-                                label={today ? index + 1 : undefined}
+                                label={today !== 'All' ? index + 1 : undefined}
                                 stackIndex={coursesSameBuildingPrior.length}
                             >
                                 <Box>

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -23,10 +23,8 @@ const ATTRIBUTION_MARKUP =
 const url = `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${ACCESS_TOKEN}`;
 
 /**
- * empty day is alias for "All Days"
- * This is used in subsequent lines of code for comparison; all event days will contain an empty string,
- * which is why it's used to represent "All". Any non-empty string will filter out certain days;
- * filtering by "All" would literally filter out all the days since no day starts with "All".
+* When filtering for events that occur on a specific day, every event's start datetime (string)
+* is checked if it includes the day. All strings contain an empty string, so "" is an alias for "all days".
  */
 const workWeek = ['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 const fullWeek = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -22,11 +22,6 @@ const ATTRIBUTION_MARKUP =
 
 const url = `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${ACCESS_TOKEN}`;
 
-/**
- * empty day is alias for "All Days"
- */
-const days = ['', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
 interface MarkerContent {
     key: string;
     image: string;
@@ -150,6 +145,10 @@ export default function CourseMap() {
         (event) => event.start.getDay() === 0 || event.start.getDay() === 6
     );
 
+    const days = hasWeekendCourse
+        ? ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+        : ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
     const today = days[selectedDayIndex];
 
     /**
@@ -180,15 +179,9 @@ export default function CourseMap() {
                 {/** Menu floats above the map. */}
                 <Paper sx={{ zIndex: 400, position: 'relative', my: 2, mx: 6.942, marginX: '15%', marginY: 8 }}>
                     <Tabs value={selectedDayIndex} onChange={handleChange} variant="fullWidth" sx={{ minHeight: 0 }}>
-                        {days
-                            .filter((day) => hasWeekendCourse || (day !== 'Sat' && day !== 'Sun'))
-                            .map((day) => (
-                                <Tab
-                                    key={day}
-                                    label={day || 'All'}
-                                    sx={{ padding: 1, minHeight: 'auto', minWidth: '10%', p: 1 }}
-                                />
-                            ))}
+                        {days.map((day) => (
+                            <Tab key={day} label={day} sx={{ padding: 1, minHeight: 'auto', minWidth: '10%', p: 1 }} />
+                        ))}
                     </Tabs>
                     <Autocomplete
                         options={buildings}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -195,7 +195,7 @@ interface LocationsCellProps {
 }
 
 const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
-    const { classes, meetings, courseName } = props;
+    const { classes, meetings } = props;
     const { setSelectedTab } = useContext(mobileContext);
 
     const focusMap = useCallback(() => {
@@ -205,8 +205,8 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
-                const [buildingName = ''] = meeting.bldg;
-                const buildingId = locationIds[buildingName] ?? 69420;
+                const [buildingName = ''] = meeting.bldg[0].split(' ');
+                const buildingId = locationIds[buildingName];
                 return meeting.bldg[0] !== 'TBA' ? (
                     <Fragment key={meeting.days + meeting.time + meeting.bldg}>
                         <Link
@@ -230,9 +230,15 @@ interface SectionEnrollmentCellProps {
     classes: ClassNameMap;
     numCurrentlyEnrolled: WebsocSectionEnrollment;
     maxCapacity: number;
-    /** This is a string because sometimes it's "n/a" */
+
+    /**
+     * This is a string because sometimes it's "n/a"
+     */
     numOnWaitlist: string;
-    /** This is a string because numOnWaitlist is a string. I haven't seen this be "n/a" but it seems possible and I don't want it to break if that happens. */
+
+    /**
+     * This is a string because numOnWaitlist is a string. I haven't seen this be "n/a" but it seems possible and I don't want it to break if that happens.
+     */
     numNewOnlyReserved: string;
 }
 


### PR DESCRIPTION
## Summary
Map will now display Menu Tabs for Sat/Sun & associated markers when there are weekend courses in your calendar.

![Weekend Tabs](https://github.com/icssc/AntAlmanac/assets/100006999/cd2b6d16-6a09-4f1d-ac99-950ebbccc6c2)

## Test Plan
Checked that functionality works swapping between schedules and when removing the weekend course

## Issues
Closes #588