### PR TITLE
UI Warning for Schedule Conflicts

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -385,13 +385,13 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         };
 
         const checkAndDisplayScheduleConflict = () => {
-            if (AppStore.getEventsInCalendar().length < 1) {
+            if (AppStore.getCourseEventsInCalendar().length < 1) {
                 setScheduleConflict(false);
                 return;
             }
 
             // An array of lists of time information on every added event
-            const calendarEventTimes = AppStore.getEventsInCalendar().map((event) => {
+            const calendarEventTimes = AppStore.getCourseEventsInCalendar().map((event) => {
                 const courseDay = event.start.getDay();
 
                 // courseStart/EndTime is normalized to ##:## (i.e. leading zero, no seconds)

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -52,7 +52,7 @@ const styles: Styles<Theme, object> = (theme) => ({
             background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
         '&.scheduleConflict': {
-            background: isDarkMode() ? '#121212' : '#bdbdbd',
+            background: isDarkMode() ? '#121212' : '#bdbdbd', // The light mode color might not be readable enough
             opacity: 0.6,
         },
     },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -52,7 +52,7 @@ const styles: Styles<Theme, object> = (theme) => ({
             background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
         '&.scheduleConflict': {
-            background: isDarkMode() ? '#121212' : '#bdbdbd', // The light mode color might not be readable enough
+            background: isDarkMode() ? '#121212' : '#7c7c7c',
             opacity: 0.6,
         },
     },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -54,8 +54,8 @@ const styles: Styles<Theme, object> = (theme) => ({
                     45deg,
                     #f44336,
                     #f44336 2px,
-                    #515151 2px,
-                    #515151 80px
+                    ${theme.palette.action.hover} 2px,
+                    ${theme.palette.action.hover} 80px
                 )`,
             },
             '&:nth-of-type(even)': {
@@ -63,8 +63,8 @@ const styles: Styles<Theme, object> = (theme) => ({
                     45deg,
                     #f44336,
                     #f44336 2px,
-                    #424242 2px,
-                    #424242 80px
+                    ${theme.palette.background.paper} 2px,
+                    ${theme.palette.background.paper} 80px
                 )`,
             },
         },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -387,7 +387,15 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     // Google Chrome console is telling me I have trememdnous amounts of event listeners pepege
     const [timingWarning, setTimingWarning] = useState(false);
 
-    const translateDaysToNums = { Su: '0', M: '1', Tu: '2', W: '3', Th: '4', F: '5', Sa: '6' };
+    const translateDaysToNums: { [key: string]: string } = {
+        Su: '0',
+        M: '1',
+        Tu: '2',
+        W: '3',
+        Th: '4',
+        F: '5',
+        Sa: '6',
+    };
 
     useEffect(() => {
         const toggleHighlight = () => {
@@ -412,6 +420,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             const coursePaneEvent = {
                 // If there already exists a more well-written way
                 // to translate secton.meetings into a day number LMK
+                // Converts SuTuTh -> [Su, Tu, Th]
                 day: section.meetings[0].days.match(/[A-Z][a-z]*/g)?.map((day: string) => translateDaysToNums[day]),
                 startTime: '',
                 endTime: '',

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -393,7 +393,8 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             // An array of lists of time information on every added event
             const calendarEventTimes = AppStore.getEventsInCalendar().map((event) => {
                 const courseDay = event.start.getDay();
-                //courseStart/EndTime is normalized to ##:## (i.e. leading zero, no seconds)
+
+                // courseStart/EndTime is normalized to ##:## (i.e. leading zero, no seconds)
                 const courseStartTime = event.start.toString().split(' ')[4].slice(0, -3);
                 const courseEndTime = event.end.toString().split(' ')[4].slice(0, -3);
                 return { day: courseDay, startTime: courseStartTime, endTime: courseEndTime };
@@ -419,7 +420,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                     continue;
                 }
 
-                // Then, IF the course ( starts AND ends BEFORE) OR ( starts AND ends AFTER), it doesn't conflict
+                // Then, IF the course doesn't ( start AND end BEFORE) AND doesn't ( start AND end AFTER), it does conflict!
                 const happensBefore =
                     coursePaneEvent.startTime <= calendarEvent.startTime &&
                     coursePaneEvent.endTime <= calendarEvent.startTime;
@@ -428,7 +429,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                     coursePaneEvent.endTime >= calendarEvent.endTime;
 
                 // If neither happensBefore or happensAfter is true, set scheduleConflict to true
-                if (!(happensBefore || happensAfter)) {
+                if (!happensBefore && !happensAfter) {
                     setScheduleConflict(true);
                     return;
                 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -485,19 +485,18 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             return;
         };
 
-        toggleHighlight();
-        AppStore.on('addedCoursesChange', toggleHighlight);
-        AppStore.on('currentScheduleIndexChange', toggleHighlight);
+        const handleEventListeners = () => {
+            toggleHighlight();
+            checkScheduleConflict();
+        };
 
-        checkScheduleConflict();
-        AppStore.on('addedCoursesChange', checkScheduleConflict);
-        AppStore.on('currentScheduleIndexChange', checkScheduleConflict);
+        handleEventListeners();
+        AppStore.on('addedCoursesChange', handleEventListeners);
+        AppStore.on('currentScheduleIndexChange', handleEventListeners);
 
         return () => {
-            AppStore.removeListener('addedCoursesChange', toggleHighlight);
-            AppStore.removeListener('currentScheduleIndexChange', toggleHighlight);
-            AppStore.removeListener('addedCoursesChange', checkScheduleConflict);
-            AppStore.removeListener('currentScheduleIndexChange', checkScheduleConflict);
+            AppStore.removeListener('addedCoursesChange', handleEventListeners);
+            AppStore.removeListener('currentScheduleIndexChange', handleEventListeners);
         };
     }, [section.sectionCode, term]); //should only run once on first render since these shouldn't change.
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -52,7 +52,7 @@ const styles: Styles<Theme, object> = (theme) => ({
             background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
         '&.scheduleConflict': {
-            background: '#121212',
+            background: isDarkMode() ? '#121212' : '#bdbdbd',
             opacity: 0.6,
         },
     },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -470,6 +470,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                     courseDetails={courseDetails}
                     term={term}
                     scheduleNames={scheduleNames}
+                    scheduleConflict={scheduleConflict}
                 />
             ) : (
                 <ColorAndDelete color={section.color} sectionCode={section.sectionCode} term={term} />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -58,8 +58,8 @@ const styles: Styles<Theme, object> = (theme) => ({
             '&:nth-of-type(odd)': {
                 background: `repeating-linear-gradient(
                     45deg,
-                    #f44336,
-                    #f44336 2px,
+                    rgba(244, 67, 54, 0.5),
+                    rgba(244, 67, 54, 0.5) 2px,
                     ${theme.palette.action.hover} 2px,
                     ${theme.palette.action.hover} 80px
                 )`,
@@ -67,8 +67,8 @@ const styles: Styles<Theme, object> = (theme) => ({
             '&:nth-of-type(even)': {
                 background: `repeating-linear-gradient(
                     45deg,
-                    #f44336,
-                    #f44336 2px,
+                    rgba(244, 67, 54, 0.5),
+                    rgba(244, 67, 54, 0.5) 2px,
                     ${theme.palette.background.paper} 2px,
                     ${theme.palette.background.paper} 80px
                 )`,

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -48,31 +48,11 @@ const styles: Styles<Theme, object> = (theme) => ({
     },
     tr: {
         '&.addedCourse': {
-            // Additional specificity is needed so addedCourse takes precendence when timingWarning is also true
-            '&:nth-of-type(n)': {
-                background: isDarkMode() ? '#b0b04f' : '#fcfc97',
-            },
+            background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
-        // Input on the stripe colors (currently red) would be appreciated
         '&.scheduleConflict': {
-            '&:nth-of-type(odd)': {
-                background: `repeating-linear-gradient(
-                    45deg,
-                    rgba(244, 67, 54, 0.5),
-                    rgba(244, 67, 54, 0.5) 2px,
-                    ${theme.palette.action.hover} 2px,
-                    ${theme.palette.action.hover} 80px
-                )`,
-            },
-            '&:nth-of-type(even)': {
-                background: `repeating-linear-gradient(
-                    45deg,
-                    rgba(244, 67, 54, 0.5),
-                    rgba(244, 67, 54, 0.5) 2px,
-                    ${theme.palette.background.paper} 2px,
-                    ${theme.palette.background.paper} 80px
-                )`,
-            },
+            background: '#121212',
+            opacity: 0.6,
         },
     },
     cell: {
@@ -505,8 +485,11 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             classes={{ root: classes.row }}
             className={classNames(
                 classes.tr,
-                { scheduleConflict: scheduleConflict },
-                { addedCourse: addedCourse && highlightAdded }
+                // If the course is added, then don't apply scheduleConflict
+                // The ternary is needed since the added course conflicts with itself
+                addedCourse && highlightAdded
+                    ? { addedCourse: addedCourse && highlightAdded }
+                    : { scheduleConflict: scheduleConflict }
             )}
         >
             {!addedCourse ? (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -47,8 +47,14 @@ const styles: Styles<Theme, object> = (theme) => ({
         },
     },
     tr: {
-        // styling changes (e.g. color, spacing of gradient) needs input and tweaking
-        '&.timingWarning': {
+        '&.addedCourse': {
+            // Additional specificity is needed so addedCourse takes precendence when timingWarning is also true
+            '&:nth-of-type(n)': {
+                background: isDarkMode() ? '#b0b04f' : '#fcfc97',
+            },
+        },
+        // Input on the stripe colors (currently red) would be appreciated
+        '&.scheduleConflict': {
             '&:nth-of-type(odd)': {
                 background: `repeating-linear-gradient(
                     45deg,
@@ -67,11 +73,6 @@ const styles: Styles<Theme, object> = (theme) => ({
                     ${theme.palette.background.paper} 80px
                 )`,
             },
-        },
-        '&.addedCourse': {
-            // I'm told !important is bad practice,
-            //but something something CSS heirarchy is kicking my butt so I'll fix it later
-            background: isDarkMode() ? '#b0b04f !important' : '#fcfc97 !important',
         },
     },
     cell: {
@@ -505,7 +506,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             classes={{ root: classes.row }}
             className={classNames(
                 classes.tr,
-                { timingWarning: scheduleConflict },
+                { scheduleConflict: scheduleConflict },
                 { addedCourse: addedCourse && highlightAdded }
             )}
         >

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -442,7 +442,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             });
 
             const coursePaneEvent = {
-                // If there already exists a more well-written way to translate secton.meetings into a day number LMK
+                // If there already exists a more well-written way to translate secton.meetings days (string) into a number, LMK
                 // Converts SuTuTh -> [Su, Tu, Th] -> [0, 2, 4]
                 day: section.meetings[0].days.match(/[A-Z][a-z]*/g)?.map((day: string) => translateDaysToNums[day]),
                 startTime: '',

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -11,7 +11,6 @@ import ColorPicker from '$components/ColorPicker';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseDetails } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
-import ConditionalWrapper from '$components/ConditionalWrapper';
 
 // Reset these params in url becasue when copy a specific class's link, it only copy its course code
 // if there is random value let in the url, it will mess up the url copied.
@@ -119,18 +118,17 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
     return (
         <TableCell padding="none">
             <div className={classes.container} style={isMobileScreen ? { flexDirection: 'column' } : {}}>
-                <ConditionalWrapper
-                    condition={scheduleConflict}
-                    wrapper={(children) => (
-                        <Tooltip title="This course overlaps with another event in your calendar!" arrow>
-                            {children}
-                        </Tooltip>
-                    )}
-                >
+                {scheduleConflict ? (
+                    <Tooltip title="This course overlaps with another event in your calendar!" arrow>
+                        <IconButton onClick={() => closeAndAddCourse(AppStore.getCurrentScheduleIndex())}>
+                            <Add fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                ) : (
                     <IconButton onClick={() => closeAndAddCourse(AppStore.getCurrentScheduleIndex())}>
                         <Add fontSize="small" />
                     </IconButton>
-                </ConditionalWrapper>
+                )}
                 <IconButton {...bindTrigger(popupState)}>
                     <ArrowDropDown fontSize="small" />
                 </IconButton>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Menu, MenuItem, TableCell, useMediaQuery } from '@material-ui/core';
+import { IconButton, Menu, MenuItem, TableCell, Tooltip, useMediaQuery } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Add, ArrowDropDown, Delete } from '@material-ui/icons';
@@ -11,6 +11,7 @@ import ColorPicker from '$components/ColorPicker';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseDetails } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
+import ConditionalWrapper from '$components/ConditionalWrapper';
 
 // Reset these params in url becasue when copy a specific class's link, it only copy its course code
 // if there is random value let in the url, it will mess up the url copied.
@@ -66,10 +67,11 @@ interface ScheduleAddCellProps {
     courseDetails: CourseDetails;
     term: string;
     scheduleNames: string[];
+    scheduleConflict: boolean;
 }
 
 export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) => {
-    const { classes, section, courseDetails, term, scheduleNames } = props;
+    const { classes, section, courseDetails, term, scheduleNames, scheduleConflict } = props;
     const popupState = usePopupState({ popupId: 'SectionTableAddCellPopup', variant: 'popover' });
     const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT}`);
 
@@ -117,9 +119,18 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
     return (
         <TableCell padding="none">
             <div className={classes.container} style={isMobileScreen ? { flexDirection: 'column' } : {}}>
-                <IconButton onClick={() => closeAndAddCourse(AppStore.getCurrentScheduleIndex())}>
-                    <Add fontSize="small" />
-                </IconButton>
+                <ConditionalWrapper
+                    condition={scheduleConflict}
+                    wrapper={(children) => (
+                        <Tooltip title="This course overlaps with another event in your calendar!" arrow>
+                            {children}
+                        </Tooltip>
+                    )}
+                >
+                    <IconButton onClick={() => closeAndAddCourse(AppStore.getCurrentScheduleIndex())}>
+                        <Add fontSize="small" />
+                    </IconButton>
+                </ConditionalWrapper>
                 <IconButton {...bindTrigger(popupState)}>
                     <ArrowDropDown fontSize="small" />
                 </IconButton>

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -138,3 +138,35 @@ export const calendarizeCustomEvents = (currentCustomEvents: RepeatingCustomEven
 
     return customEventsInCalendar;
 };
+
+/**
+ * @param section
+ * @returns the start and end time of a course in a 24 hour time with a leading zero (##:##)
+ * @returns undefined if there is no WebSOC time (e.g. 'TBA', undefined)
+ */
+export const translateWebSOCTimeTo24HourTime = (section: AASection) => {
+    const timeString = section.meetings[0].time.replace(/\s/g, '');
+
+    if (timeString !== 'TBA' && timeString !== undefined) {
+        const [, startHrStr, startMinStr, endHrStr, endMinStr, ampm] = timeString?.match(
+            /(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})(p?)/
+        ) as RegExpMatchArray;
+
+        let startHr = parseInt(startHrStr, 10);
+        let endHr = parseInt(endHrStr, 10);
+
+        if (ampm === 'p' && endHr !== 12) {
+            startHr += 12;
+            endHr += 12;
+            if (startHr > endHr) startHr -= 12;
+        }
+
+        // Times are standardized to ##:## (i.e. leading zero) for correct comparisons as strings
+        return {
+            startTime: `${startHr < 10 ? `0${startHr}` : startHr}:${startMinStr}`,
+            endTime: `${endHr < 10 ? `0${endHr}` : endHr}:${endMinStr}`,
+        };
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
## Summary
Right Pane Courses (`coursePaneEvent` in the code) will display with a grayed-out overlay (i.e. a warning) on them IF the course would conflict with another course already in the user's calendar (`calendarEventTimes`).

For example, ICS 42 at 11:00AM - 11:50 AM will be grayed-out/pseudo-hidden IF you already added ICS 68 which occurs at 11:20AM - 12:40 PM

![Feature Demo](https://github.com/icssc/AntAlmanac/assets/100006999/10555ecb-5632-4ff3-8be3-c04267722011)

Dark Mode:
<img height="500" alt="Screenshot of Feature" src="https://github.com/icssc/AntAlmanac/assets/100006999/7a61d0f5-fd14-499b-b688-2ff0d21ec8a6">

Light Mode:
![image](https://github.com/icssc/AntAlmanac/assets/100006999/c247dee4-f94d-4d7e-a0de-0335ebd72bbc)

## Test Plan
1. Courses should properly update when there are schedule conflicts.
2. The gray background and opacity should convey the pseudo-hidden state but still be readable in both dark and light mode

## Issues
Closes #