### PR TITLE
Added Course Pane will not Display ScheduleConflict

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -230,7 +230,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                                 courseDetails={course}
                                 term={course.term}
                                 colorAndDelete={true}
-                                highlightAdded={false}
+                                allowHighlight={false}
                                 analyticsCategory={analyticsEnum.addedClasses.title}
                                 scheduleNames={this.state.scheduleNames}
                             />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -171,7 +171,7 @@ const SectionTableWrapped = (
                 term={formData.term}
                 courseDetails={course}
                 colorAndDelete={false}
-                highlightAdded={true}
+                allowHighlight={true}
                 scheduleNames={scheduleNames}
                 analyticsCategory={analyticsEnum.classSearch.title}
             />
@@ -183,7 +183,7 @@ const SectionTableWrapped = (
                 term={formData.term}
                 courseDetails={course}
                 colorAndDelete={false}
-                highlightAdded={true}
+                allowHighlight={true}
                 scheduleNames={scheduleNames}
                 analyticsCategory={analyticsEnum.classSearch.title}
             />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -69,7 +69,7 @@ const styles = {
 };
 
 const SectionTable = (props: SectionTableProps) => {
-    const { classes, courseDetails, term, colorAndDelete, highlightAdded, scheduleNames, analyticsCategory } = props;
+    const { classes, courseDetails, term, colorAndDelete, allowHighlight, scheduleNames, analyticsCategory } = props;
     const courseId = courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     const encodedDept = encodeURIComponent(courseDetails.deptCode);
     const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT}`);
@@ -181,7 +181,7 @@ const SectionTable = (props: SectionTableProps) => {
                                     courseDetails={courseDetails}
                                     term={term}
                                     colorAndDelete={colorAndDelete}
-                                    highlightAdded={highlightAdded}
+                                    allowHighlight={allowHighlight}
                                     scheduleNames={scheduleNames}
                                 />
                             );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
@@ -11,7 +11,7 @@ export interface SectionTableProps {
     courseDetails: AACourse;
     term: string;
     colorAndDelete: boolean;
-    highlightAdded: boolean;
+    allowHighlight: boolean;
     scheduleNames: string[];
     analyticsCategory: string;
 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -448,9 +448,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                 classes.tr,
                 // If the course is added, then don't apply scheduleConflict
                 // The ternary is needed since the added course conflicts with itself
-                addedCourse && highlightAdded
-                    ? { addedCourse: addedCourse && highlightAdded }
-                    : { scheduleConflict: scheduleConflict }
+                addedCourse ? { addedCourse: addedCourse && highlightAdded } : { scheduleConflict: scheduleConflict }
             )}
         >
             {!addedCourse ? (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -441,13 +441,16 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         };
     }, [section.sectionCode, term]); //should only run once on first render since these shouldn't change.
 
+    console.log(`addedCourse: ${addedCourse}`);
+    console.log(highlightAdded);
     return (
         <TableRow
             classes={{ root: classes.row }}
             className={classNames(
                 classes.tr,
-                // If the course is added, then don't apply scheduleConflict
-                // The ternary is needed since the added course conflicts with itself
+                // If the course is added, then don't check for/apply scheduleConflict
+                // highlightAdded is checked with addedCourse because AddedCoursePane *always* passes highlightAdded as false, thus preventing the row from displaying with the additional styling when in addedCourses
+                // sectionTableBody always passes highlight as true (?)
                 addedCourse ? { addedCourse: addedCourse && highlightAdded } : { scheduleConflict: scheduleConflict }
             )}
         >

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -441,8 +441,6 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         };
     }, [section.sectionCode, term]); //should only run once on first render since these shouldn't change.
 
-    console.log(`addedCourse: ${addedCourse}`);
-    console.log(highlightAdded);
     return (
         <TableRow
             classes={{ root: classes.row }}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -345,13 +345,13 @@ interface SectionTableBodyProps {
     courseDetails: CourseDetails;
     term: string;
     colorAndDelete: boolean;
-    highlightAdded: boolean;
+    allowHighlight: boolean;
     scheduleNames: string[];
 }
 
 //TODO: SectionNum name parity -> SectionNumber
 const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
-    const { classes, section, courseDetails, term, colorAndDelete, highlightAdded, scheduleNames } = props;
+    const { classes, section, courseDetails, term, colorAndDelete, allowHighlight, scheduleNames } = props;
     const [addedCourse, setAddedCourse] = useState(colorAndDelete);
 
     const [scheduleConflict, setScheduleConflict] = useState(false);
@@ -447,9 +447,8 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             className={classNames(
                 classes.tr,
                 // If the course is added, then don't check for/apply scheduleConflict
-                // highlightAdded is checked with addedCourse because AddedCoursePane *always* passes highlightAdded as false, thus preventing the row from displaying with the additional styling when in addedCourses
-                // sectionTableBody always passes highlight as true (?)
-                addedCourse ? { addedCourse: addedCourse && highlightAdded } : { scheduleConflict: scheduleConflict }
+                // allowHighlight is ALWAYS false when in Added Course Pane and ALWAYS true when in CourseRenderPane
+                addedCourse ? { addedCourse: addedCourse && allowHighlight } : { scheduleConflict: scheduleConflict }
             )}
         >
             {!addedCourse ? (


### PR DESCRIPTION
## TLDR Summary
1. Fixed ternary which always resolved to `false` in `AddedCoursePane.tsx`, resulting in `scheduleConflict` always being checked, and thus always being displayed.
2. Refactored `highlightAdded` to `allowHighlight` for clarity.

![Demoing fixed Added Course Pane](https://github.com/icssc/AntAlmanac/assets/100006999/b1ab321e-13f9-42ea-adc7-3f59fe82d4d7)

-----------

## In Depth Summary
Corrected bad logic from this line:

```typescript
                addedCourse && highlightAdded
                    ? { addedCourse: addedCourse && highlightAdded }
                    : { scheduleConflict: scheduleConflict }
```

I misunderstood what the purpose of highlightAdded was, and assumed it was a state variable for displaying the yellow-highlight for added courses. highlightAdded is **actually** a prop passed by `AddedCoursePane.tsx` and `SectionTableBody.tsx` (also `GEDataFetchProvider.tsx`, but that's not relevant here) to allow highlighting or not (i.e., highlighting shouldn't be allowed on Added Course Pane). 

This means that `highlightAdded` was always `true` on Course Render Pane and always `false` on Added Course Pane. This meant that the ternary above with `highlightAdded` would always resolve to false, therefore allowing `scheduleConflict` to be added to the CSS (since `scheduleConflict` would always be true). 

For context, this was the code prior to #636:
```typescript
className={classNames(classes.tr, { addedCourse: addedCourse && highlightAdded })}
```

For future clarity, I've also decided to refactor `highlightAdded` to `allowHighlight`, which feels more appropriate. If you've got input regarding the naming, I'm all ears :) !


## Test Plan
Check that scheduleConflict functionality remains the same, except for it now not displaying on the Added Course Pane.

## Issues
Closes #660

## Misc
If the refactoring makes more sense as a separate PR, just LMK and I'll undo them!