### PR TITLE
Fix Light Mode Coloring

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
@@ -30,6 +30,7 @@ import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
 import DeleteScheduleDialog from '$components/dialogs/DeleteSchedule';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import AppStore from '$stores/AppStore';
+import { isDarkMode } from '$lib/helpers';
 
 function handleScheduleChange(index: number) {
     logAnalytics({
@@ -55,7 +56,7 @@ function handleUndo() {
     });
     undoDelete(null);
 }
-    
+
 function handleClearSchedule() {
     if (window.confirm('Are you sure you want to clear this schedule?')) {
         clearSchedules();
@@ -188,7 +189,7 @@ function SelectSchedulePopover(props: { scheduleNames: string[] }) {
         <Box>
             <Button
                 size="small"
-                color="secondary"
+                color={isDarkMode() ? 'secondary' : 'inherit'}
                 variant="outlined"
                 onClick={handleClick}
                 sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
@@ -313,7 +314,7 @@ function CalendarPaneToolbar(props: CalendarPaneToolbarProps) {
                 <SelectSchedulePopover scheduleNames={scheduleNames} />
                 <Tooltip title="Toggle showing finals schedule">
                     <Button
-                        color={showFinalsSchedule ? 'primary' : 'secondary'}
+                        color={showFinalsSchedule ? 'primary' : isDarkMode() ? 'secondary' : 'inherit'}
                         variant={showFinalsSchedule ? 'contained' : 'outlined'}
                         onClick={handleToggleFinals}
                         size="small"

--- a/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
@@ -30,7 +30,6 @@ import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
 import DeleteScheduleDialog from '$components/dialogs/DeleteSchedule';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import AppStore from '$stores/AppStore';
-import { isDarkMode } from '$lib/helpers';
 
 function handleScheduleChange(index: number) {
     logAnalytics({
@@ -189,7 +188,7 @@ function SelectSchedulePopover(props: { scheduleNames: string[] }) {
         <Box>
             <Button
                 size="small"
-                color={isDarkMode() ? 'secondary' : 'inherit'}
+                color="inherit"
                 variant="outlined"
                 onClick={handleClick}
                 sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
@@ -314,7 +313,7 @@ function CalendarPaneToolbar(props: CalendarPaneToolbarProps) {
                 <SelectSchedulePopover scheduleNames={scheduleNames} />
                 <Tooltip title="Toggle showing finals schedule">
                     <Button
-                        color={showFinalsSchedule ? 'primary' : isDarkMode() ? 'secondary' : 'inherit'}
+                        color={showFinalsSchedule ? 'primary' : 'inherit'}
                         variant={showFinalsSchedule ? 'contained' : 'outlined'}
                         onClick={handleToggleFinals}
                         size="small"

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -11,7 +11,6 @@ import CustomEventDetailView from './CustomEventDetailView';
 import { clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import AppStore from '$stores/AppStore';
-import { isDarkMode } from '$lib/helpers';
 
 const styles = {
     container: {
@@ -171,11 +170,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         <PopupState variant="popover">
                             {(popupState) => (
                                 <>
-                                    <Button
-                                        variant="outlined"
-                                        color={isDarkMode() ? 'secondary' : 'inherit'}
-                                        {...bindTrigger(popupState)}
-                                    >
+                                    <Button variant="outlined" color="inherit" {...bindTrigger(popupState)}>
                                         Copy Schedule
                                     </Button>
                                     <Menu {...bindMenu(popupState)}>
@@ -208,7 +203,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         <Button
                             className={this.props.classes.clearSchedule}
                             variant="outlined"
-                            color={isDarkMode() ? 'secondary' : 'inherit'}
+                            color="inherit"
                             onClick={() => {
                                 if (
                                     window.confirm(

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -11,6 +11,7 @@ import CustomEventDetailView from './CustomEventDetailView';
 import { clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import AppStore from '$stores/AppStore';
+import { isDarkMode } from '$lib/helpers';
 
 const styles = {
     container: {
@@ -170,7 +171,11 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         <PopupState variant="popover">
                             {(popupState) => (
                                 <>
-                                    <Button variant="outlined" {...bindTrigger(popupState)}>
+                                    <Button
+                                        variant="outlined"
+                                        color={isDarkMode() ? 'secondary' : 'inherit'}
+                                        {...bindTrigger(popupState)}
+                                    >
                                         Copy Schedule
                                     </Button>
                                     <Menu {...bindMenu(popupState)}>
@@ -203,7 +208,7 @@ class AddedCoursePane extends PureComponent<AddedCoursePaneProps, AddedCoursePan
                         <Button
                             className={this.props.classes.clearSchedule}
                             variant="outlined"
-                            color="secondary"
+                            color={isDarkMode() ? 'secondary' : 'inherit'}
                             onClick={() => {
                                 if (
                                     window.confirm(


### PR DESCRIPTION
## Summary
Schedule Dropdown, Finals Button, and Clear Schedule did not have the correct `isDarkMode()` ternary applied to them to give them proper light mode colors.

## Test Plan
Only styling changes, make sure everything is correctly viewable on light mode

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
