### PR TITLE
fix: conflicting concurrency group with testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 concurrency:
-    group: ${{ github.head_ref }}
+    group: ${{ github.head_ref }}-test
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Summary
The testing workflow has the exact same concurrency group as the staging PR workflow. Just make them distinct and both can deploy at the same time.