### PR TITLE
Change hard-coded color to random choice from palette

### DIFF
--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -175,6 +175,9 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     // If the same courseTitle exists, but not the same sectionType, return a close color
     if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, usedColors);
 
-    // If there are no existing sections with the same course title, generate a new color
-    return defaultColors.find((materialColor) => !usedColors.has(materialColor)) || '#5ec8e0';
+    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return a random one that's been used already.
+    return (
+        defaultColors.find((materialColor) => !usedColors.has(materialColor)) ||
+        defaultColors[Math.floor(Math.random() * defaultColors.length)]
+    );
 }


### PR DESCRIPTION
## Summary
When we choose a color for a course it's from a fixed-size palette. When we run out of unique colors from the palette, previously we just chose a hard-coded color. This changes it to choose a random one from the palette.
## Test Plan
Add courses until you run out of unique colors (at least 8)
