### PR TITLE
Change "Copy Section Code" to Chip

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Button, IconButton, Paper, Tooltip } from '@material-ui/core';
+import { Chip, IconButton, Paper, Tooltip } from '@material-ui/core';
 import { Theme, withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { Delete } from '@material-ui/icons';
@@ -38,6 +38,7 @@ const styles: Styles<Theme, object> = {
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        marginBottom: '0.25rem',
     },
     table: {
         border: 'none',
@@ -170,18 +171,18 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                             <td className={classes.alignToTop}>Section code</td>
                             <Tooltip title="Click to copy course code" placement="right">
                                 <td className={classes.rightCells}>
-                                    <Button
-                                        size="small"
-                                        onClick={(e) => {
+                                    <Chip
+                                        onClick={(event) => {
+                                            clickToCopy(event, sectionCode);
                                             logAnalytics({
-                                                category: analyticsEnum.calendar.title,
-                                                action: analyticsEnum.calendar.actions.COPY_COURSE_CODE,
+                                                category: analyticsEnum.classSearch.title,
+                                                action: analyticsEnum.classSearch.actions.COPY_COURSE_CODE,
                                             });
-                                            clickToCopy(e, sectionCode);
                                         }}
-                                    >
-                                        <u>{sectionCode}</u>
-                                    </Button>
+                                        className={classes.sectionCode}
+                                        label={sectionCode}
+                                        size="small"
+                                    />
                                 </td>
                             </Tooltip>
                         </tr>

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -330,9 +330,9 @@ export const warnMultipleTerms = (terms: Set<string>) => {
     );
 };
 
-export function clickToCopy(event: React.MouseEvent<HTMLElement, MouseEvent>, sectionCode: string) {
+export async function clickToCopy(event: React.MouseEvent<HTMLElement, MouseEvent>, sectionCode: string) {
     event.stopPropagation();
-    void navigator.clipboard.writeText(sectionCode);
+    await navigator.clipboard.writeText(sectionCode);
     openSnackbar('success', 'WebsocSection code copied to clipboard');
 }
 


### PR DESCRIPTION
## Summary
1. Change button component to Chip component in Calendar Event popup.
2. Makes the "Copy Button" (or Chip, I suppose) consistent across both the Calendar popup and the Right Pane.
3. Refactor `clickToCopy` to an `async` function.

<img width="522" alt="Screenshot 2023-08-22 at 3 07 00 AM" src="https://github.com/icssc/AntAlmanac/assets/100006999/5e80aae3-c455-4a24-9aa0-2eb77df51120">

## Test Plan
- [ ] Styling should still work across devices
- [ ] Functionality should still work (Click it -> is it on your clipboard ?)

## Issues
Closes #667