### PR TITLE
Resolved forwardRef warning for ScheduleNameDialog

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Te
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Add } from '@material-ui/icons';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { addSchedule, renameSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
@@ -24,7 +24,7 @@ interface ScheduleNameDialogProps {
     scheduleRenameIndex?: number;
 }
 
-const ScheduleNameDialog = (props: ScheduleNameDialogProps) => {
+const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
     const { classes, onOpen, onClose, scheduleNames, scheduleRenameIndex } = props;
     const rename = scheduleRenameIndex !== undefined;
 
@@ -87,6 +87,7 @@ const ScheduleNameDialog = (props: ScheduleNameDialogProps) => {
                 </MenuItem>
             )}
             <Dialog
+                ref={ref}
                 fullWidth
                 open={isOpen}
                 onKeyDown={handleKeyDown}
@@ -123,6 +124,8 @@ const ScheduleNameDialog = (props: ScheduleNameDialogProps) => {
             </Dialog>
         </>
     );
-};
+});
+
+ScheduleNameDialog.displayName = 'ScheduleNameDialog';
 
 export default withStyles(styles)(ScheduleNameDialog);


### PR DESCRIPTION
## Summary
Resolved forwardRef warning for `ScheduleNameDialog.tsx` by wrapping it in a forwardRef. I just glanced at what `Marker.tsx` did and nabbed that.

> react-dom.development.js:86 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

## Test Plan
Functionality is still A-Ok

## Issues
Closes #629, finishes up a bit of nonsense from #630 
