### PR TITLE
refactor: schedule selector popover

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 4
+max_line_length = 100

--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -20,7 +20,6 @@
         "lint": "eslint src"
     },
     "dependencies": {
-        "@packages/antalmanac-types": "*",
         "@date-io/date-fns": "^2.16.0",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
@@ -28,9 +27,11 @@
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
         "@material-ui/pickers": "^3.3.10",
+        "@mui/base": "5.0.0-beta.13",
         "@mui/icons-material": "^5.11.0",
         "@mui/lab": "^5.0.0-alpha.118",
         "@mui/material": "^5.11.7",
+        "@packages/antalmanac-types": "*",
         "@react-leaflet/core": "^2.1.0",
         "@tanstack/react-query": "^4.24.4",
         "@trpc/client": "^10.30.0",

--- a/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
@@ -100,7 +100,7 @@ function DeleteScheduleButton(props: { index: number }) {
 
     return (
         <Box>
-            <IconButton onClick={handleOpen} size="small">
+            <IconButton onClick={handleOpen} size="small" disabled={AppStore.schedule.getNumberOfSchedules() === 1}>
                 <DeleteIcon />
             </IconButton>
             <DeleteScheduleDialog fullWidth open={open} index={props.index} onClose={handleClose} />
@@ -188,7 +188,7 @@ function SelectSchedulePopover(props: { scheduleNames: string[] }) {
         <Box>
             <Button
                 size="small"
-                color="inherit"
+                color="secondary"
                 variant="outlined"
                 onClick={handleClick}
                 sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
@@ -313,7 +313,7 @@ function CalendarPaneToolbar(props: CalendarPaneToolbarProps) {
                 <SelectSchedulePopover scheduleNames={scheduleNames} />
                 <Tooltip title="Toggle showing finals schedule">
                     <Button
-                        color={showFinalsSchedule ? 'primary' : 'inherit'}
+                        color={showFinalsSchedule ? 'primary' : 'secondary'}
                         variant={showFinalsSchedule ? 'contained' : 'outlined'}
                         onClick={handleToggleFinals}
                         size="small"

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
@@ -18,7 +18,7 @@ import { isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 
 interface DeleteScheduleDialogProps {
-    onClose: () => void;
+    onClose?: () => void;
     scheduleIndex: number;
 }
 
@@ -36,20 +36,16 @@ const DeleteScheduleDialog = (props: DeleteScheduleDialogProps) => {
     };
 
     const handleDelete = () => {
-        props.onClose();
+        props.onClose?.();
         deleteSchedule(scheduleIndex);
         setIsOpen(false);
     };
 
     return (
         <Box>
-            <MenuItem
-                onClick={handleOpen}
-                disabled={AppStore.schedule.getNumberOfSchedules() === 1}
-                style={{ padding: 'inherit', borderRadius: '50%' }}
-            >
+            <MenuItem onClick={handleOpen} disabled={AppStore.schedule.getNumberOfSchedules() === 1}>
                 <Tooltip title="Delete Schedule">
-                    <IconButton style={{ padding: '0.325rem' }}>
+                    <IconButton size="small">
                         <Clear />
                     </IconButton>
                 </Tooltip>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -1,5 +1,5 @@
+import { forwardRef, useCallback, useState, useMemo } from 'react';
 import {
-    Box,
     Button,
     Dialog,
     DialogActions,
@@ -13,7 +13,6 @@ import {
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Add, Edit } from '@material-ui/icons';
-import React, { forwardRef, useState } from 'react';
 
 import { addSchedule, renameSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
@@ -30,75 +29,91 @@ const styles = () => ({
 interface ScheduleNameDialogProps {
     classes: ClassNameMap;
     onOpen?: () => void;
-    onClose: () => void;
+    onClose?: () => void;
     scheduleNames: string[];
     scheduleRenameIndex?: number;
 }
 
 const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
     const { classes, onOpen, onClose, scheduleNames, scheduleRenameIndex } = props;
-    const rename = scheduleRenameIndex !== undefined;
 
     const [isOpen, setIsOpen] = useState(false);
+
     const [scheduleName, setScheduleName] = useState(
         scheduleRenameIndex !== undefined ? scheduleNames[scheduleRenameIndex] : `Schedule ${scheduleNames.length + 1}`
     );
 
-    const handleOpen: React.MouseEventHandler<HTMLLIElement> = (event) => {
-        // We need to stop propagation so that the select menu won't close
-        event.stopPropagation();
-        setIsOpen(true);
-        if (onOpen) {
-            onOpen();
-        }
-    };
+    const rename = useMemo(() => scheduleRenameIndex !== undefined, [scheduleRenameIndex]);
 
-    const handleCancel = () => {
+    // We need to stop propagation so that the select menu won't close
+    const handleOpen = useCallback(
+        (event: React.MouseEvent) => {
+            event.stopPropagation();
+            setIsOpen(true);
+            onOpen?.();
+        },
+        [onOpen]
+    );
+
+    /**
+     * If the user cancelled renaming the schedule, the schedule name is changed to its original value.
+     * If the user cancelled adding a new schedule, the schedule name is changed to the default schedule name.
+     */
+    const handleCancel = useCallback(() => {
         setIsOpen(false);
-        // If the user cancelled renaming the schedule, the schedule name is changed to its original value;
-        // if the user cancelled adding a new schedule, the schedule name is changed to the default schedule name
-        setScheduleName(rename ? scheduleNames[scheduleRenameIndex] : `Schedule ${scheduleNames.length + 1}`);
-    };
 
-    const handleNameChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        if (scheduleRenameIndex != null) {
+            setScheduleName(rename ? scheduleNames[scheduleRenameIndex] : `Schedule ${scheduleNames.length + 1}`);
+        }
+    }, [rename, scheduleNames, scheduleRenameIndex]);
+
+    const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setScheduleName(event.target.value);
-    };
+    }, []);
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-        event.stopPropagation();
-        if (event.key === 'Enter') {
-            submitName();
-        }
-        if (event.key === 'Escape') {
-            setIsOpen(false);
-        }
-    };
+    const submitName = useCallback(() => {
+        onClose?.();
 
-    const submitName = () => {
-        onClose();
         if (rename) {
             renameSchedule(scheduleName, scheduleRenameIndex as number); // typecast works b/c this function only runs when `const rename = scheduleRenameIndex !== undefined` is true.
         } else {
             addSchedule(scheduleName);
         }
-    };
+
+        setIsOpen(false);
+    }, [onClose, rename, scheduleName, scheduleRenameIndex]);
+
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLDivElement>) => {
+            event.stopPropagation();
+
+            if (event.key === 'Enter') {
+                submitName();
+            }
+
+            if (event.key === 'Escape') {
+                setIsOpen(false);
+            }
+        },
+        [submitName]
+    );
 
     // For the dialog, we need to stop the propagation when a key is pressed because
     // MUI Select components support "select by typing", which can remove focus from the dialog.
     // We also need to stop the propagation when the dialog is clicked because if we don't,
     // both the select menu and dialog will close.
     return (
-        <Box>
+        <>
             {rename ? (
-                <MenuItem onClick={handleOpen} style={{ padding: 'inherit', borderRadius: '50%' }}>
+                <MenuItem onClick={handleOpen}>
                     <Tooltip title="Rename Schedule">
-                        <IconButton style={{ padding: '0.325rem' }}>
+                        <IconButton size="small">
                             <Edit />
                         </IconButton>
                     </Tooltip>
                 </MenuItem>
             ) : (
-                <MenuItem onClick={handleOpen} style={{ paddingTop: '0.75rem', paddingBottom: '0.75rem' }}>
+                <MenuItem onClick={handleOpen}>
                     <Add className={classes.addButton} />
                     Add Schedule
                 </MenuItem>
@@ -112,6 +127,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
                 onClose={() => setIsOpen(false)}
             >
                 <DialogTitle>{rename ? 'Rename Schedule' : 'Add a New Schedule'}</DialogTitle>
+
                 <DialogContent>
                     <TextField
                         // We enable autofocus in order to be consistent with the Save, Load, and Import dialogs
@@ -125,6 +141,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
                         value={scheduleName}
                     />
                 </DialogContent>
+
                 <DialogActions>
                     <Button onClick={handleCancel} color={isDarkMode() ? 'secondary' : 'primary'}>
                         Cancel
@@ -139,7 +156,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
                     </Button>
                 </DialogActions>
             </Dialog>
-        </Box>
+        </>
     );
 });
 

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -18,6 +18,11 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
      */
     const { onKeyDown, ...dialogProps } = props;
 
+    /**
+     * This is destructured separately for memoization.
+     */
+    const { onClose } = props;
+
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const defaultScheduleName = useMemo(() => `Schedule ${scheduleNames.length + 1}`, [scheduleNames]);
@@ -25,9 +30,9 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
     const [name, setName] = useState(defaultScheduleName);
 
     const handleCancel = useCallback(() => {
-        props.onClose?.({}, 'escapeKeyDown');
+        onClose?.({}, 'escapeKeyDown');
         setName(defaultScheduleName);
-    }, [props.onClose, defaultScheduleName]);
+    }, [onClose, defaultScheduleName]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
@@ -35,14 +40,16 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
 
     const submitName = useCallback(() => {
         addSchedule(name);
-        props.onClose?.({}, 'escapeKeyDown');
-    }, [props.onClose, name]);
+        onClose?.({}, 'escapeKeyDown');
+    }, [onClose, name]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
             onKeyDown?.(event);
 
             if (event.key === 'Enter') {
+                event.stopPropagation();
+                event.preventDefault();
                 submitName();
             }
 
@@ -50,7 +57,7 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
                 props.onClose?.({}, 'escapeKeyDown');
             }
         },
-        [props.onClose, submitName]
+        [onClose, submitName, onKeyDown]
     );
 
     const handleScheduleNamesChange = useCallback(() => {

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -8,8 +8,6 @@ type ScheduleNameDialogProps = DialogProps;
 
 /**
  * Dialog with a text field to add a schedule.
- *
- * State like open/closed is managed by the parent component.
  */
 function AddScheduleDialog(props: ScheduleNameDialogProps) {
     /**

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -32,14 +32,11 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
 
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
-    const defaultScheduleName = useMemo(() => `Schedule ${scheduleNames.length + 1}`, [scheduleNames]);
-
-    const [name, setName] = useState(defaultScheduleName);
+    const [name, setName] = useState(`Schedule ${scheduleNames.length + 1}`);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
-        setName(defaultScheduleName);
-    }, [onClose, defaultScheduleName]);
+    }, [onClose]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
@@ -47,6 +44,7 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
 
     const submitName = useCallback(() => {
         addSchedule(name);
+        setName(`Schedule ${AppStore.getScheduleNames().length + 1}`);
         onClose?.({}, 'escapeKeyDown');
     }, [onClose, name]);
 

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -1,36 +1,33 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useMemo } from 'react';
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, type DialogProps } from '@mui/material';
-import { renameSchedule } from '$actions/AppStoreActions';
+import { addSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 
-interface ScheduleNameDialogProps extends DialogProps {
-    /**
-     * The index of the schedule to rename (i.e. in the schedules array).
-     */
-    index: number;
-}
+type ScheduleNameDialogProps = DialogProps
 
-function RenameScheduleDialog(props: ScheduleNameDialogProps) {
-    const { onClose, index, onKeyDown, ...dialogProps } = props;
+function AddScheduleDialog(props: ScheduleNameDialogProps) {
+    const { onClose, onKeyDown, ...dialogProps } = props;
 
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
-    const [name, setName] = useState(scheduleNames[index]);
+    const defaultScheduleName = useMemo(() => `Schedule ${scheduleNames.length + 1}`, [scheduleNames]);
+
+    const [name, setName] = useState(defaultScheduleName);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
-        setName(scheduleNames[index]);
-    }, [onClose, scheduleNames, index]);
+        setName(defaultScheduleName);
+    }, [onClose, defaultScheduleName]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
     }, []);
 
     const submitName = useCallback(() => {
-        renameSchedule(name, index as number);
+        addSchedule(name);
         onClose?.({}, 'escapeKeyDown');
-    }, [onClose, name, index]);
+    }, [onClose, name]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -61,7 +58,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
 
     return (
         <Dialog onKeyDown={handleKeyDown} {...dialogProps}>
-            <DialogTitle>Rename Schedule</DialogTitle>
+            <DialogTitle>Add Schedule</DialogTitle>
 
             <DialogContent>
                 <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
@@ -72,11 +69,11 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
                     Cancel
                 </Button>
                 <Button onClick={submitName} variant="contained" color="primary" disabled={name.trim() === ''}>
-                    Rename Schedule
+                    Add Schedule
                 </Button>
             </DialogActions>
         </Dialog>
     );
 }
 
-export default RenameScheduleDialog;
+export default AddScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useState, useEffect, useMemo } from 'react';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, type DialogProps } from '@mui/material';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    TextField,
+    type DialogProps,
+    Box,
+} from '@mui/material';
 import { addSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
@@ -75,7 +84,9 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
             <DialogTitle>Add Schedule</DialogTitle>
 
             <DialogContent>
-                <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
+                <Box padding={1}>
+                    <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
+                </Box>
             </DialogContent>
 
             <DialogActions>

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -4,10 +4,19 @@ import { addSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 
-type ScheduleNameDialogProps = DialogProps
+type ScheduleNameDialogProps = DialogProps;
 
+/**
+ * Dialog with a text field to add a schedule.
+ *
+ * State like open/closed is managed by the parent component.
+ */
 function AddScheduleDialog(props: ScheduleNameDialogProps) {
-    const { onClose, onKeyDown, ...dialogProps } = props;
+    /**
+     * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.
+     * A custom {@link onKeyDown} handler is provided to handle the Enter and Escape keys.
+     */
+    const { onKeyDown, ...dialogProps } = props;
 
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
@@ -16,9 +25,9 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
     const [name, setName] = useState(defaultScheduleName);
 
     const handleCancel = useCallback(() => {
-        onClose?.({}, 'escapeKeyDown');
+        props.onClose?.({}, 'escapeKeyDown');
         setName(defaultScheduleName);
-    }, [onClose, defaultScheduleName]);
+    }, [props.onClose, defaultScheduleName]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
@@ -26,8 +35,8 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
 
     const submitName = useCallback(() => {
         addSchedule(name);
-        onClose?.({}, 'escapeKeyDown');
-    }, [onClose, name]);
+        props.onClose?.({}, 'escapeKeyDown');
+    }, [props.onClose, name]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -38,10 +47,10 @@ function AddScheduleDialog(props: ScheduleNameDialogProps) {
             }
 
             if (event.key === 'Escape') {
-                onClose?.({}, 'escapeKeyDown');
+                props.onClose?.({}, 'escapeKeyDown');
             }
         },
-        [onClose, submitName]
+        [props.onClose, submitName]
     );
 
     const handleScheduleNamesChange = useCallback(() => {

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -43,6 +43,7 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
 
     const handleDelete = useCallback(() => {
         deleteSchedule(index);
+        onClose?.({}, 'escapeKeyDown');
     }, [index]);
 
     return (

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from 'react';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    type DialogProps,
+} from '@mui/material';
+import { deleteSchedule } from '$actions/AppStoreActions';
+import { isDarkMode } from '$lib/helpers';
+import AppStore from '$stores/AppStore';
+
+interface ScheduleNameDialogProps extends DialogProps {
+    /**
+     * The index of the schedule to rename (i.e. in the schedules array).
+     */
+    index: number;
+}
+
+function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
+    /**
+     * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.
+     */
+    const { index, ...dialogProps } = props;
+
+    /**
+     * This is destructured separately for memoization.
+     */
+    const { onClose } = props;
+
+    const scheduleName = useMemo(() => {
+        return AppStore.schedule.getScheduleName(index);
+    }, [index]);
+
+    const handleCancel = useCallback(() => {
+        onClose?.({}, 'escapeKeyDown');
+    }, [onClose, index]);
+
+    const handleDelete = useCallback(() => {
+        deleteSchedule(index);
+    }, [index]);
+
+    return (
+        <Dialog {...dialogProps}>
+            <DialogTitle>Delete Schedule</DialogTitle>
+
+            <DialogContent>
+                <DialogContentText>Are you sure you want to delete &#34;{scheduleName}&#34;?</DialogContentText>
+            </DialogContent>
+
+            <DialogActions>
+                <Button onClick={handleCancel} color={isDarkMode() ? 'secondary' : 'primary'}>
+                    Cancel
+                </Button>
+                <Button onClick={handleDelete} variant="contained" color="primary">
+                    Delete Schedule
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default DeleteScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -19,6 +19,9 @@ interface ScheduleNameDialogProps extends DialogProps {
     index: number;
 }
 
+/**
+ * Dialog with a prompt to delete the specified schedule.
+ */
 function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
     /**
      * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useState, useEffect } from 'react';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, type DialogProps } from '@mui/material';
+import {
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    TextField,
+    type DialogProps,
+} from '@mui/material';
 import { renameSchedule } from '$actions/AppStoreActions';
 import { isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
@@ -18,37 +27,44 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
      */
     const { index, onKeyDown, ...dialogProps } = props;
 
+    /**
+     * This is destructured separately for memoization.
+     */
+    const { onClose } = props;
+
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const [name, setName] = useState(scheduleNames[index]);
 
     const handleCancel = useCallback(() => {
-        props.onClose?.({}, 'escapeKeyDown');
+        onClose?.({}, 'escapeKeyDown');
         setName(scheduleNames[index]);
-    }, [props.onClose, scheduleNames, index]);
+    }, [onClose, scheduleNames, index]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
     }, []);
 
     const submitName = useCallback(() => {
-        renameSchedule(name, index as number);
-        props.onClose?.({}, 'escapeKeyDown');
-    }, [props.onClose, name, index]);
+        renameSchedule(name, index);
+        onClose?.({}, 'escapeKeyDown');
+    }, [onClose, name, index]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
             onKeyDown?.(event);
 
             if (event.key === 'Enter') {
+                event.preventDefault();
+                event.stopPropagation();
                 submitName();
             }
 
             if (event.key === 'Escape') {
-                props.onClose?.({}, 'escapeKeyDown');
+                onClose?.({}, 'escapeKeyDown');
             }
         },
-        [props.onClose, submitName]
+        [onClose, submitName, onKeyDown]
     );
 
     const handleScheduleNamesChange = useCallback(() => {
@@ -68,7 +84,9 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
             <DialogTitle>Rename Schedule</DialogTitle>
 
             <DialogContent>
-                <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
+                <Box padding={1}>
+                    <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
+                </Box>
             </DialogContent>
 
             <DialogActions>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -12,16 +12,20 @@ interface ScheduleNameDialogProps extends DialogProps {
 }
 
 function RenameScheduleDialog(props: ScheduleNameDialogProps) {
-    const { onClose, index, onKeyDown, ...dialogProps } = props;
+    /**
+     * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.
+     * A custom {@link onKeyDown} handler is provided to handle the Enter and Escape keys.
+     */
+    const { index, onKeyDown, ...dialogProps } = props;
 
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const [name, setName] = useState(scheduleNames[index]);
 
     const handleCancel = useCallback(() => {
-        onClose?.({}, 'escapeKeyDown');
+        props.onClose?.({}, 'escapeKeyDown');
         setName(scheduleNames[index]);
-    }, [onClose, scheduleNames, index]);
+    }, [props.onClose, scheduleNames, index]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
@@ -29,8 +33,8 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
 
     const submitName = useCallback(() => {
         renameSchedule(name, index as number);
-        onClose?.({}, 'escapeKeyDown');
-    }, [onClose, name, index]);
+        props.onClose?.({}, 'escapeKeyDown');
+    }, [props.onClose, name, index]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -41,10 +45,10 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
             }
 
             if (event.key === 'Escape') {
-                onClose?.({}, 'escapeKeyDown');
+                props.onClose?.({}, 'escapeKeyDown');
             }
         },
-        [onClose, submitName]
+        [props.onClose, submitName]
     );
 
     const handleScheduleNamesChange = useCallback(() => {

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useState, useEffect } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, type DialogProps } from '@mui/material';
+import { renameSchedule } from '$actions/AppStoreActions';
+import { isDarkMode } from '$lib/helpers';
+import AppStore from '$stores/AppStore';
+
+interface ScheduleNameDialogProps extends DialogProps {
+    scheduleNames: string[];
+    scheduleRenameIndex: number;
+}
+
+function RenameScheduleDialog(props: ScheduleNameDialogProps) {
+    const { onClose, scheduleRenameIndex, onKeyDown, ...dialogProps } = props;
+
+    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+
+    const [name, setName] = useState(scheduleNames[scheduleRenameIndex]);
+
+    const handleCancel = useCallback(() => {
+        onClose?.({}, 'escapeKeyDown');
+        setName(scheduleNames[scheduleRenameIndex]);
+    }, [onClose, scheduleNames, scheduleRenameIndex]);
+
+    const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setName(event.target.value);
+    }, []);
+
+    const submitName = useCallback(() => {
+        renameSchedule(name, scheduleRenameIndex as number);
+        onClose?.({}, 'escapeKeyDown');
+    }, [onClose, name, scheduleRenameIndex]);
+
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLDivElement>) => {
+            onKeyDown?.(event);
+
+            if (event.key === 'Enter') {
+                submitName();
+            }
+
+            if (event.key === 'Escape') {
+                onClose?.({}, 'escapeKeyDown');
+            }
+        },
+        [onClose, submitName]
+    );
+
+    const handleScheduleNamesChange = useCallback(() => {
+        setScheduleNames(AppStore.getScheduleNames());
+    }, []);
+
+    useEffect(() => {
+        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
+
+        return () => {
+            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
+        };
+    }, [handleScheduleNamesChange]);
+
+    return (
+        <Dialog onKeyDown={handleKeyDown} {...dialogProps}>
+            <DialogTitle>Rename Schedule</DialogTitle>
+
+            <DialogContent>
+                <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
+            </DialogContent>
+
+            <DialogActions>
+                <Button onClick={handleCancel} color={isDarkMode() ? 'secondary' : 'primary'}>
+                    Cancel
+                </Button>
+                <Button onClick={submitName} variant="contained" color="primary" disabled={name.trim() === ''}>
+                    Rename Schedule
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default RenameScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -20,6 +20,9 @@ interface ScheduleNameDialogProps extends DialogProps {
     index: number;
 }
 
+/**
+ * Dialog with a form to rename a schedule.
+ */
 function RenameScheduleDialog(props: ScheduleNameDialogProps) {
     /**
      * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.8.4
       turbo:
         specifier: latest
-        version: 1.10.12
+        version: 1.10.13
 
   apps/antalmanac:
     dependencies:
@@ -47,6 +47,9 @@ importers:
       '@material-ui/pickers':
         specifier: ^3.3.10
         version: 3.3.10(@date-io/core@1.3.13)(@material-ui/core@4.12.4)(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/base':
+        specifier: 5.0.0-beta.13
+        version: 5.0.0-beta.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: ^5.11.0
         version: 5.11.9(@mui/material@5.11.10)(@types/react@18.0.28)(react@18.2.0)
@@ -370,10 +373,10 @@ importers:
         version: 10.17.27
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.54.1
-        version: 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.38.0)(typescript@5.1.6)
+        version: 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.38.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: ^5.54.1
-        version: 5.57.1(eslint@8.38.0)(typescript@5.1.6)
+        version: 5.57.1(eslint@8.38.0)(typescript@5.2.2)
       aws-cdk:
         specifier: ^2.66.1
         version: 2.66.1
@@ -391,10 +394,10 @@ importers:
         version: 2.8.4
       ts-node:
         specifier: ^9.0.0
-        version: 9.1.1(typescript@5.1.6)
+        version: 9.1.1(typescript@5.2.2)
       typescript:
         specifier: latest
-        version: 5.1.6
+        version: 5.2.2
 
   packages/peterportal-schemas:
     dependencies:
@@ -1411,6 +1414,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
+  /@babel/runtime@7.22.11:
+    resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: false
+
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
@@ -1510,8 +1520,18 @@ packages:
       '@emotion/memoize': 0.8.0
     dev: false
 
+  /@emotion/is-prop-valid@1.2.1:
+    resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+    dev: false
+
   /@emotion/memoize@0.8.0:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
+    dev: false
+
+  /@emotion/memoize@0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
 
   /@emotion/react@11.10.6(@types/react@18.0.28)(react@18.2.0):
@@ -2059,6 +2079,34 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@floating-ui/core@1.4.1:
+    resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
+    dependencies:
+      '@floating-ui/utils': 0.1.1
+    dev: false
+
+  /@floating-ui/dom@1.5.1:
+    resolution: {integrity: sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==}
+    dependencies:
+      '@floating-ui/core': 1.4.1
+      '@floating-ui/utils': 0.1.1
+    dev: false
+
+  /@floating-ui/react-dom@2.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@floating-ui/utils@0.1.1:
+    resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
+    dev: false
+
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -2345,6 +2393,31 @@ packages:
       react-is: 18.2.0
     dev: false
 
+  /@mui/base@5.0.0-beta.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uC0l97pBspfDAp+iz2cJq8YZ8Sd9i73V77+WzUiOAckIVEyCm5dyVDZCCO2/phmzckVEeZCGcytybkjMQuhPQw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@emotion/is-prop-valid': 1.2.1
+      '@floating-ui/react-dom': 2.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@mui/types': 7.2.4(@types/react@18.0.28)
+      '@mui/utils': 5.14.7(react@18.2.0)
+      '@popperjs/core': 2.11.8
+      '@types/react': 18.0.28
+      clsx: 2.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+    dev: false
+
   /@mui/core-downloads-tracker@5.11.9:
     resolution: {integrity: sha512-YGEtucQ/Nl91VZkzYaLad47Cdui51n/hW+OQm4210g4N3/nZzBxmGeKfubEalf+ShKH4aYDS86XTO6q/TpZnjQ==}
     dev: false
@@ -2516,6 +2589,17 @@ packages:
       '@types/react': 18.0.28
     dev: false
 
+  /@mui/types@7.2.4(@types/react@18.0.28):
+    resolution: {integrity: sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==}
+    peerDependencies:
+      '@types/react': '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.0.28
+    dev: false
+
   /@mui/utils@5.11.9(react@18.2.0):
     resolution: {integrity: sha512-eOJaqzcEs4qEwolcvFAmXGpln+uvouvOS9FUX6Wkrte+4I8rZbjODOBDVNlK+V6/ziTfD4iNKC0G+KfOTApbqg==}
     engines: {node: '>=12.0.0'}
@@ -2525,6 +2609,20 @@ packages:
       '@babel/runtime': 7.20.13
       '@types/prop-types': 15.7.5
       '@types/react-is': 17.0.3
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 18.2.0
+    dev: false
+
+  /@mui/utils@5.14.7(react@18.2.0):
+    resolution: {integrity: sha512-RtheP/aBoPogVdi8vj8Vo2IFnRa4mZVmnD0RGlVZ49yF60rZs+xP4/KbpIrTr83xVs34QmHQ2aQ+IX7I0a0dDw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@types/prop-types': 15.7.5
+      '@types/react-is': 18.2.1
       prop-types: 15.8.1
       react: 18.2.0
       react-is: 18.2.0
@@ -2553,6 +2651,10 @@ packages:
 
   /@popperjs/core@2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
+    dev: false
+
+  /@popperjs/core@2.11.8:
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
   /@react-leaflet/core@2.1.0(leaflet@1.9.3)(react-dom@18.2.0)(react@18.2.0):
@@ -2968,6 +3070,12 @@ packages:
       '@types/react': 18.0.28
     dev: false
 
+  /@types/react-is@18.2.1:
+    resolution: {integrity: sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==}
+    dependencies:
+      '@types/react': 18.0.28
+    dev: false
+
   /@types/react-lazyload@3.2.0:
     resolution: {integrity: sha512-4+r+z8Cf7L/mgxA1vl5uHx5GS/8gY2jqq2p5r5WCm+nUsg9KilwQ+8uaJA3EUlLj57AOzOfGGwwRJ5LOVl8fwA==}
     dependencies:
@@ -3101,7 +3209,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.38.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.38.0)(typescript@5.2.2):
     resolution: {integrity: sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3113,18 +3221,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.57.1(eslint@8.38.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.38.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.57.1
-      '@typescript-eslint/type-utils': 5.57.1(eslint@8.38.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.38.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 5.57.1(eslint@8.38.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.38.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.38.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3169,7 +3277,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.57.1(eslint@8.38.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@5.57.1(eslint@8.38.0)(typescript@5.2.2):
     resolution: {integrity: sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3181,10 +3289,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.38.0
-      typescript: 5.1.6
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3237,7 +3345,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.57.1(eslint@8.38.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@5.57.1(eslint@8.38.0)(typescript@5.2.2):
     resolution: {integrity: sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3247,12 +3355,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.38.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.38.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.38.0
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3283,7 +3391,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.57.1(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@5.57.1(typescript@5.2.2):
     resolution: {integrity: sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3298,8 +3406,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3344,7 +3452,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.57.1(eslint@8.38.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.57.1(eslint@8.38.0)(typescript@5.2.2):
     resolution: {integrity: sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3355,7 +3463,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.2.2)
       eslint: 8.38.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -3865,6 +3973,11 @@ packages:
 
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
     dev: false
 
@@ -6923,6 +7036,10 @@ packages:
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: false
+
   /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -7443,7 +7560,7 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
-  /ts-node@9.1.1(typescript@5.1.6):
+  /ts-node@9.1.1(typescript@5.2.2):
     resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
@@ -7455,7 +7572,7 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.21
-      typescript: 5.1.6
+      typescript: 5.2.2
       yn: 3.1.1
     dev: true
 
@@ -7490,14 +7607,14 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /tsutils@3.21.0(typescript@5.1.6):
+  /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.6
+      typescript: 5.2.2
     dev: true
 
   /tsx@3.12.7:
@@ -7511,65 +7628,64 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /turbo-darwin-64@1.10.12:
-    resolution: {integrity: sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==}
+  /turbo-darwin-64@1.10.13:
+    resolution: {integrity: sha512-vmngGfa2dlYvX7UFVncsNDMuT4X2KPyPJ2Jj+xvf5nvQnZR/3IeDEGleGVuMi/hRzdinoxwXqgk9flEmAYp0Xw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.10.12:
-    resolution: {integrity: sha512-3JliEESLNX2s7g54SOBqqkqJ7UhcOGkS0ywMr5SNuvF6kWVTbuUq7uBU/sVbGq8RwvK1ONlhPvJne5MUqBCTCQ==}
+  /turbo-darwin-arm64@1.10.13:
+    resolution: {integrity: sha512-eMoJC+k7gIS4i2qL6rKmrIQGP6Wr9nN4odzzgHFngLTMimok2cGLK3qbJs5O5F/XAtEeRAmuxeRnzQwTl/iuAw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.10.12:
-    resolution: {integrity: sha512-siYhgeX0DidIfHSgCR95b8xPee9enKSOjCzx7EjTLmPqPaCiVebRYvbOIYdQWRqiaKh9yfhUtFmtMOMScUf1gg==}
+  /turbo-linux-64@1.10.13:
+    resolution: {integrity: sha512-0CyYmnKTs6kcx7+JRH3nPEqCnzWduM0hj8GP/aodhaIkLNSAGAa+RiYZz6C7IXN+xUVh5rrWTnU2f1SkIy7Gdg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.10.12:
-    resolution: {integrity: sha512-K/ZhvD9l4SslclaMkTiIrnfcACgos79YcAo4kwc8bnMQaKuUeRpM15sxLpZp3xDjDg8EY93vsKyjaOhdFG2UbA==}
+  /turbo-linux-arm64@1.10.13:
+    resolution: {integrity: sha512-0iBKviSGQQlh2OjZgBsGjkPXoxvRIxrrLLbLObwJo3sOjIH0loGmVIimGS5E323soMfi/o+sidjk2wU1kFfD7Q==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.10.12:
-    resolution: {integrity: sha512-7FSgSwvktWDNOqV65l9AbZwcoueAILeE4L7JvjauNASAjjbuzXGCEq5uN8AQU3U5BOFj4TdXrVmO2dX+lLu8Zg==}
+  /turbo-windows-64@1.10.13:
+    resolution: {integrity: sha512-S5XySRfW2AmnTeY1IT+Jdr6Goq7mxWganVFfrmqU+qqq3Om/nr0GkcUX+KTIo9mPrN0D3p5QViBRzulwB5iuUQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.10.12:
-    resolution: {integrity: sha512-gCNXF52dwom1HLY9ry/cneBPOKTBHhzpqhMylcyvJP0vp9zeMQQkt6yjYv+6QdnmELC92CtKNp2FsNZo+z0pyw==}
+  /turbo-windows-arm64@1.10.13:
+    resolution: {integrity: sha512-nKol6+CyiExJIuoIc3exUQPIBjP9nIq5SkMJgJuxsot2hkgGrafAg/izVDRDrRduQcXj2s8LdtxJHvvnbI8hEQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.10.12:
-    resolution: {integrity: sha512-WM3+jTfQWnB9W208pmP4oeehZcC6JQNlydb/ZHMRrhmQa+htGhWLCzd6Q9rLe0MwZLPpSPFV2/bN5egCLyoKjQ==}
+  /turbo@1.10.13:
+    resolution: {integrity: sha512-vOF5IPytgQPIsgGtT0n2uGZizR2N3kKuPIn4b5p5DdeLoI0BV7uNiydT7eSzdkPRpdXNnO8UwS658VaI4+YSzQ==}
     hasBin: true
-    requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.12
-      turbo-darwin-arm64: 1.10.12
-      turbo-linux-64: 1.10.12
-      turbo-linux-arm64: 1.10.12
-      turbo-windows-64: 1.10.12
-      turbo-windows-arm64: 1.10.12
+      turbo-darwin-64: 1.10.13
+      turbo-darwin-arm64: 1.10.13
+      turbo-linux-64: 1.10.13
+      turbo-linux-arm64: 1.10.13
+      turbo-windows-64: 1.10.13
+      turbo-windows-arm64: 1.10.13
     dev: true
 
   /type-check@0.4.0:
@@ -7611,8 +7727,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
# Summary
Implemented the schedule selector properly with a popover component. Using a popover instead of an autocomplete or select component gives us more flexibility in customizing how it works in the future, i.e. with re-ordering drag-and-drop, etc.

## TODO (after merging)
Verify and remove the following files -- they should be extraneous.
This can be done as the "noop" commit after this is merged.

- The directory `apps/antalamanc/src/components/Calendar/Toolbar/EditSchedule`

