### PR TITLE
Add support for new API time formats

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -93,7 +93,7 @@
         "gh-pages": "^5.0.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.1.1",
-        "peterportal-api-next-types": "1.0.0-beta.2",
+        "peterportal-api-next-types": "1.0.0-rc.2.68.0",
         "prettier": "^2.8.4",
         "typescript": "^4.9.5",
         "vite": "^4.2.1",

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -91,17 +91,17 @@ export interface CourseEvent extends CommonCalendarEvent {
     finalExam: {
         examStatus: 'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL';
         dayOfWeek: 'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null;
-        month: number;
-        day: number;
+        month: number | null;
+        day: number | null;
         startTime: {
             hour: number;
             minute: number;
-        };
+        } | null;
         endTime: {
             hour: number;
             minute: number;
-        };
-        bldg: string[];
+        } | null;
+        bldg: string[] | null;
     };
     courseTitle: string;
     instructors: string[];
@@ -172,7 +172,8 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
             const timeString = translate24To12HourTime(finalExam);
 
             // FORMAT: Fri Dec 15 1:30-3:30pm
-            finalExamString = `${finalExam.dayOfWeek} ${MONTHS[finalExam.month - 1]} ${finalExam.day} ${timeString}`;
+            // TO-DO: Correct `finalExam.month - 1` to just `finalExam.month` pending PP-API changes
+            finalExamString = `${finalExam.dayOfWeek} ${MONTHS[finalExam.month! - 1]} ${finalExam.day} ${timeString}`;
         }
 
         return (

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -102,6 +102,7 @@ export interface CourseEvent extends CommonCalendarEvent {
         };
         bldg: string[];
     };
+    courseTitle: string;
     instructors: string[];
     isCustomEvent: false;
     sectionCode: string;

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -169,11 +169,11 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         } else if (finalExam.examStatus == 'TBA_FINAL') {
             finalExamString = 'Final TBA';
         } else {
-            const timeString = translate24To12HourTime(finalExam);
+            if (finalExam.startTime && finalExam.endTime && finalExam.month) {
+                const timeString = translate24To12HourTime(finalExam.startTime, finalExam.endTime);
 
-            // FORMAT: Fri Dec 15 1:30-3:30pm
-            // TO-DO: Correct `finalExam.month - 1` to just `finalExam.month` pending PP-API changes
-            finalExamString = `${finalExam.dayOfWeek} ${MONTHS[finalExam.month! - 1]} ${finalExam.day} ${timeString}`;
+                finalExamString = `${finalExam.dayOfWeek} ${MONTHS[finalExam.month]} ${finalExam.day} ${timeString}`;
+            }
         }
 
         return (

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -168,14 +168,21 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         } else if (finalExam.examStatus == 'TBA_FINAL') {
             finalExamString = 'Final TBA';
         } else {
+            const timeSuffix = finalExam.endTime.hour >= 12 ? 'PM' : 'AM';
+
+            const formattedStartHour12 =
+                finalExam.startTime.hour > 12 ? finalExam.startTime.hour - 12 : finalExam.startTime.hour;
+            const formattedEndHour12 =
+                finalExam.endTime.hour > 12 ? finalExam.endTime.hour - 12 : finalExam.endTime.hour;
+
             // prettier-ignore
-            const finalExamStartTime = `${finalExam.startTime?.hour}:${finalExam.startTime?.minute === 0 ? '00' : finalExam.startTime?.minute}`;
+            const finalExamStartTime = `${formattedStartHour12}:${finalExam.startTime?.minute === 0 ? '00' : finalExam.startTime?.minute}`;
             // prettier-ignore
-            const finalExamEndTime = `${finalExam.endTime?.hour}:${finalExam.endTime?.minute === 0 ? '00' : finalExam.endTime?.minute}`
+            const finalExamEndTime = `${formattedEndHour12}:${finalExam.endTime?.minute === 0 ? '00' : finalExam.endTime?.minute}`
 
             // FORMAT: Fri Dec 15 1:30-3:30pm
             // prettier-ignore
-            finalExamString = `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime}`
+            finalExamString = `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime} ${timeSuffix}`
         }
 
         return (

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -145,19 +145,15 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
         const buildingId = locationIds[buildingName] ?? 69420;
 
-        // FORMAT: Fri Dec 15 1:30-3:30pm
-        // TO-DO: Check if month can be returned as a Month abbreviation, not a number
-
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+        // FORMAT: Fri Dec 15 1:30-3:30pm
         const finalExamString =
             finalExam.examStatus == 'SCHEDULED_FINAL'
                 ? `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExam.day} ${finalExam.startTime.hour}:${
                       finalExam.startTime.minute == '0' ? '00' : finalExam.startTime.minute
                   }-${finalExam.endTime.hour}:${finalExam.endTime.minute == '0' ? '00' : finalExam.endTime.minute}`
                 : '';
-
-        // console.log(finalExam);
 
         return (
             <Paper className={classes.courseContainer} ref={paperRef}>

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -87,7 +87,21 @@ interface CommonCalendarEvent extends Event {
 
 export interface CourseEvent extends CommonCalendarEvent {
     bldg: string; // E.g., ICS 174, which is actually building + room
-    finalExam: string;
+    finalExam: {
+        examStatus: string;
+        dayOfWeek: string;
+        month: number;
+        day: number;
+        startTime: {
+            hour: number;
+            minute: number;
+        };
+        endTime: {
+            hour: number;
+            minute: number;
+        };
+        bldg: string[];
+    };
     instructors: string[];
     isCustomEvent: false;
     sectionCode: string;
@@ -147,13 +161,16 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+        // prettier-ignore
+        const finalExamStartTime = `${finalExam.startTime.hour}:${finalExam.startTime.minute === 0 ? '00' : finalExam.startTime.minute}`;
+        // prettier-ignore
+        const finalExamEndTime = `${finalExam.endTime.hour}:${finalExam.endTime.minute === 0 ? '00' : finalExam.endTime.minute}`
+
         // FORMAT: Fri Dec 15 1:30-3:30pm
         const finalExamString =
             finalExam.examStatus == 'SCHEDULED_FINAL'
-                ? `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExam.day} ${finalExam.startTime.hour}:${
-                      finalExam.startTime.minute == '0' ? '00' : finalExam.startTime.minute
-                  }-${finalExam.endTime.hour}:${finalExam.endTime.minute == '0' ? '00' : finalExam.endTime.minute}`
-                : '';
+                ? `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime}`
+                : ''; // Should this be something more verbose, like "No Final" ?
 
         return (
             <Paper className={classes.courseContainer} ref={paperRef}>

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -145,6 +145,20 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
         const buildingId = locationIds[buildingName] ?? 69420;
 
+        // FORMAT: Fri Dec 15 1:30-3:30pm
+        // TO-DO: Check if month can be returned as a Month abbreviation, not a number
+
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+        const finalExamString =
+            finalExam.examStatus == 'SCHEDULED_FINAL'
+                ? `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExam.day} ${finalExam.startTime.hour}:${
+                      finalExam.startTime.minute == '0' ? '00' : finalExam.startTime.minute
+                  }-${finalExam.endTime.hour}:${finalExam.endTime.minute == '0' ? '00' : finalExam.endTime.minute}`
+                : '';
+
+        // console.log(finalExam);
+
         return (
             <Paper className={classes.courseContainer} ref={paperRef}>
                 <div className={classes.titleBar}>
@@ -207,7 +221,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                         </tr>
                         <tr>
                             <td>Final</td>
-                            <td className={classes.rightCells}>{finalExam}</td>
+                            <td className={classes.rightCells}>{finalExamString}</td>
                         </tr>
                         <tr>
                             <td>Color</td>

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -182,7 +182,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
             // FORMAT: Fri Dec 15 1:30-3:30pm
             // prettier-ignore
-            finalExamString = `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime} ${timeSuffix}`
+            finalExamString = `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExam.day} ${finalExamStartTime} - ${finalExamEndTime} ${timeSuffix}`
         }
 
         return (

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -162,16 +162,21 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
 
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-        // prettier-ignore
-        const finalExamStartTime = `${finalExam.startTime.hour}:${finalExam.startTime.minute === 0 ? '00' : finalExam.startTime.minute}`;
-        // prettier-ignore
-        const finalExamEndTime = `${finalExam.endTime.hour}:${finalExam.endTime.minute === 0 ? '00' : finalExam.endTime.minute}`
+        let finalExamString = '';
+        if (finalExam.examStatus == 'NO_FINAL') {
+            finalExamString = 'No Final';
+        } else if (finalExam.examStatus == 'TBA_FINAL') {
+            finalExamString = 'Final TBA';
+        } else {
+            // prettier-ignore
+            const finalExamStartTime = `${finalExam.startTime?.hour}:${finalExam.startTime?.minute === 0 ? '00' : finalExam.startTime?.minute}`;
+            // prettier-ignore
+            const finalExamEndTime = `${finalExam.endTime?.hour}:${finalExam.endTime?.minute === 0 ? '00' : finalExam.endTime?.minute}`
 
-        // FORMAT: Fri Dec 15 1:30-3:30pm
-        const finalExamString =
-            finalExam.examStatus == 'SCHEDULED_FINAL'
-                ? `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime}`
-                : ''; // Should this be something more verbose, like "No Final" ?
+            // FORMAT: Fri Dec 15 1:30-3:30pm
+            // prettier-ignore
+            finalExamString = `${finalExam.dayOfWeek} ${months[finalExam.month - 1]} ${finalExamStartTime} - ${finalExamEndTime}`
+        }
 
         return (
             <Paper className={classes.courseContainer} ref={paperRef}>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -315,14 +315,23 @@ const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>TBA</Box>;
                 }
 
-                // prettier-ignore
-                const meetingStartTime = `${meeting.startTime?.hour}:${meeting.startTime?.minute === 0 ? '00' : meeting.startTime?.minute}`;
-                // prettier-ignore
-                const meetingEndTime = `${meeting.endTime?.hour}:${meeting.endTime?.minute === 0 ? '00' : meeting.endTime?.minute}`;
+                if (meeting.startTime && meeting.endTime) {
+                    const timeSuffix = meeting.endTime.hour >= 12 ? 'PM' : 'AM';
 
-                const timeString = `${meetingStartTime} - ${meetingEndTime}`;
+                    const formattedStartHour12 =
+                        meeting.startTime.hour > 12 ? meeting.startTime.hour - 12 : meeting.startTime.hour;
+                    const formattedEndHour12 =
+                        meeting.endTime.hour > 12 ? meeting.endTime.hour - 12 : meeting.endTime.hour;
 
-                return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
+                    // prettier-ignore
+                    const meetingStartTime = `${formattedStartHour12}:${meeting.startTime?.minute === 0 ? '00' : meeting.startTime?.minute}`;
+                    // prettier-ignore
+                    const meetingEndTime = `${formattedEndHour12}:${meeting.endTime?.minute === 0 ? '00' : meeting.endTime?.minute}`;
+
+                    const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
+
+                    return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
+                }
             })}
         </NoPaddingTableCell>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -19,7 +19,7 @@ import { clickToCopy, CourseDetails, isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 import { mobileContext } from '$components/MobileHome';
 import locationIds from '$lib/location_ids';
-import { translateWebSOCTimeTo24HourTime, parseDaysString } from '$stores/calendarizeHelpers';
+import { translateWebSOCTimeTo24HourTime, parseDaysString, translate24To12HourTime } from '$stores/calendarizeHelpers';
 
 const styles: Styles<Theme, object> = (theme) => ({
     popover: {
@@ -306,29 +306,15 @@ interface DayAndTimeCellProps {
 const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
     const { classes, meetings } = props;
 
-    console.log(meetings);
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
-                // TO-DO: Fix lack of leading zero when minute is 0. PP-API returns 0, but preferably it should be 00
                 if (meeting.timeIsTBA) {
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>TBA</Box>;
                 }
 
                 if (meeting.startTime && meeting.endTime) {
-                    const timeSuffix = meeting.endTime.hour >= 12 ? 'PM' : 'AM';
-
-                    const formattedStartHour12 =
-                        meeting.startTime.hour > 12 ? meeting.startTime.hour - 12 : meeting.startTime.hour;
-                    const formattedEndHour12 =
-                        meeting.endTime.hour > 12 ? meeting.endTime.hour - 12 : meeting.endTime.hour;
-
-                    // prettier-ignore
-                    const meetingStartTime = `${formattedStartHour12}:${meeting.startTime?.minute === 0 ? '00' : meeting.startTime?.minute}`;
-                    // prettier-ignore
-                    const meetingEndTime = `${formattedEndHour12}:${meeting.endTime?.minute === 0 ? '00' : meeting.endTime?.minute}`;
-
-                    const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
+                    const timeString = translate24To12HourTime(meeting);
 
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
                 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -314,7 +314,7 @@ const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
                 }
 
                 if (meeting.startTime && meeting.endTime) {
-                    const timeString = translate24To12HourTime(meeting);
+                    const timeString = translate24To12HourTime(meeting.startTime, meeting.endTime);
 
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
                 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -19,7 +19,7 @@ import { clickToCopy, CourseDetails, isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 import { mobileContext } from '$components/MobileHome';
 import locationIds from '$lib/location_ids';
-import { translateWebSOCTimeTo24HourTime, parseDaysString, translate24To12HourTime } from '$stores/calendarizeHelpers';
+import { normalizeTime, parseDaysString, translate24To12HourTime } from '$stores/calendarizeHelpers';
 
 const styles: Styles<Theme, object> = (theme) => ({
     popover: {
@@ -389,7 +389,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     const sectionDetails = useMemo(() => {
         return {
             daysOccurring: parseDaysString(section.meetings[0].days),
-            // ...translateWebSOCTimeTo24HourTime(section.meetings[0].time),
+            ...normalizeTime(section.meetings[0]),
         };
     }, [section.meetings[0]]);
 
@@ -442,46 +442,46 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     /**
      * Whether the current section conflicts with any of the calendar events.
      */
-    // const scheduleConflict = useMemo(() => {
-    //     // If there are currently no calendar events, there can't be any conflicts.
-    //     if (calendarEvents.length === 0) {
-    //         return false;
-    //     }
+    const scheduleConflict = useMemo(() => {
+        // If there are currently no calendar events, there can't be any conflicts.
+        if (calendarEvents.length === 0) {
+            return false;
+        }
 
-    //     // If the section's time wasn't parseable, then don't consider conflicts.
-    //     if (sectionDetails.startTime == null || sectionDetails.endTime == null) {
-    //         return false;
-    //     }
+        // If the section's time wasn't parseable, then don't consider conflicts.
+        if (sectionDetails.startTime == null || sectionDetails.endTime == null) {
+            return false;
+        }
 
-    //     const { startTime, endTime } = sectionDetails;
+        const { startTime, endTime } = sectionDetails;
 
-    //     const conflictingEvent = calendarEvents.find((event) => {
-    //         // If it occurs on a different day, no conflict.
-    //         if (!sectionDetails?.daysOccurring?.includes(event.start.getDay())) {
-    //             return false;
-    //         }
+        const conflictingEvent = calendarEvents.find((event) => {
+            // If it occurs on a different day, no conflict.
+            if (!sectionDetails?.daysOccurring?.includes(event.start.getDay())) {
+                return false;
+            }
 
-    //         /**
-    //          * A time normalized to ##:##
-    //          * @example '10:00'
-    //          */
-    //         const eventStartTime = event.start.toString().split(' ')[4].slice(0, -3);
+            /**
+             * A time normalized to ##:##
+             * @example '10:00'
+             */
+            const eventStartTime = event.start.toString().split(' ')[4].slice(0, -3);
 
-    //         /**
-    //          * Normalized to ##:##
-    //          * @example '10:00'
-    //          */
-    //         const eventEndTime = event.end.toString().split(' ')[4].slice(0, -3);
+            /**
+             * Normalized to ##:##
+             * @example '10:00'
+             */
+            const eventEndTime = event.end.toString().split(' ')[4].slice(0, -3);
 
-    //         const happensBefore = startTime <= eventStartTime && endTime <= eventStartTime;
+            const happensBefore = startTime <= eventStartTime && endTime <= eventStartTime;
 
-    //         const happensAfter = startTime >= eventEndTime && endTime >= eventEndTime;
+            const happensAfter = startTime >= eventEndTime && endTime >= eventEndTime;
 
-    //         return !(happensBefore || happensAfter);
-    //     });
+            return !(happensBefore || happensAfter);
+        });
 
-    //     return Boolean(conflictingEvent);
-    // }, [calendarEvents, sectionDetails]);
+        return Boolean(conflictingEvent);
+    }, [calendarEvents, sectionDetails]);
 
     return (
         <TableRow
@@ -490,7 +490,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                 classes.tr,
                 // If the course is added, then don't check for/apply scheduleConflict
                 // allowHighlight is ALWAYS false when in Added Course Pane and ALWAYS true when in CourseRenderPane
-                addedCourse ? { addedCourse: addedCourse && allowHighlight } : { scheduleConflict: false }
+                addedCourse ? { addedCourse: addedCourse && allowHighlight } : { scheduleConflict: scheduleConflict }
             )}
         >
             {!addedCourse ? (
@@ -499,7 +499,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                     courseDetails={courseDetails}
                     term={term}
                     scheduleNames={scheduleNames}
-                    scheduleConflict={false}
+                    scheduleConflict={scheduleConflict}
                 />
             ) : (
                 <ColorAndDelete color={section.color} sectionCode={section.sectionCode} term={term} />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -202,7 +202,7 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
                 const [buildingName = ''] = meeting.bldg;
                 const buildingId = locationIds[buildingName] ?? 69420;
                 return meeting.bldg[0] !== 'TBA' ? (
-                    <Fragment key={meeting.days + meeting.startTime + meeting.bldg}>
+                    <Fragment key={meeting.timeIsTBA + meeting.bldg[0]}>
                         <Link
                             className={classes.clickableLocation}
                             to={`/map?location=${buildingId}`}
@@ -312,19 +312,17 @@ const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
             {meetings.map((meeting) => {
                 // TO-DO: Fix lack of leading zero when minute is 0. PP-API returns 0, but preferably it should be 00
                 if (meeting.timeIsTBA) {
-                    return <Box key={meeting.days + meeting.startTime + meeting.bldg}>TBA</Box>;
+                    return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>TBA</Box>;
                 }
 
                 // prettier-ignore
-                const meetingStartTime = `${meeting.startTime.hour}:${meeting.startTime.minute === 0 ? '00' : meeting.startTime.minute}`;
+                const meetingStartTime = `${meeting.startTime?.hour}:${meeting.startTime?.minute === 0 ? '00' : meeting.startTime?.minute}`;
                 // prettier-ignore
-                const meetingEndTime = `${meeting.endTime.hour}:${meeting.endTime.minute === 0 ? '00' : meeting.endTime.minute}`;
+                const meetingEndTime = `${meeting.endTime?.hour}:${meeting.endTime?.minute === 0 ? '00' : meeting.endTime?.minute}`;
 
                 const timeString = `${meetingStartTime} - ${meetingEndTime}`;
 
-                return (
-                    <Box key={meeting.days + meeting.startTime + meeting.bldg}>{`${meeting.days} ${timeString}`}</Box>
-                );
+                return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
             })}
         </NoPaddingTableCell>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -202,7 +202,7 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
                 const [buildingName = ''] = meeting.bldg;
                 const buildingId = locationIds[buildingName] ?? 69420;
                 return meeting.bldg[0] !== 'TBA' ? (
-                    <Fragment key={meeting.days + meeting.time + meeting.bldg}>
+                    <Fragment key={meeting.days + meeting.startTime + meeting.bldg}>
                         <Link
                             className={classes.clickableLocation}
                             to={`/map?location=${buildingId}`}
@@ -306,20 +306,24 @@ interface DayAndTimeCellProps {
 const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
     const { classes, meetings } = props;
 
+    console.log(meetings);
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
                 // TO-DO: Fix lack of leading zero when minute is 0. PP-API returns 0, but preferably it should be 00
-                const timeString = meeting.timeIsTBA
-                    ? 'TBA'
-                    : `${meeting.startTime.hour}:${
-                          meeting.startTime.minute == '0' ? '00' : meeting.startTime.minute
-                      } - ${meeting.endTime.hour}:${meeting.endTime.minute == '0' ? '00' : meeting.endTime.minute}`;
+                if (meeting.timeIsTBA) {
+                    return <Box key={meeting.days + meeting.startTime + meeting.bldg}>TBA</Box>;
+                }
+
+                // prettier-ignore
+                const meetingStartTime = `${meeting.startTime.hour}:${meeting.startTime.minute === 0 ? '00' : meeting.startTime.minute}`;
+                // prettier-ignore
+                const meetingEndTime = `${meeting.endTime.hour}:${meeting.endTime.minute === 0 ? '00' : meeting.endTime.minute}`;
+
+                const timeString = `${meetingStartTime} - ${meetingEndTime}`;
 
                 return (
-                    <Box key={meeting.days + meeting.startTime + meeting.bldg}>{`${
-                        meeting.days ? meeting.days : ''
-                    } ${timeString}`}</Box>
+                    <Box key={meeting.days + meeting.startTime + meeting.bldg}>{`${meeting.days} ${timeString}`}</Box>
                 );
             })}
         </NoPaddingTableCell>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -77,7 +77,7 @@ export const ScheduleAddCell = withStyles(styles)((props: ScheduleAddCellProps) 
     const closeAndAddCourse = (scheduleIndex: number, specificSchedule?: boolean) => {
         popupState.close();
         for (const meeting of section.meetings) {
-            if (meeting.time === 'TBA') {
+            if (meeting.timeIsTBA) {
                 openSnackbar('success', 'Online/TBA class added');
                 // See Added Classes."
                 break;

--- a/apps/antalmanac/src/lib/api/endpoints.ts
+++ b/apps/antalmanac/src/lib/api/endpoints.ts
@@ -17,4 +17,7 @@ export const REGISTER_NOTIFICATIONS_ENDPOINT = endpointTransform('/api/notificat
 // PeterPortal API
 export const PETERPORTAL_GRAPHQL_ENDPOINT = 'https://api-next.peterportal.org/v1/graphql';
 export const PETERPORTAL_REST_ENDPOINT = 'https://api-next.peterportal.org/v1/rest';
-export const PETERPORTAL_WEBSOC_ENDPOINT = `${PETERPORTAL_REST_ENDPOINT}/websoc`;
+
+// Testing API
+export const PETERPORTAL_REST_ENDPOINT_68 = 'https://staging-68.api-next.peterportal.org/v1/rest';
+export const PETERPORTAL_WEBSOC_ENDPOINT = `${PETERPORTAL_REST_ENDPOINT_68}/websoc`;

--- a/apps/antalmanac/src/lib/utils.ts
+++ b/apps/antalmanac/src/lib/utils.ts
@@ -1,0 +1,11 @@
+export function notNull<T>(value: T): value is NonNullable<T> {
+    return value != null;
+}
+
+/**
+ * Given a reference array and an input, generate an array of booleans for each position in the
+ * reference array, indicating whether the value at that position is in the input.
+ */
+export function getReferencesOccurring(reference: string[], input?: string | string[] | null): boolean[] {
+    return input ? reference.map((reference) => input.includes(reference)) : reference.map(() => false);
+}

--- a/apps/antalmanac/src/lib/utils.ts
+++ b/apps/antalmanac/src/lib/utils.ts
@@ -5,6 +5,25 @@ export function notNull<T>(value: T): value is NonNullable<T> {
 /**
  * Given a reference array and an input, generate an array of booleans for each position in the
  * reference array, indicating whether the value at that position is in the input.
+ *
+ * @example
+ * reference = ['a', 'b', 'c', 'd', 'e']
+ * input = 'ace'
+ * result = [true, false, true, false, true]
+ *
+ * Can be used in conjunection with {@link notNull} to get only indices.
+ *
+ * @example
+ *
+ * ```ts
+ *
+ * const reference = ['a', 'b', 'c', 'd', 'e'];
+ * const input = 'ace';
+ *
+ * const occurringReferences = getReferencesOccurring(reference, input)
+ * const indicesOrNull = occurringReferences.map((occurring, index) => occurring ? index : null)
+ * const indices = indicesOrNull.filter(notNull)
+ * ```
  */
 export function getReferencesOccurring(reference: string[], input?: string | string[] | null): boolean[] {
     return input ? reference.map((reference) => input.includes(reference)) : reference.map(() => false);

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -12,7 +12,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
             const endHour = parseInt(meeting.endTime.hour, 10);
             const endMin = parseInt(meeting.endTime.minute, 10);
 
-            const dates = [
+            const dates: boolean[] = [
                 meeting.days.includes('Su'),
                 meeting.days.includes('M'),
                 meeting.days.includes('Tu'),
@@ -53,15 +53,16 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
 
     for (const course of currentCourses) {
         const finalExam = course.section.finalExam;
-        if (finalExam.length > 5) {
-            const [, date, , , startStr, startMinStr, endStr, endMinStr, ampm] = finalExam.match(
-                /([A-za-z]+) ([A-Za-z]+) *(\d{1,2}) *(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})(am|pm)/
-            ) as RegExpMatchArray;
+        console.log(finalExam);
+        if (finalExam.examStatus == 'SCHEDULED_FINAL') {
+            const date = finalExam.dayOfWeek;
+
             // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
-            let startHour = parseInt(startStr, 10);
-            const startMin = parseInt(startMinStr, 10);
-            let endHour = parseInt(endStr, 10);
-            const endMin = parseInt(endMinStr, 10);
+            const startHour = parseInt(finalExam.startTime.hour, 10);
+            const startMin = parseInt(finalExam.startTime.minute, 10);
+            const endHour = parseInt(finalExam.endTime.hour, 10);
+            const endMin = parseInt(finalExam.endTime.minute, 10);
+
             const weekdayInclusion: boolean[] = [
                 date.includes('Sat'),
                 date.includes('Sun'),
@@ -71,11 +72,6 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
                 date.includes('Thu'),
                 date.includes('Fri'),
             ];
-            if (ampm === 'pm' && endHour !== 12) {
-                startHour += 12;
-                endHour += 12;
-                if (startHour > endHour) startHour -= 12;
-            }
 
             weekdayInclusion.forEach((shouldBeInCal, index) => {
                 if (shouldBeInCal)

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -11,7 +11,7 @@ const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
     return currentCourses.flatMap((course) => {
         return course.section.meetings
-            .filter((meeting) => meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days)
+            .filter((meeting) => !meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days)
             .flatMap((meeting) => {
                 const startHour = meeting.startTime?.hour;
                 const startMin = meeting.startTime?.minute;

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -186,21 +186,23 @@ export function normalizeTime(meeting: WebsocSectionMeeting): NormalizedWebSOCTi
     }
 }
 
-export function translate24To12HourTime(section: WebsocSectionMeeting | WebsocSectionFinalExam): string | undefined {
-    if (section.startTime && section.endTime) {
-        const timeSuffix = section.endTime.hour >= 12 ? 'PM' : 'AM';
-
-        const formattedStartHour12 = section.startTime.hour > 12 ? section.startTime.hour - 12 : section.startTime.hour;
-        const formattedEndHour12 = section.endTime.hour > 12 ? section.endTime.hour - 12 : section.endTime.hour;
-
-        // TO-DO: See if a leading zero can be added to minute
-        // prettier-ignore
-        const meetingStartTime = `${formattedStartHour12}:${section.startTime?.minute === 0 ? '00' : section.startTime?.minute}`;
-        // prettier-ignore
-        const meetingEndTime = `${formattedEndHour12}:${section.endTime?.minute === 0 ? '00' : section.endTime?.minute}`;
-
-        const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
-
-        return timeString;
+export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMinute): string | undefined {
+    if (!startTime || !endTime) {
+        return;
     }
+    const postMeridian = endTime.hour >= 12;
+
+    const timeSuffix = postMeridian ? 'PM' : 'AM';
+
+    const formattedStartHour = `${startTime.hour - +(postMeridian && 12)}`
+
+    const formattedEndHour = `${endTime.hour - +(postMeridian && 12)}`
+
+    const meetingStartTime = `${formattedStartHour}:${formattedStartHour.padStart(2, '0')}`;
+
+    const meetingEndTime = `${formattedEndHour}:${formattedEndHour.padStart(2, '0')}`;
+
+    const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
+
+    return timeString;
 }

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -7,55 +7,41 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 
     for (const course of currentCourses) {
         for (const meeting of course.section.meetings) {
-            const timeString = meeting.time.replace(/\s/g, '');
+            const startHour = parseInt(meeting.startTime.hour, 10);
+            const startMin = parseInt(meeting.startTime.minute, 10);
+            const endHour = parseInt(meeting.endTime.hour, 10);
+            const endMin = parseInt(meeting.endTime.minute, 10);
 
-            if (timeString !== 'TBA') {
-                const [, startHrStr, startMinStr, endHrStr, endMinStr, ampm] = timeString.match(
-                    /(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})(p?)/
-                ) as RegExpMatchArray;
+            const dates = [
+                meeting.days.includes('Su'),
+                meeting.days.includes('M'),
+                meeting.days.includes('Tu'),
+                meeting.days.includes('W'),
+                meeting.days.includes('Th'),
+                meeting.days.includes('F'),
+                meeting.days.includes('Sa'),
+            ];
 
-                let startHr = parseInt(startHrStr, 10);
-                const startMin = parseInt(startMinStr, 10);
-                let endHr = parseInt(endHrStr, 10);
-                const endMin = parseInt(endMinStr, 10);
+            dates.forEach((shouldBeInCal, index) => {
+                if (shouldBeInCal) {
+                    const newEvent = {
+                        color: course.section.color,
+                        term: course.term,
+                        title: course.deptCode + ' ' + course.courseNumber,
+                        courseTitle: course.courseTitle,
+                        bldg: meeting.bldg[0],
+                        instructors: course.section.instructors,
+                        sectionCode: course.section.sectionCode,
+                        sectionType: course.section.sectionType,
+                        start: new Date(2018, 0, index, startHour, startMin),
+                        end: new Date(2018, 0, index, endHour, endMin),
+                        finalExam: course.section.finalExam,
+                        isCustomEvent: false as const,
+                    };
 
-                const dates = [
-                    meeting.days.includes('Su'),
-                    meeting.days.includes('M'),
-                    meeting.days.includes('Tu'),
-                    meeting.days.includes('W'),
-                    meeting.days.includes('Th'),
-                    meeting.days.includes('F'),
-                    meeting.days.includes('Sa'),
-                ];
-
-                if (ampm === 'p' && endHr !== 12) {
-                    startHr += 12;
-                    endHr += 12;
-                    if (startHr > endHr) startHr -= 12;
+                    courseEventsInCalendar.push(newEvent);
                 }
-
-                dates.forEach((shouldBeInCal, index) => {
-                    if (shouldBeInCal) {
-                        const newEvent = {
-                            color: course.section.color,
-                            term: course.term,
-                            title: course.deptCode + ' ' + course.courseNumber,
-                            courseTitle: course.courseTitle,
-                            bldg: meeting.bldg[0],
-                            instructors: course.section.instructors,
-                            sectionCode: course.section.sectionCode,
-                            sectionType: course.section.sectionType,
-                            start: new Date(2018, 0, index, startHr, startMin),
-                            finalExam: course.section.finalExam,
-                            end: new Date(2018, 0, index, endHr, endMin),
-                            isCustomEvent: false as const,
-                        };
-
-                        courseEventsInCalendar.push(newEvent);
-                    }
-                });
-            }
+            });
         }
     }
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -24,7 +24,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 
             dates.forEach((shouldBeInCal, index) => {
                 if (shouldBeInCal) {
-                    const newEvent = {
+                    courseEventsInCalendar.push({
                         color: course.section.color,
                         term: course.term,
                         title: course.deptCode + ' ' + course.courseNumber,
@@ -37,9 +37,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
                         end: new Date(2018, 0, index, endHour, endMin),
                         finalExam: course.section.finalExam,
                         isCustomEvent: false as const,
-                    };
-
-                    courseEventsInCalendar.push(newEvent);
+                    });
                 }
             });
         }
@@ -53,7 +51,7 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
 
     for (const course of currentCourses) {
         const finalExam = course.section.finalExam;
-        console.log(finalExam);
+
         if (finalExam.examStatus == 'SCHEDULED_FINAL') {
             const date = finalExam.dayOfWeek;
 
@@ -76,16 +74,17 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
             weekdayInclusion.forEach((shouldBeInCal, index) => {
                 if (shouldBeInCal)
                     finalsEventsInCalendar.push({
+                        color: course.section.color,
+                        term: course.term,
                         title: course.deptCode + ' ' + course.courseNumber,
+                        courseTitle: course.courseTitle,
+                        bldg: course.section.meetings[0].bldg[0],
+                        instructors: course.section.instructors,
                         sectionCode: course.section.sectionCode,
                         sectionType: 'Fin',
-                        bldg: course.section.meetings[0].bldg[0],
-                        color: course.section.color,
                         start: new Date(2018, 0, index - 1, startHour, startMin),
                         end: new Date(2018, 0, index - 1, endHour, endMin),
                         finalExam: course.section.finalExam,
-                        instructors: course.section.instructors,
-                        term: course.term,
                         isCustomEvent: false,
                     });
             });

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -7,39 +7,41 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 
     for (const course of currentCourses) {
         for (const meeting of course.section.meetings) {
-            const startHour = meeting.startTime.hour;
-            const startMin = meeting.startTime.minute;
-            const endHour = meeting.endTime.hour;
-            const endMin = meeting.endTime.minute;
+            if (!meeting.timeIsTBA) {
+                const startHour = meeting.startTime.hour;
+                const startMin = meeting.startTime.minute;
+                const endHour = meeting.endTime.hour;
+                const endMin = meeting.endTime.minute;
 
-            const dates: boolean[] = [
-                meeting.days.includes('Su'),
-                meeting.days.includes('M'),
-                meeting.days.includes('Tu'),
-                meeting.days.includes('W'),
-                meeting.days.includes('Th'),
-                meeting.days.includes('F'),
-                meeting.days.includes('Sa'),
-            ];
+                const dates: boolean[] = [
+                    meeting.days.includes('Su'),
+                    meeting.days.includes('M'),
+                    meeting.days.includes('Tu'),
+                    meeting.days.includes('W'),
+                    meeting.days.includes('Th'),
+                    meeting.days.includes('F'),
+                    meeting.days.includes('Sa'),
+                ];
 
-            dates.forEach((shouldBeInCal, index) => {
-                if (shouldBeInCal) {
-                    courseEventsInCalendar.push({
-                        color: course.section.color,
-                        term: course.term,
-                        title: course.deptCode + ' ' + course.courseNumber,
-                        courseTitle: course.courseTitle,
-                        bldg: meeting.bldg[0],
-                        instructors: course.section.instructors,
-                        sectionCode: course.section.sectionCode,
-                        sectionType: course.section.sectionType,
-                        start: new Date(2018, 0, index, startHour, startMin),
-                        end: new Date(2018, 0, index, endHour, endMin),
-                        finalExam: course.section.finalExam,
-                        isCustomEvent: false as const,
-                    });
-                }
-            });
+                dates.forEach((shouldBeInCal, index) => {
+                    if (shouldBeInCal) {
+                        courseEventsInCalendar.push({
+                            color: course.section.color,
+                            term: course.term,
+                            title: course.deptCode + ' ' + course.courseNumber,
+                            courseTitle: course.courseTitle,
+                            bldg: meeting.bldg[0],
+                            instructors: course.section.instructors,
+                            sectionCode: course.section.sectionCode,
+                            sectionType: course.section.sectionType,
+                            start: new Date(2018, 0, index, startHour, startMin),
+                            end: new Date(2018, 0, index, endHour, endMin),
+                            finalExam: course.section.finalExam,
+                            isCustomEvent: false as const,
+                        });
+                    }
+                });
+            }
         }
     }
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -195,12 +195,10 @@ export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMi
         return;
     }
 
-    const postMeridian = endTime.hour >= 12;
+    const timeSuffix = endTime.hour >= 12 ? 'PM' : 'AM';
 
-    const timeSuffix = postMeridian ? 'PM' : 'AM';
-
-    const formattedStartHour = `${startTime.hour - Number(postMeridian && 12)}`;
-    const formattedEndHour = `${endTime.hour - Number(postMeridian && 12)}`;
+    const formattedStartHour = `${startTime.hour > 12 ? startTime.hour - 12 : startTime.hour}`;
+    const formattedEndHour = `${endTime.hour > 12 ? endTime.hour - 12 : endTime.hour}`;
 
     const formattedStartMinute = `${startTime.minute}`;
     const formattedEndMinute = `${endTime.minute}`;

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -1,4 +1,5 @@
 import { ScheduleCourse } from '@packages/antalmanac-types';
+import { WebsocSectionFinalExam, WebsocSectionMeeting } from 'peterportal-api-next-types';
 import { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { RepeatingCustomEvent } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 
@@ -64,13 +65,13 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
             const endMin = finalExam.endTime.minute;
 
             const weekdayInclusion: boolean[] = [
-                date.includes('Sat'),
-                date.includes('Sun'),
-                date.includes('Mon'),
-                date.includes('Tue'),
-                date.includes('Wed'),
-                date.includes('Thu'),
-                date.includes('Fri'),
+                (date as string).includes('Sat'), // Because date is "technically" possibly null, it's typecast here for TS warnings
+                (date as string).includes('Sun'), // In reality, it will never be null since we're checking for "SCHEDULED_FINAL" which guarantees non-null
+                (date as string).includes('Mon'),
+                (date as string).includes('Tue'),
+                (date as string).includes('Wed'),
+                (date as string).includes('Thu'),
+                (date as string).includes('Fri'),
             ];
 
             weekdayInclusion.forEach((shouldBeInCal, index) => {
@@ -182,4 +183,23 @@ export function parseDaysString(daysString: string): number[] {
     }
 
     return days;
+}
+
+export function translate24To12HourTime(section: WebsocSectionMeeting | WebsocSectionFinalExam): string | undefined {
+    if (section.startTime && section.endTime) {
+        const timeSuffix = section.endTime.hour >= 12 ? 'PM' : 'AM';
+
+        const formattedStartHour12 = section.startTime.hour > 12 ? section.startTime.hour - 12 : section.startTime.hour;
+        const formattedEndHour12 = section.endTime.hour > 12 ? section.endTime.hour - 12 : section.endTime.hour;
+
+        // TO-DO: See if a leading zero can be added to minute
+        // prettier-ignore
+        const meetingStartTime = `${formattedStartHour12}:${section.startTime?.minute === 0 ? '00' : section.startTime?.minute}`;
+        // prettier-ignore
+        const meetingEndTime = `${formattedEndHour12}:${section.endTime?.minute === 0 ? '00' : section.endTime?.minute}`;
+
+        const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
+
+        return timeString;
+    }
 }

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -127,7 +127,25 @@ export const calendarizeCustomEvents = (currentCustomEvents: RepeatingCustomEven
         }
     }
 
-    return customEventsInCalendar;
+export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
+    return currentCustomEvents.flatMap((customEvent) => {
+        return customEvent.days.filter(Boolean).map((_day, index) => {
+            const startHour = parseInt(customEvent.start.slice(0, 2), 10);
+            const startMin = parseInt(customEvent.start.slice(3, 5), 10);
+            const endHour = parseInt(customEvent.end.slice(0, 2), 10);
+            const endMin = parseInt(customEvent.end.slice(3, 5), 10);
+
+            return {
+                customEventID: customEvent.customEventID,
+                color: customEvent.color ?? '#000000',
+                start: new Date(2018, 0, index, startHour, startMin),
+                isCustomEvent: true,
+                end: new Date(2018, 0, index, endHour, endMin),
+                title: customEvent.title,
+            };
+        });
+    });
+}
 };
 
 export const SHORT_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -169,23 +169,38 @@ interface NormalizedWebSOCTime {
  * @returns The start and end time of a course in a 24 hour time with a leading zero (##:##).
  * @returns undefined if there is no WebSOC time (e.g. 'TBA', undefined)
  */
-export function normalizeTime(meeting: WebsocSectionMeeting): NormalizedWebSOCTime | undefined {
-    if (meeting.timeIsTBA) {
-        return undefined;
-    }
-
-    if (meeting.startTime && meeting.endTime) {
-        // Times are normalized to ##:## (10:00, 09:00 etc)
-        const startHour = `${meeting.startTime.hour < 10 ? `0${meeting.startTime.hour}` : meeting.startTime.hour}`;
-        const endHour = `${meeting.endTime.hour < 10 ? `0${meeting.endTime.hour}` : meeting.endTime.hour}`;
-
-        const startTime = `${startHour}:${meeting.startTime.minute}`;
-        const endTime = `${endHour}:${meeting.endTime.minute}`;
-
-        return { startTime: startTime, endTime: endTime };
-    }
+interface NormalizeTimeOptions {
+  timeIsTBA?: boolean;
+  startTime?: HourMinute | null;
+  endTime?: HourMinute | null;
 }
 
+// This also works.
+type NormalizeTimeOptions = Pick<WebsocSectionMeeting, 'timeIsTBA' | 'startTime' | 'endTime'>
+
+/**
+ * @param section
+ * @returns The start and end time of a course in a 24 hour time with a leading zero (##:##).
+ * @returns undefined if there is no WebSOC time (e.g. 'TBA', undefined)
+ */
+export function normalizeTime(options: NormalizeTimeOptions): NormalizedWebSOCTime | undefined {
+    if (options.timeIsTBA) {
+        return;
+    }
+
+    if (!options.startTime || !options.endTime) {
+        return;
+    }
+
+    // Times are normalized to ##:## (10:00, 09:00 etc)
+    const startHour = `${options.startTime.hour}`.padStart(2, '0')
+    const endHour = `${options.endTime.hour}`.padStart(2, '0')
+
+    const startTime = `${startHour}:${options.startTime.minute}`;
+    const endTime = `${endHour}:${options.endTime.minute}`;
+
+    return { startTime, endTime };
+}
 export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMinute): string | undefined {
     if (!startTime || !endTime) {
         return;

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -7,10 +7,10 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 
     for (const course of currentCourses) {
         for (const meeting of course.section.meetings) {
-            const startHour = parseInt(meeting.startTime.hour, 10);
-            const startMin = parseInt(meeting.startTime.minute, 10);
-            const endHour = parseInt(meeting.endTime.hour, 10);
-            const endMin = parseInt(meeting.endTime.minute, 10);
+            const startHour = meeting.startTime.hour;
+            const startMin = meeting.startTime.minute;
+            const endHour = meeting.endTime.hour;
+            const endMin = meeting.endTime.minute;
 
             const dates: boolean[] = [
                 meeting.days.includes('Su'),
@@ -56,10 +56,10 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
             const date = finalExam.dayOfWeek;
 
             // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
-            const startHour = parseInt(finalExam.startTime.hour, 10);
-            const startMin = parseInt(finalExam.startTime.minute, 10);
-            const endHour = parseInt(finalExam.endTime.hour, 10);
-            const endMin = parseInt(finalExam.endTime.minute, 10);
+            const startHour = finalExam.startTime.hour;
+            const startMin = finalExam.startTime.minute;
+            const endHour = finalExam.endTime.hour;
+            const endMin = finalExam.endTime.minute;
 
             const weekdayInclusion: boolean[] = [
                 date.includes('Sat'),

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -2,127 +2,128 @@ import { ScheduleCourse } from '@packages/antalmanac-types';
 import { HourMinute } from 'peterportal-api-next-types';
 import { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { RepeatingCustomEvent } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
+import { notNull, getReferencesOccurring } from '$lib/utils';
 
-export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []): CourseEvent[] => {
-    const courseEventsInCalendar: CourseEvent[] = [];
+const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 
-    for (const course of currentCourses) {
-        for (const meeting of course.section.meetings) {
-            if (!meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days) {
-                const startHour = meeting.startTime.hour;
-                const startMin = meeting.startTime.minute;
-                const endHour = meeting.endTime.hour;
-                const endMin = meeting.endTime.minute;
+const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
-                const dates: boolean[] = [
-                    meeting.days.includes('Su'),
-                    meeting.days.includes('M'),
-                    meeting.days.includes('Tu'),
-                    meeting.days.includes('W'),
-                    meeting.days.includes('Th'),
-                    meeting.days.includes('F'),
-                    meeting.days.includes('Sa'),
-                ];
+export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
+    return currentCourses.flatMap((course) => {
+        return course.section.meetings
+            .filter((meeting) => meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days)
+            .flatMap((meeting) => {
+                const startHour = meeting.startTime?.hour;
+                const startMin = meeting.startTime?.minute;
+                const endHour = meeting.endTime?.hour;
+                const endMin = meeting.endTime?.minute;
 
-                dates.forEach((shouldBeInCal, index) => {
-                    if (shouldBeInCal) {
-                        courseEventsInCalendar.push({
-                            color: course.section.color,
-                            term: course.term,
-                            title: course.deptCode + ' ' + course.courseNumber,
-                            courseTitle: course.courseTitle,
-                            bldg: meeting.bldg[0],
-                            instructors: course.section.instructors,
-                            sectionCode: course.section.sectionCode,
-                            sectionType: course.section.sectionType,
-                            start: new Date(2018, 0, index, startHour, startMin),
-                            end: new Date(2018, 0, index, endHour, endMin),
-                            finalExam: course.section.finalExam,
-                            isCustomEvent: false as const,
-                        });
-                    }
-                });
-            }
-        }
-    }
+                /**
+                 * An array of booleans indicating whether a course meeting occurs on that day.
+                 *
+                 * @example [false, true, false, true, false, true, false], i.e. [M, W, F]
+                 */
+                const daysOccurring = getReferencesOccurring(COURSE_WEEK_DAYS, meeting.days);
 
-    return courseEventsInCalendar;
-};
+                /**
+                 * Only include the day indices that the meeting occurs.
+                 *
+                 * @example [false, true, false, true, false, true, false] -> [1, 3, 5]
+                 */
+                const dayIndicesOccurring = daysOccurring
+                    .map((day, index) => (day ? index : undefined))
+                    .filter(notNull);
 
-export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []): CourseEvent[] => {
-    const finalsEventsInCalendar: CourseEvent[] = [];
-
-    for (const course of currentCourses) {
-        const finalExam = course.section.finalExam;
-
-        if (
-            finalExam.examStatus == 'SCHEDULED_FINAL' &&
-            finalExam.startTime &&
-            finalExam.endTime &&
-            finalExam.dayOfWeek
-        ) {
-            // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
-
-            const startHour = finalExam.startTime.hour;
-            const startMin = finalExam.startTime.minute;
-            const endHour = finalExam.endTime.hour;
-            const endMin = finalExam.endTime.minute;
-
-            const weekdayInclusion: boolean[] = [
-                finalExam.dayOfWeek.includes('Sat'),
-                finalExam.dayOfWeek.includes('Sun'),
-                finalExam.dayOfWeek.includes('Mon'),
-                finalExam.dayOfWeek.includes('Tue'),
-                finalExam.dayOfWeek.includes('Wed'),
-                finalExam.dayOfWeek.includes('Thu'),
-                finalExam.dayOfWeek.includes('Fri'),
-            ];
-
-            weekdayInclusion.forEach((shouldBeInCal, index) => {
-                if (shouldBeInCal)
-                    finalsEventsInCalendar.push({
+                return dayIndicesOccurring.map((dayIndex) => {
+                    return {
                         color: course.section.color,
                         term: course.term,
-                        title: course.deptCode + ' ' + course.courseNumber,
+                        title: `${course.deptCode} ${course.courseNumber}`,
                         courseTitle: course.courseTitle,
-                        bldg: course.section.meetings[0].bldg[0],
+                        bldg: meeting.bldg[0],
                         instructors: course.section.instructors,
                         sectionCode: course.section.sectionCode,
-                        sectionType: 'Fin',
-                        start: new Date(2018, 0, index - 1, startHour, startMin),
-                        end: new Date(2018, 0, index - 1, endHour, endMin),
+                        sectionType: course.section.sectionType,
+                        start: new Date(2018, 0, dayIndex, startHour, startMin),
+                        end: new Date(2018, 0, dayIndex, endHour, endMin),
                         finalExam: course.section.finalExam,
                         isCustomEvent: false,
-                    });
-            });
-        }
-    }
-
-    return finalsEventsInCalendar;
-};
-
-export const calendarizeCustomEvents = (currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] => {
-    const customEventsInCalendar: CustomEvent[] = [];
-    for (const customEvent of currentCustomEvents) {
-        for (let dayIndex = 0; dayIndex < customEvent.days.length; dayIndex++) {
-            if (customEvent.days[dayIndex]) {
-                const startHour = parseInt(customEvent.start.slice(0, 2), 10);
-                const startMin = parseInt(customEvent.start.slice(3, 5), 10);
-                const endHour = parseInt(customEvent.end.slice(0, 2), 10);
-                const endMin = parseInt(customEvent.end.slice(3, 5), 10);
-                customEventsInCalendar.push({
-                    customEventID: customEvent.customEventID,
-                    color: customEvent.color ?? '#000000',
-                    start: new Date(2018, 0, dayIndex, startHour, startMin),
-                    isCustomEvent: true,
-                    end: new Date(2018, 0, dayIndex, endHour, endMin),
-                    title: customEvent.title,
+                    };
                 });
-            }
-        }
-    }
-    return customEventsInCalendar;
-};
+            });
+    });
+}
+
+export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
+    return currentCourses
+        .filter(
+            (course) =>
+                course.section.finalExam.examStatus === 'SCHEDULED_FINAL' &&
+                course.section.finalExam.startTime &&
+                course.section.finalExam.endTime &&
+                course.section.finalExam.dayOfWeek
+        )
+        .flatMap((course) => {
+            const finalExam = course.section.finalExam;
+            const startHour = finalExam.startTime?.hour;
+            const startMin = finalExam.startTime?.minute;
+            const endHour = finalExam.endTime?.hour;
+            const endMin = finalExam.endTime?.minute;
+
+            /**
+             * An array of booleans indicating whether the day at that index is a day that the final.
+             *
+             * @example [false, false, false, true, false, true, false], i.e. [T, Th]
+             */
+            const weekdaysOccurring = getReferencesOccurring(FINALS_WEEK_DAYS, course.section.finalExam.dayOfWeek);
+
+            /**
+             * Only include the day indices that the final is occurring.
+             *
+             * @example [false, false, false, true, false, true, false] -> [3, 5]
+             */
+            const dayIndicesOcurring = weekdaysOccurring.map((day, index) => (day ? index : undefined)).filter(notNull);
+
+            return dayIndicesOcurring.map((dayIndex) => {
+                return {
+                    color: course.section.color,
+                    term: course.term,
+                    title: `${course.deptCode} ${course.courseNumber}`,
+                    courseTitle: course.courseTitle,
+                    bldg: course.section.meetings[0].bldg[0],
+                    instructors: course.section.instructors,
+                    sectionCode: course.section.sectionCode,
+                    sectionType: 'Fin',
+                    start: new Date(2018, 0, dayIndex - 1, startHour, startMin),
+                    end: new Date(2018, 0, dayIndex - 1, endHour, endMin),
+                    finalExam: course.section.finalExam,
+                    isCustomEvent: false,
+                };
+            });
+        });
+}
+
+export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
+    return currentCustomEvents.flatMap((customEvent) => {
+        const dayIndiciesOcurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
+
+        return dayIndiciesOcurring.map((dayIndex) => {
+            const startHour = parseInt(customEvent.start.slice(0, 2), 10);
+            const startMin = parseInt(customEvent.start.slice(3, 5), 10);
+            const endHour = parseInt(customEvent.end.slice(0, 2), 10);
+            const endMin = parseInt(customEvent.end.slice(3, 5), 10);
+
+            return {
+                customEventID: customEvent.customEventID,
+                color: customEvent.color ?? '#000000',
+                start: new Date(2018, 0, dayIndex, startHour, startMin),
+                isCustomEvent: true,
+                end: new Date(2018, 0, dayIndex, endHour, endMin),
+                title: customEvent.title,
+            };
+        });
+    });
+}
 
 export const SHORT_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 
@@ -175,11 +176,7 @@ interface NormalizeTimeOptions {
  * @returns undefined if there is no WebSOC time (e.g. 'TBA', undefined)
  */
 export function normalizeTime(options: NormalizeTimeOptions): NormalizedWebSOCTime | undefined {
-    if (options.timeIsTBA) {
-        return;
-    }
-
-    if (!options.startTime || !options.endTime) {
+    if (options.timeIsTBA || !options.startTime || !options.endTime) {
         return;
     }
 
@@ -198,18 +195,18 @@ export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMi
         return;
     }
 
-    const timeSuffix = endTime.hour >= 12 ? 'PM' : 'AM';
+    const postMeridian = endTime.hour >= 12;
 
-    const formattedStartHour = `${startTime.hour > 12 ? startTime.hour - 12 : startTime.hour}`;
-    const formattedEndHour = `${endTime.hour > 12 ? endTime.hour - 12 : endTime.hour}`;
+    const timeSuffix = postMeridian ? 'PM' : 'AM';
 
-    const formattedStartMinute = `${startTime.minute}`.padStart(2, '0');
-    const formattedEndMinute = `${endTime.minute}`.padStart(2, '0');
+    const formattedStartHour = `${startTime.hour - Number(postMeridian && 12)}`;
+    const formattedEndHour = `${endTime.hour - Number(postMeridian && 12)}`;
 
-    const meetingStartTime = `${formattedStartHour}:${formattedStartMinute}`;
-    const meetingEndTime = `${formattedEndHour}:${formattedEndMinute}`;
+    const formattedStartMinute = `${startTime.minute}`;
+    const formattedEndMinute = `${endTime.minute}`;
 
-    const timeString = `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
+    const meetingStartTime = `${formattedStartHour}:${formattedStartMinute.padStart(2, '0')}`;
+    const meetingEndTime = `${formattedEndHour}:${formattedEndMinute.padStart(2, '0')}`;
 
-    return timeString;
+    return `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
 }

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -56,7 +56,51 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
     const finalsEventsInCalendar: CourseEvent[] = [];
 
-    for (const course of currentCourses) {
+const WEEK_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+/**
+ * Given a string or string array of weekdays, return an array of booleans indicating whether
+ * each weekday occurs in the input.
+ */
+function getWeekdaysOcurring(weekDays?: string | string[] | null): boolean[] {
+    return weekDays ? WEEK_DAYS.map((day) => weekDays.includes(day)) : WEEK_DAYS.map(() => false);
+}
+
+export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
+    return currentCourses
+        .filter((course) => course.section.finalExam.examStatus === 'SCHEDULED_FINAL')
+        .filter(
+            (course) =>
+                course.section.finalExam.startTime &&
+                course.section.finalExam.endTime &&
+                course.section.finalExam.dayOfWeek
+        )
+        .flatMap((course) => {
+            const finalExam = course.section.finalExam;
+            const startHour = finalExam.startTime?.hour;
+            const startMin = finalExam.startTime?.minute;
+            const endHour = finalExam.endTime?.hour;
+            const endMin = finalExam.endTime?.minute;
+
+            const weekdaysOccurring = getWeekdaysOcurring(course.section.finalExam.dayOfWeek);
+            return weekdaysOccurring.filter(Boolean).map((_day, index) => {
+                return {
+                    color: course.section.color,
+                    term: course.term,
+                    title: course.deptCode + ' ' + course.courseNumber,
+                    courseTitle: course.courseTitle,
+                    bldg: course.section.meetings[0].bldg[0],
+                    instructors: course.section.instructors,
+                    sectionCode: course.section.sectionCode,
+                    sectionType: 'Fin',
+                    start: new Date(2018, 0, index - 1, startHour, startMin),
+                    end: new Date(2018, 0, index - 1, endHour, endMin),
+                    finalExam: course.section.finalExam,
+                    isCustomEvent: false,
+                };
+            });
+        });
+}
         const finalExam = course.section.finalExam;
 
         if (finalExam.examStatus == 'SCHEDULED_FINAL') {

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -3,7 +3,7 @@ import { HourMinute } from 'peterportal-api-next-types';
 import { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { RepeatingCustomEvent } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 
-export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) => {
+export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []): CourseEvent[] => {
     const courseEventsInCalendar: CourseEvent[] = [];
 
     for (const course of currentCourses) {
@@ -49,7 +49,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
     return courseEventsInCalendar;
 };
 
-export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
+export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []): CourseEvent[] => {
     const finalsEventsInCalendar: CourseEvent[] = [];
 
     for (const course of currentCourses) {
@@ -101,25 +101,28 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
     return finalsEventsInCalendar;
 };
 
-export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
-    return currentCustomEvents.flatMap((customEvent) => {
-        return customEvent.days.filter(Boolean).map((_day, index) => {
-            const startHour = parseInt(customEvent.start.slice(0, 2), 10);
-            const startMin = parseInt(customEvent.start.slice(3, 5), 10);
-            const endHour = parseInt(customEvent.end.slice(0, 2), 10);
-            const endMin = parseInt(customEvent.end.slice(3, 5), 10);
-
-            return {
-                customEventID: customEvent.customEventID,
-                color: customEvent.color ?? '#000000',
-                start: new Date(2018, 0, index, startHour, startMin),
-                isCustomEvent: true,
-                end: new Date(2018, 0, index, endHour, endMin),
-                title: customEvent.title,
-            };
-        });
-    });
-}
+export const calendarizeCustomEvents = (currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] => {
+    const customEventsInCalendar: CustomEvent[] = [];
+    for (const customEvent of currentCustomEvents) {
+        for (let dayIndex = 0; dayIndex < customEvent.days.length; dayIndex++) {
+            if (customEvent.days[dayIndex]) {
+                const startHour = parseInt(customEvent.start.slice(0, 2), 10);
+                const startMin = parseInt(customEvent.start.slice(3, 5), 10);
+                const endHour = parseInt(customEvent.end.slice(0, 2), 10);
+                const endMin = parseInt(customEvent.end.slice(3, 5), 10);
+                customEventsInCalendar.push({
+                    customEventID: customEvent.customEventID,
+                    color: customEvent.color ?? '#000000',
+                    start: new Date(2018, 0, dayIndex, startHour, startMin),
+                    isCustomEvent: true,
+                    end: new Date(2018, 0, dayIndex, endHour, endMin),
+                    title: customEvent.title,
+                });
+            }
+        }
+    }
+    return customEventsInCalendar;
+};
 
 export const SHORT_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -9,39 +9,43 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
     for (const course of currentCourses) {
         for (const meeting of course.section.meetings) {
             if (!meeting.timeIsTBA) {
-                const startHour = meeting.startTime.hour;
-                const startMin = meeting.startTime.minute;
-                const endHour = meeting.endTime.hour;
-                const endMin = meeting.endTime.minute;
+                // Because these props are "technically" possibly null, it's checked here for TS warnings
+                // In reality, it will never be null since we're checking for "timeIsTBA" which guarantees non-null
+                if (meeting.startTime && meeting.endTime && meeting.days) {
+                    const startHour = meeting.startTime.hour;
+                    const startMin = meeting.startTime.minute;
+                    const endHour = meeting.endTime.hour;
+                    const endMin = meeting.endTime.minute;
 
-                const dates: boolean[] = [
-                    meeting.days.includes('Su'),
-                    meeting.days.includes('M'),
-                    meeting.days.includes('Tu'),
-                    meeting.days.includes('W'),
-                    meeting.days.includes('Th'),
-                    meeting.days.includes('F'),
-                    meeting.days.includes('Sa'),
-                ];
+                    const dates: boolean[] = [
+                        meeting.days.includes('Su'),
+                        meeting.days.includes('M'),
+                        meeting.days.includes('Tu'),
+                        meeting.days.includes('W'),
+                        meeting.days.includes('Th'),
+                        meeting.days.includes('F'),
+                        meeting.days.includes('Sa'),
+                    ];
 
-                dates.forEach((shouldBeInCal, index) => {
-                    if (shouldBeInCal) {
-                        courseEventsInCalendar.push({
-                            color: course.section.color,
-                            term: course.term,
-                            title: course.deptCode + ' ' + course.courseNumber,
-                            courseTitle: course.courseTitle,
-                            bldg: meeting.bldg[0],
-                            instructors: course.section.instructors,
-                            sectionCode: course.section.sectionCode,
-                            sectionType: course.section.sectionType,
-                            start: new Date(2018, 0, index, startHour, startMin),
-                            end: new Date(2018, 0, index, endHour, endMin),
-                            finalExam: course.section.finalExam,
-                            isCustomEvent: false as const,
-                        });
-                    }
-                });
+                    dates.forEach((shouldBeInCal, index) => {
+                        if (shouldBeInCal) {
+                            courseEventsInCalendar.push({
+                                color: course.section.color,
+                                term: course.term,
+                                title: course.deptCode + ' ' + course.courseNumber,
+                                courseTitle: course.courseTitle,
+                                bldg: meeting.bldg[0],
+                                instructors: course.section.instructors,
+                                sectionCode: course.section.sectionCode,
+                                sectionType: course.section.sectionType,
+                                start: new Date(2018, 0, index, startHour, startMin),
+                                end: new Date(2018, 0, index, endHour, endMin),
+                                finalExam: course.section.finalExam,
+                                isCustomEvent: false as const,
+                            });
+                        }
+                    });
+                }
             }
         }
     }
@@ -56,41 +60,44 @@ export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
         const finalExam = course.section.finalExam;
 
         if (finalExam.examStatus == 'SCHEDULED_FINAL') {
-            const date = finalExam.dayOfWeek;
-
             // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
-            const startHour = finalExam.startTime.hour;
-            const startMin = finalExam.startTime.minute;
-            const endHour = finalExam.endTime.hour;
-            const endMin = finalExam.endTime.minute;
 
-            const weekdayInclusion: boolean[] = [
-                (date as string).includes('Sat'), // Because date is "technically" possibly null, it's typecast here for TS warnings
-                (date as string).includes('Sun'), // In reality, it will never be null since we're checking for "SCHEDULED_FINAL" which guarantees non-null
-                (date as string).includes('Mon'),
-                (date as string).includes('Tue'),
-                (date as string).includes('Wed'),
-                (date as string).includes('Thu'),
-                (date as string).includes('Fri'),
-            ];
+            // Because these props are "technically" possibly null, it's checked here for TS warnings
+            // In reality, it will never be null since we're checking for "timeIsTBA" which guarantees non-null
+            if (finalExam.startTime && finalExam.endTime && finalExam.dayOfWeek) {
+                const startHour = finalExam.startTime.hour;
+                const startMin = finalExam.startTime.minute;
+                const endHour = finalExam.endTime.hour;
+                const endMin = finalExam.endTime.minute;
 
-            weekdayInclusion.forEach((shouldBeInCal, index) => {
-                if (shouldBeInCal)
-                    finalsEventsInCalendar.push({
-                        color: course.section.color,
-                        term: course.term,
-                        title: course.deptCode + ' ' + course.courseNumber,
-                        courseTitle: course.courseTitle,
-                        bldg: course.section.meetings[0].bldg[0],
-                        instructors: course.section.instructors,
-                        sectionCode: course.section.sectionCode,
-                        sectionType: 'Fin',
-                        start: new Date(2018, 0, index - 1, startHour, startMin),
-                        end: new Date(2018, 0, index - 1, endHour, endMin),
-                        finalExam: course.section.finalExam,
-                        isCustomEvent: false,
-                    });
-            });
+                const weekdayInclusion: boolean[] = [
+                    finalExam.dayOfWeek.includes('Sat'),
+                    finalExam.dayOfWeek.includes('Sun'),
+                    finalExam.dayOfWeek.includes('Mon'),
+                    finalExam.dayOfWeek.includes('Tue'),
+                    finalExam.dayOfWeek.includes('Wed'),
+                    finalExam.dayOfWeek.includes('Thu'),
+                    finalExam.dayOfWeek.includes('Fri'),
+                ];
+
+                weekdayInclusion.forEach((shouldBeInCal, index) => {
+                    if (shouldBeInCal)
+                        finalsEventsInCalendar.push({
+                            color: course.section.color,
+                            term: course.term,
+                            title: course.deptCode + ' ' + course.courseNumber,
+                            courseTitle: course.courseTitle,
+                            bldg: course.section.meetings[0].bldg[0],
+                            instructors: course.section.instructors,
+                            sectionCode: course.section.sectionCode,
+                            sectionType: 'Fin',
+                            start: new Date(2018, 0, index - 1, startHour, startMin),
+                            end: new Date(2018, 0, index - 1, endHour, endMin),
+                            finalExam: course.section.finalExam,
+                            isCustomEvent: false,
+                        });
+                });
+            }
         }
     }
 
@@ -136,7 +143,11 @@ export const SHORT_DAY_REGEX = new RegExp(`(${SHORT_DAYS.join('|')})`, 'g');
  * @example 'TuTh' -> [2, 4]
  * @example 'MWFTh' -> [1, 3, 5, 4]
  */
-export function parseDaysString(daysString: string): number[] {
+export function parseDaysString(daysString: string | null): number[] | null {
+    if (daysString == null) {
+        return null;
+    }
+
     const days: number[] = [];
 
     let match: RegExpExecArray | null;

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -8,44 +8,40 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
 
     for (const course of currentCourses) {
         for (const meeting of course.section.meetings) {
-            if (!meeting.timeIsTBA) {
-                // Because these props are "technically" possibly null, it's checked here for TS warnings
-                // In reality, it will never be null since we're checking for "timeIsTBA" which guarantees non-null
-                if (meeting.startTime && meeting.endTime && meeting.days) {
-                    const startHour = meeting.startTime.hour;
-                    const startMin = meeting.startTime.minute;
-                    const endHour = meeting.endTime.hour;
-                    const endMin = meeting.endTime.minute;
+            if (!meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days) {
+                const startHour = meeting.startTime.hour;
+                const startMin = meeting.startTime.minute;
+                const endHour = meeting.endTime.hour;
+                const endMin = meeting.endTime.minute;
 
-                    const dates: boolean[] = [
-                        meeting.days.includes('Su'),
-                        meeting.days.includes('M'),
-                        meeting.days.includes('Tu'),
-                        meeting.days.includes('W'),
-                        meeting.days.includes('Th'),
-                        meeting.days.includes('F'),
-                        meeting.days.includes('Sa'),
-                    ];
+                const dates: boolean[] = [
+                    meeting.days.includes('Su'),
+                    meeting.days.includes('M'),
+                    meeting.days.includes('Tu'),
+                    meeting.days.includes('W'),
+                    meeting.days.includes('Th'),
+                    meeting.days.includes('F'),
+                    meeting.days.includes('Sa'),
+                ];
 
-                    dates.forEach((shouldBeInCal, index) => {
-                        if (shouldBeInCal) {
-                            courseEventsInCalendar.push({
-                                color: course.section.color,
-                                term: course.term,
-                                title: course.deptCode + ' ' + course.courseNumber,
-                                courseTitle: course.courseTitle,
-                                bldg: meeting.bldg[0],
-                                instructors: course.section.instructors,
-                                sectionCode: course.section.sectionCode,
-                                sectionType: course.section.sectionType,
-                                start: new Date(2018, 0, index, startHour, startMin),
-                                end: new Date(2018, 0, index, endHour, endMin),
-                                finalExam: course.section.finalExam,
-                                isCustomEvent: false as const,
-                            });
-                        }
-                    });
-                }
+                dates.forEach((shouldBeInCal, index) => {
+                    if (shouldBeInCal) {
+                        courseEventsInCalendar.push({
+                            color: course.section.color,
+                            term: course.term,
+                            title: course.deptCode + ' ' + course.courseNumber,
+                            courseTitle: course.courseTitle,
+                            bldg: meeting.bldg[0],
+                            instructors: course.section.instructors,
+                            sectionCode: course.section.sectionCode,
+                            sectionType: course.section.sectionType,
+                            start: new Date(2018, 0, index, startHour, startMin),
+                            end: new Date(2018, 0, index, endHour, endMin),
+                            finalExam: course.section.finalExam,
+                            isCustomEvent: false as const,
+                        });
+                    }
+                });
             }
         }
     }
@@ -53,51 +49,57 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []) =
     return courseEventsInCalendar;
 };
 
-const WEEK_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+export const calendarizeFinals = (currentCourses: ScheduleCourse[] = []) => {
+    const finalsEventsInCalendar: CourseEvent[] = [];
 
-/**
- * Given a string or string array of weekdays, return an array of booleans indicating whether
- * each weekday occurs in the input.
- */
-function getWeekdaysOcurring(weekDays?: string | string[] | null): boolean[] {
-    return weekDays ? WEEK_DAYS.map((day) => weekDays.includes(day)) : WEEK_DAYS.map(() => false);
-}
+    for (const course of currentCourses) {
+        const finalExam = course.section.finalExam;
 
-export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
-    return currentCourses
-        .filter((course) => course.section.finalExam.examStatus === 'SCHEDULED_FINAL')
-        .filter(
-            (course) =>
-                course.section.finalExam.startTime &&
-                course.section.finalExam.endTime &&
-                course.section.finalExam.dayOfWeek
-        )
-        .flatMap((course) => {
-            const finalExam = course.section.finalExam;
-            const startHour = finalExam.startTime?.hour;
-            const startMin = finalExam.startTime?.minute;
-            const endHour = finalExam.endTime?.hour;
-            const endMin = finalExam.endTime?.minute;
+        if (
+            finalExam.examStatus == 'SCHEDULED_FINAL' &&
+            finalExam.startTime &&
+            finalExam.endTime &&
+            finalExam.dayOfWeek
+        ) {
+            // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
 
-            const weekdaysOccurring = getWeekdaysOcurring(course.section.finalExam.dayOfWeek);
-            return weekdaysOccurring.filter(Boolean).map((_day, index) => {
-                return {
-                    color: course.section.color,
-                    term: course.term,
-                    title: course.deptCode + ' ' + course.courseNumber,
-                    courseTitle: course.courseTitle,
-                    bldg: course.section.meetings[0].bldg[0],
-                    instructors: course.section.instructors,
-                    sectionCode: course.section.sectionCode,
-                    sectionType: 'Fin',
-                    start: new Date(2018, 0, index - 1, startHour, startMin),
-                    end: new Date(2018, 0, index - 1, endHour, endMin),
-                    finalExam: course.section.finalExam,
-                    isCustomEvent: false,
-                };
+            const startHour = finalExam.startTime.hour;
+            const startMin = finalExam.startTime.minute;
+            const endHour = finalExam.endTime.hour;
+            const endMin = finalExam.endTime.minute;
+
+            const weekdayInclusion: boolean[] = [
+                finalExam.dayOfWeek.includes('Sat'),
+                finalExam.dayOfWeek.includes('Sun'),
+                finalExam.dayOfWeek.includes('Mon'),
+                finalExam.dayOfWeek.includes('Tue'),
+                finalExam.dayOfWeek.includes('Wed'),
+                finalExam.dayOfWeek.includes('Thu'),
+                finalExam.dayOfWeek.includes('Fri'),
+            ];
+
+            weekdayInclusion.forEach((shouldBeInCal, index) => {
+                if (shouldBeInCal)
+                    finalsEventsInCalendar.push({
+                        color: course.section.color,
+                        term: course.term,
+                        title: course.deptCode + ' ' + course.courseNumber,
+                        courseTitle: course.courseTitle,
+                        bldg: course.section.meetings[0].bldg[0],
+                        instructors: course.section.instructors,
+                        sectionCode: course.section.sectionCode,
+                        sectionType: 'Fin',
+                        start: new Date(2018, 0, index - 1, startHour, startMin),
+                        end: new Date(2018, 0, index - 1, endHour, endMin),
+                        finalExam: course.section.finalExam,
+                        isCustomEvent: false,
+                    });
             });
-        });
-}
+        }
+    }
+
+    return finalsEventsInCalendar;
+};
 
 export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
     return currentCustomEvents.flatMap((customEvent) => {

--- a/apps/antalmanac/tests/calendarize-helpers.test.ts
+++ b/apps/antalmanac/tests/calendarize-helpers.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect } from 'vitest';
+import type { ScheduleCourse } from '@packages/antalmanac-types';
+import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
+import type { RepeatingCustomEvent } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
+import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } from '$stores/calendarizeHelpers';
+
+describe('calendarize-helpers', () => {
+    const courses: ScheduleCourse[] = [
+        {
+            courseComment: 'string',
+            courseNumber: 'string',
+            courseTitle: 'string',
+            deptCode: 'string',
+            prerequisiteLink: 'string',
+            section: {
+                color: 'string',
+                sectionCode: 'string',
+                sectionType: 'string',
+                sectionNum: 'string',
+                units: 'string',
+                instructors: [],
+                meetings: [
+                    {
+                        timeIsTBA: false,
+                        bldg: [],
+                        days: 'MWF',
+                        startTime: {
+                            hour: 1,
+                            minute: 2,
+                        },
+                        endTime: {
+                            hour: 3,
+                            minute: 4,
+                        },
+                    },
+                ],
+                finalExam: {
+                    examStatus: 'SCHEDULED_FINAL',
+                    dayOfWeek: 'Sun',
+                    month: 2,
+                    day: 3,
+                    startTime: {
+                        hour: 1,
+                        minute: 2,
+                    },
+                    endTime: {
+                        hour: 3,
+                        minute: 4,
+                    },
+                    bldg: [],
+                },
+                maxCapacity: 'string',
+                numCurrentlyEnrolled: {
+                    totalEnrolled: 'string',
+                    sectionEnrolled: 'string',
+                },
+                numOnWaitlist: 'string',
+                numWaitlistCap: 'string',
+                numRequested: 'string',
+                numNewOnlyReserved: 'string',
+                restrictions: 'string',
+                status: 'OPEN',
+                sectionComment: 'string',
+            },
+            term: 'string',
+        },
+    ];
+
+    const customEvents: RepeatingCustomEvent[] = [
+        {
+            title: 'title',
+            start: '01:02',
+            end: '03:04',
+            days: [true, false, true, false, true, false, true],
+            customEventID: 0,
+            color: '#000000',
+        },
+    ];
+
+    test('calendarizeCourseEvents', () => {
+        const newResult = calendarizeCourseEvents(courses);
+        const oldResult = oldCalendarizeCourseEvents(courses);
+        expect(newResult).toStrictEqual(oldResult);
+    });
+
+    test('calendarizeFinals', () => {
+        const newResult = calendarizeFinals(courses);
+        const oldResult = oldCalendarizeFinals(courses);
+        expect(newResult).toStrictEqual(oldResult);
+    });
+
+    test('calendarizeCustomEvents', () => {
+        const newResult = calendarizeCustomEvents(customEvents);
+        const oldResult = oldClendarizeCustomEvents(customEvents);
+        expect(newResult).toStrictEqual(oldResult);
+    });
+});
+
+/**
+ * TODO: Remove this and replace with an array of expected values.
+ */
+export function oldCalendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
+    const courseEventsInCalendar: CourseEvent[] = [];
+
+    for (const course of currentCourses) {
+        for (const meeting of course.section.meetings) {
+            if (!meeting.timeIsTBA && meeting.startTime && meeting.endTime && meeting.days) {
+                const startHour = meeting.startTime.hour;
+                const startMin = meeting.startTime.minute;
+                const endHour = meeting.endTime.hour;
+                const endMin = meeting.endTime.minute;
+
+                const dates: boolean[] = [
+                    meeting.days.includes('Su'),
+                    meeting.days.includes('M'),
+                    meeting.days.includes('Tu'),
+                    meeting.days.includes('W'),
+                    meeting.days.includes('Th'),
+                    meeting.days.includes('F'),
+                    meeting.days.includes('Sa'),
+                ];
+
+                dates.forEach((shouldBeInCal, index) => {
+                    if (shouldBeInCal) {
+                        courseEventsInCalendar.push({
+                            color: course.section.color,
+                            term: course.term,
+                            title: course.deptCode + ' ' + course.courseNumber,
+                            courseTitle: course.courseTitle,
+                            bldg: meeting.bldg[0],
+                            instructors: course.section.instructors,
+                            sectionCode: course.section.sectionCode,
+                            sectionType: course.section.sectionType,
+                            start: new Date(2018, 0, index, startHour, startMin),
+                            end: new Date(2018, 0, index, endHour, endMin),
+                            finalExam: course.section.finalExam,
+                            isCustomEvent: false as const,
+                        });
+                    }
+                });
+            }
+        }
+    }
+
+    return courseEventsInCalendar;
+}
+
+/**
+ * TODO: Remove this and replace with an array of expected values.
+ */
+export function oldCalendarizeFinals(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
+    const finalsEventsInCalendar: CourseEvent[] = [];
+
+    for (const course of currentCourses) {
+        const finalExam = course.section.finalExam;
+
+        if (
+            finalExam.examStatus == 'SCHEDULED_FINAL' &&
+            finalExam.startTime &&
+            finalExam.endTime &&
+            finalExam.dayOfWeek
+        ) {
+            // TODO: this block is almost the same as in calenarizeCourseEvents. we should refactor to remove the duplicate code.
+
+            const startHour = finalExam.startTime.hour;
+            const startMin = finalExam.startTime.minute;
+            const endHour = finalExam.endTime.hour;
+            const endMin = finalExam.endTime.minute;
+
+            const weekdayInclusion: boolean[] = [
+                finalExam.dayOfWeek.includes('Sat'),
+                finalExam.dayOfWeek.includes('Sun'),
+                finalExam.dayOfWeek.includes('Mon'),
+                finalExam.dayOfWeek.includes('Tue'),
+                finalExam.dayOfWeek.includes('Wed'),
+                finalExam.dayOfWeek.includes('Thu'),
+                finalExam.dayOfWeek.includes('Fri'),
+            ];
+
+            weekdayInclusion.forEach((shouldBeInCal, index) => {
+                if (shouldBeInCal)
+                    finalsEventsInCalendar.push({
+                        color: course.section.color,
+                        term: course.term,
+                        title: course.deptCode + ' ' + course.courseNumber,
+                        courseTitle: course.courseTitle,
+                        bldg: course.section.meetings[0].bldg[0],
+                        instructors: course.section.instructors,
+                        sectionCode: course.section.sectionCode,
+                        sectionType: 'Fin',
+                        start: new Date(2018, 0, index - 1, startHour, startMin),
+                        end: new Date(2018, 0, index - 1, endHour, endMin),
+                        finalExam: course.section.finalExam,
+                        isCustomEvent: false,
+                    });
+            });
+        }
+    }
+
+    return finalsEventsInCalendar;
+}
+
+/**
+ * TODO: Remove this and replace with an array of expected values.
+ */
+export function oldClendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
+    const customEventsInCalendar: CustomEvent[] = [];
+    for (const customEvent of currentCustomEvents) {
+        for (let dayIndex = 0; dayIndex < customEvent.days.length; dayIndex++) {
+            if (customEvent.days[dayIndex]) {
+                const startHour = parseInt(customEvent.start.slice(0, 2), 10);
+                const startMin = parseInt(customEvent.start.slice(3, 5), 10);
+                const endHour = parseInt(customEvent.end.slice(0, 2), 10);
+                const endMin = parseInt(customEvent.end.slice(3, 5), 10);
+                customEventsInCalendar.push({
+                    customEventID: customEvent.customEventID,
+                    color: customEvent.color ?? '#000000',
+                    start: new Date(2018, 0, dayIndex, startHour, startMin),
+                    isCustomEvent: true,
+                    end: new Date(2018, 0, dayIndex, endHour, endMin),
+                    title: customEvent.title,
+                });
+            }
+        }
+    }
+    return customEventsInCalendar;
+}

--- a/apps/antalmanac/tsconfig.json
+++ b/apps/antalmanac/tsconfig.json
@@ -22,7 +22,7 @@
             "$lib/*": ["src/lib/*"],
             "$providers/*": ["src/providers/*"],
             "$routes/*": ["src/routes/*"],
-            "$stores/*": ["src/stores/*"],
+            "$stores/*": ["src/stores/*"]
         }
-    },
+    }
 }

--- a/packages/peterportal-schemas/src/websoc.ts
+++ b/packages/peterportal-schemas/src/websoc.ts
@@ -1,81 +1,98 @@
-import { type Infer, arrayOf, type } from "arktype";
-import { type Quarter, quarters } from "peterportal-api-next-types";
-import enumerate from "./enumerate";
+import { type Infer, arrayOf, type } from 'arktype';
+import { type Quarter, quarters } from 'peterportal-api-next-types';
+import enumerate from './enumerate';
+
+export const WebsocSectionTimeFormat = type({
+    hour: 'number',
+    minute: 'number',
+});
 
 export const WebsocSectionMeeting = type({
-  days: "string",
-  time: "string",
-  bldg: "string[]",
+    timeIsTBA: 'boolean',
+    bldg: 'string[]',
+    days: 'string',
+    startTime: WebsocSectionTimeFormat,
+    endTime: WebsocSectionTimeFormat,
 });
 
 export const WebsocSectionEnrollment = type({
-  totalEnrolled: "string",
-  sectionEnrolled: "string",
+    totalEnrolled: 'string',
+    sectionEnrolled: 'string',
+});
+
+export const WebSocSectionFinals = type({
+    examStatus: 'string',
+    dayOfWeek: 'string',
+    month: 'number',
+    day: 'number',
+    startTime: WebsocSectionTimeFormat,
+    endTime: WebsocSectionTimeFormat,
+    bldg: 'string[]',
 });
 
 export const WebsocSection = type({
-  sectionCode: "string",
-  sectionType: "string",
-  sectionNum: "string",
-  units: "string",
-  instructors: "string[]",
-  meetings: arrayOf(WebsocSectionMeeting),
-  finalExam: "string",
-  maxCapacity: "string",
-  numCurrentlyEnrolled: WebsocSectionEnrollment,
-  numOnWaitlist: "string",
-  numWaitlistCap: "string",
-  numRequested: "string",
-  numNewOnlyReserved: "string",
-  restrictions: "string",
-  status: enumerate(["OPEN", "Waitl", "FULL", "NewOnly"] as const),
-  sectionComment: "string",
+    sectionCode: 'string',
+    sectionType: 'string',
+    sectionNum: 'string',
+    units: 'string',
+    instructors: 'string[]',
+    meetings: arrayOf(WebsocSectionMeeting),
+    finalExam: WebSocSectionFinals,
+    maxCapacity: 'string',
+    numCurrentlyEnrolled: WebsocSectionEnrollment,
+    numOnWaitlist: 'string',
+    numWaitlistCap: 'string',
+    numRequested: 'string',
+    numNewOnlyReserved: 'string',
+    restrictions: 'string',
+    status: enumerate(['OPEN', 'Waitl', 'FULL', 'NewOnly'] as const),
+    sectionComment: 'string',
 });
 
 export const WebsocCourse = type({
-  deptCode: "string",
-  courseNumber: "string",
-  courseTitle: "string",
-  courseComment: "string",
-  prerequisiteLink: "string",
-  // sections: arrayOf(WebsocSection),
-  // Commenting out sections because I don't know how to override this property
+    deptCode: 'string',
+    courseNumber: 'string',
+    courseTitle: 'string',
+    courseComment: 'string',
+    prerequisiteLink: 'string',
+    // sections: arrayOf(WebsocSection),
+    // Commenting out sections because I don't know how to override this property
 });
 
 export const WebsocDepartment = type({
-  deptName: "string",
-  deptCode: "string",
-  deptComment: "string",
-  courses: arrayOf(WebsocCourse),
-  sectionCodeRangeComments: "string[]",
-  courseNumberRangeComments: "string[]",
+    deptName: 'string',
+    deptCode: 'string',
+    deptComment: 'string',
+    courses: arrayOf(WebsocCourse),
+    sectionCodeRangeComments: 'string[]',
+    courseNumberRangeComments: 'string[]',
 });
 
 export const WebsocSchool = type({
-  schoolName: "string",
-  schoolComment: "string",
-  departments: arrayOf(WebsocDepartment),
+    schoolName: 'string',
+    schoolComment: 'string',
+    departments: arrayOf(WebsocDepartment),
 });
 
 export const Term = type({
-  year: "string",
-  quarter: enumerate(quarters),
+    year: 'string',
+    quarter: enumerate(quarters),
 });
 
 export const WebsocAPIResponse = {
-  schools: arrayOf(WebsocSchool),
+    schools: arrayOf(WebsocSchool),
 };
 
 export const Department = type({
-  deptLabel: "string",
-  deptValue: "string",
+    deptLabel: 'string',
+    deptValue: 'string',
 });
 
 export const DepartmentResponse = arrayOf(Department);
 
 export const TermData = type({
-  shortName: "string" as Infer<`${string} ${Quarter}`>,
-  longName: "string",
+    shortName: 'string' as Infer<`${string} ${Quarter}`>,
+    longName: 'string',
 });
 
 export const TermResponse = arrayOf(TermData);

--- a/packages/peterportal-schemas/src/websoc.ts
+++ b/packages/peterportal-schemas/src/websoc.ts
@@ -21,8 +21,8 @@ export const WebsocSectionEnrollment = type({
 });
 
 export const WebSocSectionFinals = type({
-    examStatus: 'string',
-    dayOfWeek: 'string',
+    examStatus: "'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL'",
+    dayOfWeek: "'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null",
     month: 'number',
     day: 'number',
     startTime: WebsocSectionTimeFormat,

--- a/packages/peterportal-schemas/src/websoc.ts
+++ b/packages/peterportal-schemas/src/websoc.ts
@@ -1,8 +1,8 @@
-import { type Infer, arrayOf, type } from 'arktype';
+import { type Infer, arrayOf, type, union } from 'arktype';
 import { type Quarter, quarters } from 'peterportal-api-next-types';
 import enumerate from './enumerate';
 
-export const WebsocSectionTimeFormat = type({
+export const HourMinute = type({
     hour: 'number',
     minute: 'number',
 });
@@ -10,9 +10,9 @@ export const WebsocSectionTimeFormat = type({
 export const WebsocSectionMeeting = type({
     timeIsTBA: 'boolean',
     bldg: 'string[]',
-    days: 'string',
-    startTime: WebsocSectionTimeFormat,
-    endTime: WebsocSectionTimeFormat,
+    days: 'string | null',
+    startTime: union(HourMinute, 'null'),
+    endTime: union(HourMinute, 'null'),
 });
 
 export const WebsocSectionEnrollment = type({
@@ -21,13 +21,13 @@ export const WebsocSectionEnrollment = type({
 });
 
 export const WebSocSectionFinals = type({
-    examStatus: "'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL'",
-    dayOfWeek: "'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null",
-    month: 'number',
-    day: 'number',
-    startTime: WebsocSectionTimeFormat,
-    endTime: WebsocSectionTimeFormat,
-    bldg: 'string[]',
+    examStatus: '"NO_FINAL" | "TBA_FINAL" | "SCHEDULED_FINAL"',
+    dayOfWeek: '"Sun" | "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | null',
+    month: 'number | null',
+    day: 'number | null',
+    startTime: union(HourMinute, 'null'),
+    endTime: union(HourMinute, 'null'),
+    bldg: 'string[] | null',
 });
 
 export const WebsocSection = type({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^13.1.1
         version: 13.1.2
       peterportal-api-next-types:
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2
+        specifier: 1.0.0-rc.2.68.0
+        version: 1.0.0-rc.2.68.0
       prettier:
         specifier: ^2.8.4
         version: 2.8.4
@@ -6743,8 +6743,8 @@ packages:
     resolution: {integrity: sha512-sbQmYiH21t6wIsgFXStJcBZWhMOCjKQspLGdpUEmpYQaR4tL1kwGQ+KNix5EwLJxHM9BnMtK1BJcwu6fOTeqMQ==}
     dev: false
 
-  /peterportal-api-next-types@1.0.0-beta.2:
-    resolution: {integrity: sha512-y7uFk8nYmOQ9oWxFMCztUoIIDU5eFAfWct92HPGEbIKvTJTDBeNTb57/5qQP0kq0QE0n26dtmLMADvLkbN7P1Q==}
+  /peterportal-api-next-types@1.0.0-rc.2.68.0:
+    resolution: {integrity: sha512-gq0k53abt6ea9roA+GlSgP3Rbv+0tC4rGw4gGbrahh+ZNnmTGdlZSF8ISq07DbQ7td8dBev4gMrjrZq+Xn500A==}
     dev: true
 
   /picocolors@1.0.0:


### PR DESCRIPTION
## Summary
Updated and refactored code + types related to times and dates used across AA to support the breaking changes of the API's new time formats.

On the user-side, nothing has changed aside from meeting time text which went from:
`MWF 12:00 - 12:50p` to `MWF 12:00 - 12:50 PM`

![Functionality Demo](https://github.com/icssc/AntAlmanac/assets/100006999/485d8571-9367-4b17-9481-5ff6db6a301b)

## Detailed Summary
1. Peterportal types updated to [Staging Instance 68](https://staging-68.api-next.peterportal.org/)
2. Types across AA have been updated in accordance to # 1 ^
3. As mentioned above, formatting of times in `SectionTableBody.tsx` looks like this now: `MWF 12:00 - 12:50 PM`. AM will now also be included in the string.
4. Calendarization has been updated, removing all the nasty regex

## To-Do
- [x] Convert 24 hour to 12 hour in a sane way
- [x] Get correct types
- [x] Update months to 0-indexing (pending PP-API changes)

## Test Plan
- [ ] Please don't crash 🫠

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
