### PR TITLE
Add Show/Hide & Restyle Clear/Copy Buttons in AddedCoursePane

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -24,6 +24,9 @@ const styles = {
         display: 'flex',
         width: '100%',
         justifyContent: 'space-between',
+        alignItem: 'flex-end',
+        marginLeft: '4px',
+        marginRight: '4px',
     },
     clearSchedule: {
         marginLeft: '4px',
@@ -236,7 +239,11 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         </Grid>
                     );
                 })}
-                {this.state.customEvents.length > 0 && <Typography variant="h6">Custom Events</Typography>}
+                {this.state.customEvents.length > 0 && (
+                    <Typography variant="h6" className={this.props.classes.titleRow}>
+                        Custom Events
+                    </Typography>
+                )}
                 {this.state.customEvents.map((customEvent) => {
                     return (
                         <Grid item md={12} xs={12} key={customEvent.title}>
@@ -248,7 +255,9 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         </Grid>
                     );
                 })}
-                <Typography variant="h6">Schedule Notes</Typography>
+                <Typography variant="h6" className={this.props.classes.titleRow}>
+                    Schedule Notes
+                </Typography>
                 <Paper className={this.props.classes.scheduleNoteContainer}>
                     <TextField
                         type="text"

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,10 +1,12 @@
-import { Box, Button, Grid, Menu, MenuItem, Paper, TextField, Typography } from '@material-ui/core';
+import { Box, Button, Grid, /*IconButton,*/ Menu, MenuItem, Paper, TextField, Typography } from '@material-ui/core';
+import { IconButton } from '@mui/material';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { PureComponent } from 'react';
 
 import { AACourse } from '@packages/antalmanac-types';
+import { ContentCopy } from '@mui/icons-material';
 import { ColumnToggleButton } from '../CoursePane/CoursePaneButtonRow';
 import { RepeatingCustomEvent } from '../../Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
@@ -174,12 +176,60 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         padding: 4,
                     }}
                 >
+                    <PopupState variant="popover">
+                        {(popupState) => (
+                            <>
+                                <IconButton
+                                    {...bindTrigger(popupState)}
+                                    sx={{
+                                        backgroundColor: 'rgba(236, 236, 236, 1)',
+                                        marginRight: 1,
+                                        padding: 1.5,
+                                        boxShadow: '2',
+                                        color: 'black',
+                                        '&:hover': {
+                                            backgroundColor: 'grey',
+                                        },
+                                        pointerEvents: 'auto',
+                                    }}
+                                >
+                                    <ContentCopy />
+                                </IconButton>
+                                <Menu {...bindMenu(popupState)}>
+                                    {this.state.scheduleNames.map((name, index) => {
+                                        return (
+                                            <MenuItem
+                                                key={index}
+                                                disabled={AppStore.getCurrentScheduleIndex() === index}
+                                                onClick={() => {
+                                                    copySchedule(index);
+                                                    popupState.close();
+                                                }}
+                                            >
+                                                Copy to {name}
+                                            </MenuItem>
+                                        );
+                                    })}
+                                    <MenuItem
+                                        onClick={() => {
+                                            copySchedule(this.state.scheduleNames.length);
+                                            popupState.close();
+                                        }}
+                                    >
+                                        Copy to All Schedules
+                                    </MenuItem>
+                                </Menu>
+                            </>
+                        )}
+                    </PopupState>
                     <ColumnToggleButton />
                 </Box>
-                <div className={this.props.classes.titleRow}>
-                    <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                <div>
+                    <Typography variant="h6" className={this.props.classes.titleRow}>
+                        {`${scheduleName} (${scheduleUnits} Units)`}{' '}
+                    </Typography>
 
-                    <div>
+                    {/* <div>
                         <PopupState variant="popover">
                             {(popupState) => (
                                 <>
@@ -216,7 +266,6 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         <Button
                             className={this.props.classes.clearSchedule}
                             variant="outlined"
-                            color="secondary"
                             onClick={() => {
                                 if (
                                     window.confirm(
@@ -233,7 +282,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         >
                             Clear Schedule
                         </Button>
-                    </div>
+                    </div> */}
                 </div>
                 {this.state.courses.map((course) => {
                     return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,10 +1,11 @@
-import { Button, Grid, Menu, MenuItem, Paper, TextField, Typography } from '@material-ui/core';
+import { Box, Button, Grid, Menu, MenuItem, Paper, TextField, Typography } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { PureComponent } from 'react';
 
 import { AACourse } from '@packages/antalmanac-types';
+import { ColumnToggleButton } from '../CoursePane/CoursePaneButtonRow';
 import { RepeatingCustomEvent } from '../../Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
 import CustomEventDetailView from './CustomEventDetailView';
@@ -24,7 +25,7 @@ const styles = {
         display: 'flex',
         width: '100%',
         justifyContent: 'space-between',
-        alignItem: 'flex-end',
+        alignItems: 'flex-end',
         marginLeft: '4px',
         marginRight: '4px',
     },
@@ -166,6 +167,15 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
 
         return (
             <>
+                <Box
+                    sx={{
+                        width: '100%',
+                        zIndex: 3,
+                        padding: 4,
+                    }}
+                >
+                    <ColumnToggleButton />
+                </Box>
                 <div className={this.props.classes.titleRow}>
                     <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -224,37 +224,37 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                             </>
                         )}
                     </PopupState>
-                    <IconButton
-                        sx={{
-                            backgroundColor: 'rgba(236, 236, 236, 1)',
-                            marginRight: 1,
-                            padding: 1.5,
-                            boxShadow: '2',
-                            color: 'black',
-                            '&:hover': {
-                                backgroundColor: 'grey',
-                            },
-                            pointerEvents: 'auto',
-                        }}
-                        onClick={() => {
-                            if (window.confirm('Are you sure you want to clear this schedule?')) {
-                                clearSchedules();
-                                logAnalytics({
-                                    category: analyticsEnum.addedClasses.title,
-                                    action: analyticsEnum.addedClasses.actions.CLEAR_SCHEDULE,
-                                });
-                            }
-                        }}
-                    >
-                        <DeleteOutline />
-                    </IconButton>
+                    <Tooltip title="Clear Schedule">
+                        <IconButton
+                            sx={{
+                                backgroundColor: 'rgba(236, 236, 236, 1)',
+                                marginRight: 1,
+                                padding: 1.5,
+                                boxShadow: '2',
+                                color: 'black',
+                                '&:hover': {
+                                    backgroundColor: 'grey',
+                                },
+                                pointerEvents: 'auto',
+                            }}
+                            onClick={() => {
+                                if (window.confirm('Are you sure you want to clear this schedule?')) {
+                                    clearSchedules();
+                                    logAnalytics({
+                                        category: analyticsEnum.addedClasses.title,
+                                        action: analyticsEnum.addedClasses.actions.CLEAR_SCHEDULE,
+                                    });
+                                }
+                            }}
+                        >
+                            <DeleteOutline />
+                        </IconButton>
+                    </Tooltip>
                     <ColumnToggleButton />
                 </Box>
-                <div>
-                    <Typography variant="h6" className={this.props.classes.titleRow}>
-                        {`${scheduleName} (${scheduleUnits} Units)`}{' '}
-                    </Typography>
-                </div>
+                <Typography variant="h6" className={this.props.classes.titleRow}>
+                    {`${scheduleName} (${scheduleUnits} Units)`}{' '}
+                </Typography>
                 {this.state.courses.map((course) => {
                     return (
                         <Grid item md={12} xs={12} key={course.deptCode + course.courseNumber}>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,4 +1,14 @@
-import { Box, Button, Grid, /*IconButton,*/ Menu, MenuItem, Paper, TextField, Typography } from '@material-ui/core';
+import {
+    Box,
+    Button,
+    Grid,
+    /*IconButton,*/ Menu,
+    MenuItem,
+    Paper,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@material-ui/core';
 import { IconButton } from '@mui/material';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
@@ -179,22 +189,24 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                     <PopupState variant="popover">
                         {(popupState) => (
                             <>
-                                <IconButton
-                                    {...bindTrigger(popupState)}
-                                    sx={{
-                                        backgroundColor: 'rgba(236, 236, 236, 1)',
-                                        marginRight: 1,
-                                        padding: 1.5,
-                                        boxShadow: '2',
-                                        color: 'black',
-                                        '&:hover': {
-                                            backgroundColor: 'grey',
-                                        },
-                                        pointerEvents: 'auto',
-                                    }}
-                                >
-                                    <ContentCopy />
-                                </IconButton>
+                                <Tooltip title="Copy Schedule">
+                                    <IconButton
+                                        {...bindTrigger(popupState)}
+                                        sx={{
+                                            backgroundColor: 'rgba(236, 236, 236, 1)',
+                                            marginRight: 1,
+                                            padding: 1.5,
+                                            boxShadow: '2',
+                                            color: 'black',
+                                            '&:hover': {
+                                                backgroundColor: 'grey',
+                                            },
+                                            pointerEvents: 'auto',
+                                        }}
+                                    >
+                                        <ContentCopy />
+                                    </IconButton>
+                                </Tooltip>
                                 <Menu {...bindMenu(popupState)}>
                                     {this.state.scheduleNames.map((name, index) => {
                                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,14 +1,4 @@
-import {
-    Box,
-    Button,
-    Grid,
-    /*IconButton,*/ Menu,
-    MenuItem,
-    Paper,
-    TextField,
-    Tooltip,
-    Typography,
-} from '@material-ui/core';
+import { Box, Grid, Menu, MenuItem, Paper, TextField, Tooltip, Typography } from '@material-ui/core';
 import { IconButton } from '@mui/material';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
@@ -16,7 +6,7 @@ import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { PureComponent } from 'react';
 
 import { AACourse } from '@packages/antalmanac-types';
-import { ContentCopy } from '@mui/icons-material';
+import { ContentCopy, DeleteOutline } from '@mui/icons-material';
 import { ColumnToggleButton } from '../CoursePane/CoursePaneButtonRow';
 import { RepeatingCustomEvent } from '../../Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
@@ -234,67 +224,36 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                             </>
                         )}
                     </PopupState>
+                    <IconButton
+                        sx={{
+                            backgroundColor: 'rgba(236, 236, 236, 1)',
+                            marginRight: 1,
+                            padding: 1.5,
+                            boxShadow: '2',
+                            color: 'black',
+                            '&:hover': {
+                                backgroundColor: 'grey',
+                            },
+                            pointerEvents: 'auto',
+                        }}
+                        onClick={() => {
+                            if (window.confirm('Are you sure you want to clear this schedule?')) {
+                                clearSchedules();
+                                logAnalytics({
+                                    category: analyticsEnum.addedClasses.title,
+                                    action: analyticsEnum.addedClasses.actions.CLEAR_SCHEDULE,
+                                });
+                            }
+                        }}
+                    >
+                        <DeleteOutline />
+                    </IconButton>
                     <ColumnToggleButton />
                 </Box>
                 <div>
                     <Typography variant="h6" className={this.props.classes.titleRow}>
                         {`${scheduleName} (${scheduleUnits} Units)`}{' '}
                     </Typography>
-
-                    {/* <div>
-                        <PopupState variant="popover">
-                            {(popupState) => (
-                                <>
-                                    <Button variant="outlined" {...bindTrigger(popupState)}>
-                                        Copy Schedule
-                                    </Button>
-                                    <Menu {...bindMenu(popupState)}>
-                                        {this.state.scheduleNames.map((name, index) => {
-                                            return (
-                                                <MenuItem
-                                                    key={index}
-                                                    disabled={AppStore.getCurrentScheduleIndex() === index}
-                                                    onClick={() => {
-                                                        copySchedule(index);
-                                                        popupState.close();
-                                                    }}
-                                                >
-                                                    Copy to {name}
-                                                </MenuItem>
-                                            );
-                                        })}
-                                        <MenuItem
-                                            onClick={() => {
-                                                copySchedule(this.state.scheduleNames.length);
-                                                popupState.close();
-                                            }}
-                                        >
-                                            Copy to All Schedules
-                                        </MenuItem>
-                                    </Menu>
-                                </>
-                            )}
-                        </PopupState>
-                        <Button
-                            className={this.props.classes.clearSchedule}
-                            variant="outlined"
-                            onClick={() => {
-                                if (
-                                    window.confirm(
-                                        'Are you sure you want to clear this schedule? You cannot undo this action, but you can load your schedule again.'
-                                    )
-                                ) {
-                                    clearSchedules();
-                                    logAnalytics({
-                                        category: analyticsEnum.addedClasses.title,
-                                        action: analyticsEnum.addedClasses.actions.CLEAR_SCHEDULE,
-                                    });
-                                }
-                            }}
-                        >
-                            Clear Schedule
-                        </Button>
-                    </div> */}
                 </div>
                 {this.state.courses.map((course) => {
                     return (

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -103,7 +103,7 @@ export class Schedules {
     }
 
     /**
-     * Adds all courses from current schedule to another (doesn't wipe schedules that are being copied into)
+     * Adds all events from current schedule to another (doesn't wipe schedules that are being copied into)
      * More like append than copy
      * @param to If equal to number of schedules will copy to all schedules
      */
@@ -116,14 +116,14 @@ export class Schedules {
                 this.addCourse(course, to, false);
             }
         }
-        for (const course of this.getCurrentCustomEvents()) {
+        for (const event of this.getCurrentCustomEvents()) {
             if (to === this.getNumberOfSchedules()) {
                 this.addCustomEvent(
-                    course,
+                    event,
                     [...Array(to).keys()] // Creates an array of indices from 0 to 'to'; https://stackoverflow.com/questions/3746725/how-to-create-an-array-containing-1-n
                 );
             } else {
-                this.addCustomEvent(course, [to]);
+                this.addCustomEvent(event, [to]);
             }
         }
     }

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -116,6 +116,16 @@ export class Schedules {
                 this.addCourse(course, to, false);
             }
         }
+        for (const course of this.getCurrentCustomEvents()) {
+            if (to === this.getNumberOfSchedules()) {
+                this.addCustomEvent(
+                    course,
+                    [...Array(to).keys()] // Creates an array of indices from 0 to 'to'; https://stackoverflow.com/questions/3746725/how-to-create-an-array-containing-1-n
+                );
+            } else {
+                this.addCustomEvent(course, [to]);
+            }
+        }
     }
 
     // --- Course related methods ---


### PR DESCRIPTION
## Summary
The reasoning for this change is to both add Show/Hide functionality to Added Courses, but the Copy/Clear changes are so that visually Show/Hide is in the same position. (See below for a gif of what it would look like without the Copy/Clear changes)

1. Show/Hide Column button is now also accessible on the Added Course Pane, fixing the user-flow issue referenced in the original pull request
2. Copy Schedule and Clear Schedule have been turned into IconButton components.
3. Clean up styling
4. Copy Schedule will now also copy custom events

Before: 
<img width="650" alt="Before" src="https://github.com/icssc/AntAlmanac/assets/100006999/46589db5-7e3f-4cf4-80e0-bf0a562ff690">

After:
<img width="650" alt="After" src="https://github.com/icssc/AntAlmanac/assets/100006999/eee439e7-b61f-4010-a7de-6ee7fc65a84f">

Copy and Clear Demo:
![Copy and Clear demo](https://github.com/icssc/AntAlmanac/assets/100006999/4be21c22-a9b5-48e6-ba92-af652c27ad4d)

Show/Hide Columns Demo:
![Show/Hide Columns Demo](https://github.com/icssc/AntAlmanac/assets/100006999/7bd54e41-4b94-4a76-9b9f-c2cb63e4bf80)


## Detailed Summary

### Show/Hide
1. As described in issue #664, the lack of a Show/Hide column button in the Added Course Pane could/would create a poor user experience because they wouldn't be able to reenable (or disable) columns from the Added Course Pane that they had adjusted in Course Render Pane.
2. Adding it into Added Course Pane resolves the above issue, but creates its own visual issues as well (see below)...

### Moving Copy + Clear Schedules into IconButtons
1. The Show/Hide button initially worked fine on its own, but the lack of visual consistency between the Search and Added Course panes was poor because the Show/Hide button would've been 3rd on Course pane and 1st on Added pane.

Demo:
![Demo of Visual Issue](https://github.com/icssc/AntAlmanac/assets/100006999/a8f733f4-38e7-4120-8dfc-c22988eb3d67)

2. By moving Copy & Clear, visual consistency can be maintained (and, in my opinion, improved) while also cleaning up the styling
3. Visual consistency is better with these three new "action" buttons at all time. But more specifically, the consistency is due to the Show/Hide button being able to maintain the same position on the screen.

### Copy Schedule now copies Custom Events
1. Previously, `copySchedule(index)` did not copy over custom events. It now does.

![Copy Schedule Demo](https://github.com/icssc/AntAlmanac/assets/100006999/026631bd-e858-48ab-81c1-84e451811bb0)

## Test Plan
- [ ] Functional
- [ ] Functional on all devices

## Issues
Closes #664

## To-Do
- [ ] Confirm whether or not copySchedule _should_ copy custom events and/or whether or not new, specific functions should be created for all events, course events, and custom events.

## Misc
- I'm not sure what the policy on mixing MUI 4 and 5 is, but currently I have Icons and IconButton from MUI 5 so I can use the styling from the sx prop.
