### PR TITLE
Fix helper function: removeDuplicateMeetings

### DIFF
--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -190,7 +190,9 @@ function removeDuplicateMeetings(websocResp: WebsocAPIResponse): WebsocAPIRespon
 
                         for (let i = 0; i < existingMeetings.length; i++) {
                             const sameDayAndTime =
-                                meeting.days === existingMeetings[i].days && meeting.time === existingMeetings[i].time;
+                                meeting.days === existingMeetings[i].days &&
+                                meeting.startTime === existingMeetings[i].startTime &&
+                                meeting.endTime === existingMeetings[i].endTime;
                             const sameBuilding = meeting.bldg === existingMeetings[i].bldg;
 
                             //This shouldn't be possible because there shouldn't be duplicate locations in a section
@@ -202,8 +204,10 @@ function removeDuplicateMeetings(websocResp: WebsocAPIResponse): WebsocAPIRespon
                             // Add the building to existing meeting instead of creating a new one
                             if (sameDayAndTime && !sameBuilding) {
                                 existingMeetings[i] = {
+                                    timeIsTBA: existingMeetings[i].timeIsTBA,
                                     days: existingMeetings[i].days,
-                                    time: existingMeetings[i].time,
+                                    startTime: existingMeetings[i].startTime,
+                                    endTime: existingMeetings[i].endTime,
                                     bldg: [existingMeetings[i].bldg + ' & ' + meeting.bldg],
                                 };
                                 isNewMeeting = false;


### PR DESCRIPTION
## Summary
Overlooked `removeDuplicateMeetings` in `helpers.ts`, now it has the correct properties and types. I'm guessing that it wasn't caught in testing mainly because courses at the same time but at different buildings are pretty rare.

## Test Plan
Does everything work?

## Issues
Closes #

## Future Followup
On the topic of `removeDuplicateMeetings`, I'm wondering if this note still applies, or if the API now handles this issue.
>    //The data from the API will duplicate a section if it has multiple locations.
>    //I.e., if there's a Tuesday section in two different (probably adjoined) rooms,
>    //courses[i].sections[j].meetings will have two entries, despite it being the same section.
>    //For now, I'm correcting it with removeDuplicateMeetings, but the API should handle this

