### PR TITLE
Rename tabs for descriptiveness and concision

### DIFF
--- a/apps/antalmanac/src/components/MobileHome.tsx
+++ b/apps/antalmanac/src/components/MobileHome.tsx
@@ -44,7 +44,7 @@ const MobileHome = () => {
                     }}
                 >
                     <Tab label={<div>Calendar</div>} />
-                    <Tab label={<div>Search</div>} />
+                    <Tab label={<div>Classes</div>} />
                 </Tabs>
             </Paper>
             <mobileContext.Provider value={{ setSelectedTab }}>{components[selectedTab]}</mobileContext.Provider>

--- a/apps/antalmanac/src/components/RightPane/RightPaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/RightPaneRoot.tsx
@@ -33,12 +33,12 @@ export default function Desktop({ style }: DesktopTabsProps) {
 
   const tabs = [
     {
-      label: 'Class Search',
+      label: 'Search',
       href: '/',
       icon: Search,
     },
     {
-      label: 'Added Courses',
+      label: 'Added',
       href: '/added',
       icon: FormatListBulleted,
     },


### PR DESCRIPTION
## Summary

Rename tab names for descriptiveness and concision.

"Class Search" -> "Search".
"Added Courses" -> "Added" (You can already see the naming inconsistencies that plague us).
"Search" -> "Classes" in mobile home. There's no reason to call a tab search when a sub-tab is the actual search tab. I feel less confident in my judgment on this one, but I am certain that the name needs to change

## Test Plan
See that it looks alright. Not much to test
