### PR TITLE
Prereq Tree is now within a Popover Component

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.css
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.css
@@ -206,6 +206,7 @@
     margin-top: 2em;
 }
 
+/* Styling that targets the Popover component (not sure why it can't be done inline)*/
 .MuiPopover-paper {
     overflow-x: auto;
 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.css
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.css
@@ -205,3 +205,7 @@
     background-color: #f5f5f5;
     margin-top: 2em;
 }
+
+.MuiPopover-paper {
+    overflow-x: auto;
+}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-const */
 import { Prerequisite, PrerequisiteTree } from 'peterportal-api-next-types';
-import { FC } from 'react';
+import { FC, useState } from 'react';
+import { Button, Modal, Popover } from '@material-ui/core';
 
 import { CourseInfo } from './CourseInfoBar';
 import { isDarkMode } from '$lib/helpers';
@@ -99,6 +100,18 @@ const PrereqTree: FC<PrereqProps> = (props) => {
     let hasPrereqs = JSON.stringify(props.prerequisite_tree) !== '{}';
     let hasDependencies = Object.keys(props.prerequisite_for).length !== 0;
 
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const open = Boolean(anchorEl);
+
     if (props.id === undefined) return <></>;
     else if (!hasPrereqs && !hasDependencies)
         return (
@@ -109,48 +122,62 @@ const PrereqTree: FC<PrereqProps> = (props) => {
     return (
         <div>
             <div className={'prereq-tree'}>
-                <div
-                    style={{
-                        display: 'inline-flex',
-                        flexDirection: 'row',
-                        width: 'fit-content',
-                        justifyContent: 'center',
-                        margin: 'auto',
-                    }}
-                >
-                    {/* Display dependencies */}
-                    {hasDependencies && (
-                        <>
-                            <ul style={{ padding: '0', display: 'flex' }}>
-                                <div className={'dependency-list-branch'}>
-                                    {Object.values(props.prerequisite_for).map((dependency, index) => (
-                                        <li key={`dependencyNode-${index}`} className={'dependency-node'}>
-                                            <Node label={dependency} node={'dependencyNode'} />
-                                        </li>
-                                    ))}
+                <div>
+                    <Button onClick={handleClick} variant="contained" color="primary">
+                        Display Prerequisite Tree
+                    </Button>
+                    <Popover
+                        open={open}
+                        anchorEl={anchorEl}
+                        onClose={handleClose}
+                        anchorOrigin={{
+                            vertical: 'center',
+                            horizontal: 'left',
+                        }}
+                        transformOrigin={{
+                            vertical: 'center',
+                            horizontal: 'right',
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: 'inline-flex',
+                                flexDirection: 'row',
+                                margin: '10px',
+                            }}
+                        >
+                            {/* Display dependencies */}
+                            {hasDependencies && (
+                                <>
+                                    <ul style={{ padding: '0', display: 'flex' }}>
+                                        <div className={'dependency-list-branch'}>
+                                            {Object.values(props.prerequisite_for).map((dependency, index) => (
+                                                <li key={`dependencyNode-${index}`} className={'dependency-node'}>
+                                                    <Node label={dependency} node={'dependencyNode'} />
+                                                </li>
+                                            ))}
+                                        </div>
+                                    </ul>
+                                    <div style={{ display: 'inline-flex', flexDirection: 'row', marginLeft: '0.5rem' }}>
+                                        <span style={{ margin: 'auto 1rem' }}>
+                                            <div className="dependency-needs dependency-branch">needs</div>
+                                        </span>
+                                    </div>
+                                </>
+                            )}
+                            {/* Display the class id */}
+                            <Node label={`${props.department} ${props.courseNumber}`} node={'course-node'} />
+                            {/* Spawns the root of the prerequisite tree */}
+                            {hasPrereqs && (
+                                <div style={{ display: 'flex', justifyContent: 'center', alignContent: 'center' }}>
+                                    <PrereqTreeNode
+                                        prerequisiteNames={props.prerequisite_list}
+                                        prerequisite={props.prerequisite_tree}
+                                    />
                                 </div>
-                            </ul>
-
-                            <div style={{ display: 'inline-flex', flexDirection: 'row', marginLeft: '0.5rem' }}>
-                                <span style={{ margin: 'auto 1rem' }}>
-                                    <div className="dependency-needs dependency-branch">needs</div>
-                                </span>
-                            </div>
-                        </>
-                    )}
-
-                    {/* Display the class id */}
-                    <Node label={`${props.department} ${props.courseNumber}`} node={'course-node'} />
-
-                    {/* Spawns the root of the prerequisite tree */}
-                    {hasPrereqs && (
-                        <div style={{ display: 'flex', justifyContent: 'center', alignContent: 'center' }}>
-                            <PrereqTreeNode
-                                prerequisiteNames={props.prerequisite_list}
-                                prerequisite={props.prerequisite_tree}
-                            />
+                            )}
                         </div>
-                    )}
+                    </Popover>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
1. Added a Button and Popover component which contains the Prereq Tree. Previously, for courses such as Math 3A, the Prereq Tree was very large and made for a less friendly UX. 
2. Although this adds an additional step for the user, I think that because the prereq tree is obscuring other info such as GE categories (or even the prereqs/dependencies as just text), it's alright for it to be put behind another action.

Before:
![](https://user-images.githubusercontent.com/100006999/257868170-71f637a0-ac4f-4890-b305-96a9424e5d83.gif)

After:
![chrome-capture-2023-7-3](https://github.com/icssc/AntAlmanac/assets/100006999/41f5ccbd-afc7-4bc9-ba34-8db14005c4fa)

## Test Plan
1. Make sure that the styling and functionality work as intended across all devices.

## Issues
Closes #650 