### PR TITLE
Patch Notes now display if they haven't been viewed. 

### DIFF
--- a/apps/antalmanac/src/components/PatchNotes.tsx
+++ b/apps/antalmanac/src/components/PatchNotes.tsx
@@ -5,12 +5,15 @@ import { useEffect, useState } from 'react';
 const PatchNotes = () => {
     const [isOpen, setIsOpen] = useState(true);
 
-    // show modal only on first visit
+    // show modal only if the current patch notes haven't been shown
+    // This is denoted by a date string YYYYMMDD (e.g. 20230819)
+    const latestPatchNotesUpdate = '20230819';
+
     useEffect(() => {
-        if (localStorage.getItem('visitedCount') == 'y') {
+        if (localStorage.getItem('latestVisit') == latestPatchNotesUpdate) {
             setIsOpen(false);
         } else {
-            localStorage.setItem('visitedCount', 'y');
+            localStorage.setItem('latestVisit', latestPatchNotesUpdate);
         }
     }, []);
 


### PR DESCRIPTION
## Summary
1. Changed the "hard-coded" `if (localStorage.getItem('visitedCount') == 'y')` to a new arbitrary string.
2. This new arbitrary string is in the format YYYYMMDD and would also need to be updated anytime the patch notes are updated. (Technically means you could just make it any random string, but making it based on the date should prevent non-unique values)

![Patch Note demo](https://github.com/icssc/AntAlmanac/assets/100006999/9e627efc-d0dc-4e4a-8a31-6db1657772cb)

Description Above: _When localStorage's `latestValue` is not 20230819, the patch notes show up again!_

## Test Plan
1. Do patch notes still display as intended (i.e. if the user hasn't seen it yet)?

## Issues
Closes #656

<!-- [Optional]
## Future Followup
-->
