### PR TITLE
Colors and Courses duplication fix

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -172,7 +172,7 @@ export class Schedules {
             ...newCourse,
             section: {
                 ...newCourse.section,
-                color: getColorForNewSection(newCourse, this.getCurrentCourses()),
+                color: getColorForNewSection(newCourse, this.getAllCourses()),
             },
         };
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -163,8 +163,19 @@ export class Schedules {
         }
 
         const existingSection = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
+
+        const existsInSchedule = this.doesCourseExistInSchedule(
+            newCourse.section.sectionCode,
+            newCourse.term,
+            scheduleIndex
+        );
+
+        if (existsInSchedule) {
+            return existingSection; // If it's already present in a schedule, then no need to push it
+        }
+
         if (existingSection) {
-            this.schedules[scheduleIndex].courses.push(existingSection);
+            this.schedules[scheduleIndex].courses.push(existingSection); // existingSection is pushed so methods (e.g. @changeCourseColor) have the appropriate (i.e. same) course reference across all schedules
             return existingSection;
         }
 
@@ -172,7 +183,7 @@ export class Schedules {
             ...newCourse,
             section: {
                 ...newCourse.section,
-                color: getColorForNewSection(newCourse, this.getAllCourses()),
+                color: getColorForNewSection(newCourse, this.getAllCourses()), // New colors are drawn from a Set of unused colors across all schedules
             },
         };
 


### PR DESCRIPTION
## Summary
1. Colors from new courses are now drawn from a Set of colors unused across all schedules. This means that if Blue was used for ICS 6B in schedule 1, Blue can't be used for ICS 32A in schedule 2.
2. Courses will no longer be pushed if they already exist in the to-be-pushed-to schedule. The course reference is still returned, however, to maintain functionality.

## Test Plan
1. Colors can still be changed universally
2. Courses can still be added and removed without issue

## Issues
Closes #633 

___Sorry about the lack of cute gifs/pics! Wifi is not super hot rn___
