### PR TITLE
SearchForm: toggle between Fuzzy vs. Manual search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/DeptSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/DeptSearchBar.tsx
@@ -50,15 +50,15 @@ class DeptSearchBar extends PureComponent<DeptSearchBarProps, DeptSearchBarState
     }
 
     getDeptValue() {
-      return RightPaneStore.getUrlDeptValue().trim() 
-        ? this.updatedeptValueAndGetFormData() 
-        : RightPaneStore.getFormData().deptValue
+        return RightPaneStore.getUrlDeptValue().trim()
+            ? this.updatedeptValueAndGetFormData()
+            : RightPaneStore.getFormData().deptValue;
     }
 
     getDeptLabel() {
-      return RightPaneStore.getUrlDeptLabel().trim() 
-        ? this.updatedeptLabelAndGetFormData()
-        : RightPaneStore.getFormData().deptLabel;
+        return RightPaneStore.getUrlDeptLabel().trim()
+            ? this.updatedeptLabelAndGetFormData()
+            : RightPaneStore.getFormData().deptLabel;
     }
 
     constructor(props: DeptSearchBarProps) {
@@ -67,7 +67,7 @@ class DeptSearchBar extends PureComponent<DeptSearchBarProps, DeptSearchBarState
         let favorites: Department[] = [];
         if (typeof Storage !== 'undefined') {
             const locallyStoredFavorites = window.localStorage.getItem('favorites');
-            favorites = locallyStoredFavorites != null ? (JSON.parse(locallyStoredFavorites)) : [];
+            favorites = locallyStoredFavorites != null ? JSON.parse(locallyStoredFavorites) : [];
         }
         this.state = {
             value: {
@@ -159,7 +159,9 @@ class DeptSearchBar extends PureComponent<DeptSearchBarProps, DeptSearchBarState
                     includeInputInList={true}
                     noOptionsText="No departments match the search"
                     groupBy={(dept) => (dept.isFavorite ? 'Recent Departments' : 'Departments')}
-                    renderInput={(params) => <TextField {...params} label="Department" />}
+                    renderInput={(params) => (
+                        <TextField {...params} label="Department" type="search" InputLabelProps={{ shrink: true }} />
+                    )}
                 />
             </div>
         );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -82,20 +82,23 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                             changeState={(field: string, value: string) => RightPaneStore.updateFormValue(field, value)}
                             fieldName={'term'}
                         />
+                        <Tooltip title="Manual Search">
+                            <IconButton onClick={toggleShowLegacySearch}>
+                                <Tune />
+                            </IconButton>
+                        </Tooltip>
                     </div>
 
-                    <div className={classes.container}>
-                        <div className={classes.searchBar}>
-                            <FuzzySearch toggleSearch={toggleSearch} toggleShowLegacySearch={toggleShowLegacySearch} />
-                            <Tooltip title="Manual Search">
-                                <IconButton onClick={toggleShowLegacySearch}>
-                                    <Tune />
-                                </IconButton>
-                            </Tooltip>
+                    {!showLegacySearch ? (
+                        <div className={classes.container}>
+                            <div className={classes.searchBar}>
+                                <FuzzySearch
+                                    toggleSearch={toggleSearch}
+                                    toggleShowLegacySearch={toggleShowLegacySearch}
+                                />
+                            </div>
                         </div>
-                    </div>
-
-                    {showLegacySearch && (
+                    ) : (
                         <LegacySearch
                             onSubmit={() => {
                                 logAnalytics({

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -82,7 +82,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                             changeState={(field: string, value: string) => RightPaneStore.updateFormValue(field, value)}
                             fieldName={'term'}
                         />
-                        <Tooltip title="Manual Search">
+                        <Tooltip title="Toggle Manual Search">
                             <IconButton onClick={toggleShowLegacySearch}>
                                 <Tune />
                             </IconButton>


### PR DESCRIPTION
## Summary
1. `SearchForm.tsx` will now conditionally render the Fuzzy Search (Autocomplete) and the Manual (legacy) searches based on the condition `isLegacySearch` 
2. I also took the liberty of making that damn Department label stop animating every time Manual Search is opened

![Toggle Manual Search](https://github.com/icssc/AntAlmanac/assets/100006999/bf7a9307-7230-489c-ad82-b6d731b5ecaa)

## Test Plan
1. No "serious" code changes, just make sure it still works right

## Issues
Closes #680

<!-- [Optional]
## Future Followup
-->
