### PR TITLE
Add Course Level Filtering, Restyle Advanced Search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -227,6 +227,7 @@ class CourseRenderPane extends PureComponent<CourseRenderPaneProps, CourseRender
                 fullCourses: formData.coursesFull,
                 building: formData.building,
                 room: formData.room,
+                division: formData.division,
             };
 
             try {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -1,4 +1,5 @@
 import {
+    Box,
     Button,
     Collapse,
     FormControl,
@@ -19,16 +20,24 @@ import { ChangeEvent, PureComponent } from 'react';
 import RightPaneStore from '../../RightPaneStore';
 
 const styles: Styles<Theme, object> = {
+    fieldContainer: {
+        display: 'flex',
+        gap: '1.5rem',
+        flexWrap: 'wrap',
+        paddingLeft: '8px',
+        paddingRight: '8px',
+        marginBottom: '1rem',
+    },
     units: {
         width: '80px',
     },
     timePicker: {
         width: '130px',
     },
-    smallTextFields: {
-        display: 'flex',
-        justifyContent: 'space-around',
-        flexWrap: 'wrap',
+    onlineSwitch: {
+        margin: 0,
+        justifyContent: 'flex-end',
+        left: 0,
     },
 };
 
@@ -132,7 +141,7 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
         const endsBeforeMenuItems = ['', ...menuItemTimes].map((time) => createdMenuItemTime(time));
 
         return (
-            <div className={classes?.smallTextFields}>
+            <Box className={classes?.fieldContainer}>
                 <TextField
                     label="Instructor"
                     type="search"
@@ -213,8 +222,9 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                             checked={this.state.building === 'ON'}
                         />
                     }
-                    label="Online Classes Only"
+                    label="Online Only"
                     labelPlacement="top"
+                    className={classes?.onlineSwitch}
                 />
 
                 <TextField
@@ -232,7 +242,7 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                     value={this.state.room}
                     onChange={this.handleChange('room')}
                 />
-            </div>
+            </Box>
         );
     }
 }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -1,6 +1,5 @@
 import {
     Button,
-    Checkbox,
     Collapse,
     FormControl,
     FormControlLabel,
@@ -215,6 +214,7 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                         />
                     }
                     label="Online Classes Only"
+                    labelPlacement="top"
                 />
 
                 <TextField

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -1,5 +1,6 @@
 import {
     Button,
+    Checkbox,
     Collapse,
     FormControl,
     FormControlLabel,
@@ -44,6 +45,7 @@ interface AdvancedSearchTextFieldsState {
     coursesFull: string;
     building: string;
     room: string;
+    division: string;
 }
 
 interface AdvancedSearchProps {
@@ -66,6 +68,7 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
         coursesFull: RightPaneStore.getFormData().coursesFull,
         building: RightPaneStore.getFormData().building,
         room: RightPaneStore.getFormData().room,
+        division: RightPaneStore.getFormData().division,
     };
 
     componentDidMount() {
@@ -85,6 +88,7 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
             coursesFull: RightPaneStore.getFormData().coursesFull,
             building: RightPaneStore.getFormData().building,
             room: RightPaneStore.getFormData().room,
+            division: RightPaneStore.getFormData().division,
         });
     };
 
@@ -156,6 +160,24 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                         <MenuItem value={'SkipFull'}>Skip full courses</MenuItem>
                         <MenuItem value={'FullOnly'}>Show only full or waitlisted courses</MenuItem>
                         <MenuItem value={'Overenrolled'}>Show only over-enrolled courses</MenuItem>
+                    </Select>
+                </FormControl>
+
+                <FormControl>
+                    <InputLabel id="division-label" shrink>
+                        Course Level
+                    </InputLabel>
+                    <Select
+                        labelId="division-label"
+                        value={this.state.division}
+                        onChange={this.handleChange('division')}
+                        className={classes?.courseLevel}
+                        displayEmpty
+                    >
+                        <MenuItem value={''}>Any Course Division</MenuItem>
+                        <MenuItem value={'LowerDiv'}>Lower Division Only</MenuItem>
+                        <MenuItem value={'UpperDiv'}>Upper Division Only</MenuItem>
+                        <MenuItem value={'Graduate'}>Graduate/Professional Only</MenuItem>
                     </Select>
                 </FormControl>
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -162,7 +162,21 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
 
                 <FormControl>
                     <InputLabel>Class Full Option</InputLabel>
-                    <Select value={this.state.coursesFull} onChange={this.handleChange('coursesFull')}>
+                    <Select
+                        value={this.state.coursesFull}
+                        onChange={this.handleChange('coursesFull')}
+                        MenuProps={{
+                            anchorOrigin: {
+                                vertical: 'bottom',
+                                horizontal: 'left',
+                            },
+                            transformOrigin: {
+                                vertical: 'top',
+                                horizontal: 'left',
+                            },
+                            getContentAnchorEl: null,
+                        }}
+                    >
                         <MenuItem value={'ANY'}>Include all classes</MenuItem>
                         <MenuItem value={'SkipFullWaitlist'}>Include full courses if space on waitlist</MenuItem>
                         <MenuItem value={'SkipFull'}>Skip full courses</MenuItem>
@@ -181,6 +195,17 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                         onChange={this.handleChange('division')}
                         className={classes?.courseLevel}
                         displayEmpty
+                        MenuProps={{
+                            anchorOrigin: {
+                                vertical: 'bottom',
+                                horizontal: 'left',
+                            },
+                            transformOrigin: {
+                                vertical: 'top',
+                                horizontal: 'left',
+                            },
+                            getContentAnchorEl: null,
+                        }}
                     >
                         <MenuItem value={''}>Any Division</MenuItem>
                         <MenuItem value={'LowerDiv'}>Lower Division</MenuItem>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -173,10 +173,10 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
                         className={classes?.courseLevel}
                         displayEmpty
                     >
-                        <MenuItem value={''}>Any Course Division</MenuItem>
-                        <MenuItem value={'LowerDiv'}>Lower Division Only</MenuItem>
-                        <MenuItem value={'UpperDiv'}>Upper Division Only</MenuItem>
-                        <MenuItem value={'Graduate'}>Graduate/Professional Only</MenuItem>
+                        <MenuItem value={''}>Any Division</MenuItem>
+                        <MenuItem value={'LowerDiv'}>Lower Division</MenuItem>
+                        <MenuItem value={'UpperDiv'}>Upper Division</MenuItem>
+                        <MenuItem value={'Graduate'}>Graduate/Professional</MenuItem>
                     </Select>
                 </FormControl>
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CourseNumberSearchBar.tsx
@@ -1,12 +1,10 @@
-import { FormControlLabel, Switch, TextField } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import { ChangeEvent, PureComponent } from 'react';
 
 import RightPaneStore from '../../RightPaneStore';
-
 interface CourseNumberSearchBarState {
     courseNumber: string;
 }
-
 class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseNumberSearchBarState> {
     updateCourseNumAndGetFormData() {
         RightPaneStore.updateFormValue('courseNumber', RightPaneStore.getUrlCourseNumValue());
@@ -23,70 +21,40 @@ class CourseNumberSearchBar extends PureComponent<Record<string, never>, CourseN
         courseNumber: this.getCourseNumber(),
     };
 
-    handleUpperDivChange = (event: ChangeEvent<HTMLInputElement>) => {
-        if (event.target.checked) {
-            this.handleCourseNumbers('100-199');
-        } else {
-            this.handleCourseNumbers('');
-        }
-    };
-
-    handleNumbersChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        this.handleCourseNumbers(event.target.value);
-    };
-
-    handleCourseNumbers = (eventCourseNumbers: string) => {
+    handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        this.setState({ courseNumber: event.target.value });
+        RightPaneStore.updateFormValue('courseNumber', event.target.value);
         const url = new URL(window.location.href);
         const urlParam = new URLSearchParams(url.search);
         urlParam.delete('courseNumber');
-
-        this.setState({ courseNumber: eventCourseNumbers });
-        RightPaneStore.updateFormValue('courseNumber', eventCourseNumbers);
-        if (eventCourseNumbers !== '') {
-            urlParam.append('courseNumber', eventCourseNumbers);
+        if (event.target.value) {
+            urlParam.append('courseNumber', event.target.value);
         }
-
         const param = urlParam.toString();
         const new_url = `${param.trim() ? '?' : ''}${param}`;
         history.replaceState({ url: 'url' }, 'url', '/' + new_url);
     };
-
     componentDidMount() {
         RightPaneStore.on('formReset', this.resetField);
     }
-
     componentWillUnmount() {
         RightPaneStore.removeListener('formReset', this.resetField);
     }
-
     resetField = () => {
         this.setState({ courseNumber: RightPaneStore.getFormData().courseNumber });
     };
 
     render() {
         return (
-            <>
+            <div>
                 <TextField
                     label="Course Number(s)"
                     type="search"
                     value={this.state.courseNumber}
-                    onChange={this.handleNumbersChange}
+                    onChange={this.handleChange}
                     helperText="ex. 6B, 17, 30-40"
                 />
-
-                <FormControlLabel
-                    control={
-                        <Switch
-                            onChange={this.handleUpperDivChange}
-                            value="100-199"
-                            color="primary"
-                            checked={this.state.courseNumber === '100-199'}
-                        />
-                    }
-                    labelPlacement="top"
-                    label="Upper Div Only"
-                />
-            </>
+            </div>
         );
     }
 }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
@@ -42,15 +42,12 @@ class GESelector extends PureComponent<GESelectorProps, GESelectorState> {
     }
 
     getGe() {
-        return RightPaneStore.getUrlGEValue().trim()
-          ? this.updateGEAndGetFormData()
-          : RightPaneStore.getFormData().ge
+        return RightPaneStore.getUrlGEValue().trim() ? this.updateGEAndGetFormData() : RightPaneStore.getFormData().ge;
     }
 
     state = {
         ge: this.getGe(),
     };
-
 
     handleChange = (event: ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         this.setState({ ge: event.target.value as string });
@@ -86,7 +83,22 @@ class GESelector extends PureComponent<GESelectorProps, GESelectorState> {
         return (
             <FormControl className={classes.formControl}>
                 <InputLabel>General Education</InputLabel>
-                <Select value={this.state.ge} onChange={this.handleChange} fullWidth>
+                <Select
+                    value={this.state.ge}
+                    onChange={this.handleChange}
+                    fullWidth
+                    MenuProps={{
+                        anchorOrigin: {
+                            vertical: 'bottom',
+                            horizontal: 'left',
+                        },
+                        transformOrigin: {
+                            vertical: 'top',
+                            horizontal: 'left',
+                        },
+                        getContentAnchorEl: null,
+                    }}
+                >
                     {geList.map((category) => {
                         return (
                             <MenuItem key={category.value} value={category.value}>

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -37,6 +37,7 @@ const defaultFormValues: Record<string, string> = {
     coursesFull: 'ANY',
     building: '',
     room: '',
+    division: '',
 };
 
 export interface BuildingFocusInfo {

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -133,6 +133,12 @@ function cleanParams(record: Record<string, string>) {
         }
     }
 
+    if ('division' in record) {
+        if (record['division'] === '') {
+            delete record['division'];
+        }
+    }
+
     return record;
 }
 

--- a/packages/peterportal-schemas/src/websoc.ts
+++ b/packages/peterportal-schemas/src/websoc.ts
@@ -1,81 +1,81 @@
-import { type Infer, arrayOf, type } from "arktype";
-import { type Quarter, quarters } from "peterportal-api-next-types";
-import enumerate from "./enumerate";
+import { type Infer, arrayOf, type } from 'arktype';
+import { type Quarter, quarters } from 'peterportal-api-next-types';
+import enumerate from './enumerate';
 
 export const WebsocSectionMeeting = type({
-  days: "string",
-  time: "string",
-  bldg: "string[]",
+    days: 'string',
+    time: 'string',
+    bldg: 'string[]',
 });
 
 export const WebsocSectionEnrollment = type({
-  totalEnrolled: "string",
-  sectionEnrolled: "string",
+    totalEnrolled: 'string',
+    sectionEnrolled: 'string',
 });
 
 export const WebsocSection = type({
-  sectionCode: "string",
-  sectionType: "string",
-  sectionNum: "string",
-  units: "string",
-  instructors: "string[]",
-  meetings: arrayOf(WebsocSectionMeeting),
-  finalExam: "string",
-  maxCapacity: "string",
-  numCurrentlyEnrolled: WebsocSectionEnrollment,
-  numOnWaitlist: "string",
-  numWaitlistCap: "string",
-  numRequested: "string",
-  numNewOnlyReserved: "string",
-  restrictions: "string",
-  status: enumerate(["OPEN", "Waitl", "FULL", "NewOnly"] as const),
-  sectionComment: "string",
+    sectionCode: 'string',
+    sectionType: 'string',
+    sectionNum: 'string',
+    units: 'string',
+    instructors: 'string[]',
+    meetings: arrayOf(WebsocSectionMeeting),
+    finalExam: 'string',
+    maxCapacity: 'string',
+    numCurrentlyEnrolled: WebsocSectionEnrollment,
+    numOnWaitlist: 'string',
+    numWaitlistCap: 'string',
+    numRequested: 'string',
+    numNewOnlyReserved: 'string',
+    restrictions: 'string',
+    status: enumerate(['OPEN', 'Waitl', 'FULL', 'NewOnly'] as const),
+    sectionComment: 'string',
 });
 
 export const WebsocCourse = type({
-  deptCode: "string",
-  courseNumber: "string",
-  courseTitle: "string",
-  courseComment: "string",
-  prerequisiteLink: "string",
-  // sections: arrayOf(WebsocSection),
-  // Commenting out sections because I don't know how to override this property
+    deptCode: 'string',
+    courseNumber: 'string',
+    courseTitle: 'string',
+    courseComment: 'string',
+    prerequisiteLink: 'string',
+    // sections: arrayOf(WebsocSection),
+    // Commenting out sections because I don't know how to override this property
 });
 
 export const WebsocDepartment = type({
-  deptName: "string",
-  deptCode: "string",
-  deptComment: "string",
-  courses: arrayOf(WebsocCourse),
-  sectionCodeRangeComments: "string[]",
-  courseNumberRangeComments: "string[]",
+    deptName: 'string',
+    deptCode: 'string',
+    deptComment: 'string',
+    courses: arrayOf(WebsocCourse),
+    sectionCodeRangeComments: 'string[]',
+    courseNumberRangeComments: 'string[]',
 });
 
 export const WebsocSchool = type({
-  schoolName: "string",
-  schoolComment: "string",
-  departments: arrayOf(WebsocDepartment),
+    schoolName: 'string',
+    schoolComment: 'string',
+    departments: arrayOf(WebsocDepartment),
 });
 
 export const Term = type({
-  year: "string",
-  quarter: enumerate(quarters),
+    year: 'string',
+    quarter: enumerate(quarters),
 });
 
 export const WebsocAPIResponse = {
-  schools: arrayOf(WebsocSchool),
+    schools: arrayOf(WebsocSchool),
 };
 
 export const Department = type({
-  deptLabel: "string",
-  deptValue: "string",
+    deptLabel: 'string',
+    deptValue: 'string',
 });
 
 export const DepartmentResponse = arrayOf(Department);
 
 export const TermData = type({
-  shortName: "string" as Infer<`${string} ${Quarter}`>,
-  longName: "string",
+    shortName: 'string' as Infer<`${string} ${Quarter}`>,
+    longName: 'string',
 });
 
 export const TermResponse = arrayOf(TermData);


### PR DESCRIPTION
## Summary
- Add Course Level filtering functionality. It's housed in the Advanced Search Options because it doesn't change the URL.
- I've also taken the liberty of moving the Online Classes label to `top` instead of the default (`right`), which fits more cleanly.

![Course Level Demo](https://github.com/icssc/AntAlmanac/assets/100006999/f72613a0-9d00-4432-b5a9-84f1247b8488)
_It's pretty blurry in this GIF, but upon selecting Upper Division Only, returned results are only those between 100 and 199 :D_

-----------------
##  Advanced Search Styling Changes:

Before:
<img width="300" alt="Before Advanced Search Layout" src="https://github.com/icssc/AntAlmanac/assets/100006999/0b310902-7d3d-4af9-8415-948af535167e">

After:
<img width="300" alt="After Advanced Search Layout" src="https://github.com/icssc/AntAlmanac/assets/100006999/30703dfa-32d4-46c0-9255-94ac94cb92b0">

![After Demo Gif](https://github.com/icssc/AntAlmanac/assets/100006999/0dc8f635-abbb-43d1-af73-e014f33b72b2)

I'm a really big fan of the new look with it's left-sided alignment and consistent gap. My main gripe is that MUI doesn't support row-only gap, so the gaps vertically can be a tad much. You can see it happening in the after image to the Room element, which looks a little orphaned. _Worthy tradeoff in my opinion_

## Test Plan
- Make sure it works

## Issues
Closes #627, the successful sibling to #628