### PR TITLE
Light Mode Accessibility - Schedule Conflict

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -41,7 +41,7 @@ const styles: Styles<Theme, object> = (theme) => ({
             background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
         '&.scheduleConflict': {
-            background: isDarkMode() ? 'rgba(18, 18, 18)' : 'rgba(160, 160, 160)',
+            background: isDarkMode() ? '#121212' : '#a0a0a0',
             opacity: isDarkMode() ? 0.6 : 1,
         },
     },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -41,8 +41,8 @@ const styles: Styles<Theme, object> = (theme) => ({
             background: isDarkMode() ? '#b0b04f' : '#fcfc97',
         },
         '&.scheduleConflict': {
-            background: isDarkMode() ? '#121212' : '#7c7c7c',
-            opacity: 0.6,
+            background: isDarkMode() ? 'rgba(18, 18, 18)' : 'rgba(160, 160, 160)',
+            opacity: isDarkMode() ? 0.6 : 1,
         },
     },
     cell: {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -76,7 +76,7 @@ const styles: Styles<Theme, object> = (theme) => ({
     },
     Act: { color: '#c87137' },
     Col: { color: '#ff40b5' },
-    Dis: { color: '#8d63f0' },
+    Dis: { color: '#ff6e00' },
     Fld: { color: '#1ac805' },
     Lab: { color: '#1abbe9' },
     Lec: { color: '#d40000' },


### PR DESCRIPTION
## Summary
1. Opacity will only apply to dark mode
2. Light mode's "pseudo-disabled" gray coloring was lightened
3. Dis is now colored orange #ff6e00 instead of #8d63f0 (violet) for readability

Before:
![](https://user-images.githubusercontent.com/64875104/261917434-15cc0eae-a180-4adc-b0cb-4625ec7c0491.png)

After:
![](https://cdn.discordapp.com/attachments/1107836699603644437/1143066532352622632/Screenshot_2023-08-20_at_11.18.13_PM.png)

![](https://cdn.discordapp.com/attachments/1107836699603644437/1143066532008710204/Screenshot_2023-08-20_at_11.18.03_PM.png)

## Test Plan
1. Changes are limited to styling only, so... does it look cute? 💖

## Issues
Closes #661

<!-- [Optional]
## Future Followup
-->
