### PR TITLE
Used Colors come from the same Term

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -183,7 +183,10 @@ export class Schedules {
             ...newCourse,
             section: {
                 ...newCourse.section,
-                color: getColorForNewSection(newCourse, this.getAllCourses()), // New colors are drawn from a Set of unused colors across all schedules
+                color: getColorForNewSection(
+                    newCourse,
+                    this.getAllCourses().filter((course) => course.term === newCourse.term)
+                ), // New colors are drawn from a Set of unused colors across the newCourse's term
             },
         };
 


### PR DESCRIPTION
## Summary
Instead of drawing a Set of usedColors from all courses in all schedules, which depletes our 7 course colors very rapidly, used colors will now be drawn from courses that share the same term as the to-be-added course.

## Test Plan
After depleting our 7 preset colors and triggering the random palette, swap to another term and start adding courses. The courses in the other term should be able to use the 7 preset colors in the right order (blue -> pink -> purple -> etc)

## Additional Notes
This might be a good time to also consider expanding our set of preset colors as even when we're only considering courses in the same term, 7 does get used up quickly! 

`const defaultColors = [blue[500], pink[500], purple[500], green[500], amber[500], deepPurple[500], deepOrange[500]];`

We could add a dark red, a brown, a black, and a white if we're interested in expanding!