### PR TITLE
Syncing fork changes for multiple buildings (#696-a)

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -69,30 +69,28 @@ const AntAlmanacEvent =
     ({ classes }: { classes: ClassNameMap }) =>
     // eslint-disable-next-line react/display-name
     ({ event }: { event: CalendarEvent }) => {
-        if (!event.isCustomEvent)
-            return (
-                <div>
-                    <div className={classes.firstLineContainer}>
-                        <div> {event.title}</div>
-                        <div className={classes.sectionType}> {event.sectionType}</div>
-                    </div>
-                    <div className={classes.secondLineContainer}>
-                        <div>
-                            {event.bldg.length > 1
-                                ? `${event.bldg.length} Locations`
-                                : `${event.bldg[0].building} ${event.bldg[0].room}`}
-                        </div>
-                        <div>{event.sectionCode}</div>
-                    </div>
+        return event.isCustomEvent ? (
+            <div className={classes.customEventContainer}>
+                <div className={classes.customEventTitle}>{event.title}</div>
+            </div>
+        ) : (
+            <div>
+                <div className={classes.firstLineContainer}>
+                    <div> {event.title}</div>
+                    <div className={classes.sectionType}> {event.sectionType}</div>
                 </div>
-            );
-        else {
-            return (
-                <div className={classes.customEventContainer}>
-                    <div className={classes.customEventTitle}>{event.title}</div>
+                <div className={classes.secondLineContainer}>
+                    <div>
+                        {event.showLocationInfo
+                            ? event.locations.map((location) => `${location.building} ${location.room}`).join(', ')
+                            : event.locations.length > 1
+                            ? `${event.locations.length} Locations`
+                            : `${event.locations[0].building} ${event.locations[0].room}`}
+                    </div>
+                    <div>{event.sectionCode}</div>
                 </div>
-            );
-        }
+            </div>
+        );
     };
 interface ScheduleCalendarProps {
     classes: ClassNameMap;

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -106,7 +106,8 @@ export interface Location {
 }
 
 export interface CourseEvent extends CommonCalendarEvent {
-    bldg: Location[];
+    locations: Location[];
+    showLocationInfo: boolean;
     finalExam: {
         examStatus: 'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL';
         dayOfWeek: 'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null;
@@ -120,7 +121,7 @@ export interface CourseEvent extends CommonCalendarEvent {
             hour: number;
             minute: number;
         } | null;
-        bldg: string[] | null;
+        locations: Location[] | null;
     };
     courseTitle: string;
     instructors: string[];
@@ -177,7 +178,8 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     const { classes, courseInMoreInfo } = props;
 
     if (!courseInMoreInfo.isCustomEvent) {
-        const { term, instructors, sectionCode, title, finalExam, bldg, sectionType } = courseInMoreInfo;
+        console.log(courseInMoreInfo);
+        const { term, instructors, sectionCode, title, finalExam, locations, sectionType } = courseInMoreInfo;
 
         let finalExamString = '';
 
@@ -186,9 +188,11 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         } else if (finalExam.examStatus == 'TBA_FINAL') {
             finalExamString = 'Final TBA';
         } else {
-            if (finalExam.startTime && finalExam.endTime && finalExam.month && finalExam.bldg) {
+            if (finalExam.startTime && finalExam.endTime && finalExam.month && finalExam.locations) {
                 const timeString = translate24To12HourTime(finalExam.startTime, finalExam.endTime);
-                const locationString = `at ${finalExam.bldg.join(', ')}`;
+                const locationString = `at ${finalExam.locations
+                    .map((location) => `${location.building} ${location.room}`)
+                    .join(', ')}`;
                 const finalExamMonth = MONTHS[finalExam.month];
 
                 finalExamString = `${finalExam.dayOfWeek} ${finalExamMonth} ${finalExam.day} ${timeString} ${locationString}`;
@@ -244,9 +248,9 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                             <td className={`${classes.multiline} ${classes.rightCells}`}>{instructors.join('\n')}</td>
                         </tr>
                         <tr>
-                            <td className={classes.alignToTop}>Location{bldg.length > 1 && 's'}</td>
+                            <td className={classes.alignToTop}>Location{locations.length > 1 && 's'}</td>
                             <td className={`${classes.multiline} ${classes.rightCells}`}>
-                                {bldg.map((location) => (
+                                {locations.map((location) => (
                                     <div key={`${sectionCode} @ ${location.building} ${location.room}`}>
                                         <Link
                                             className={classes.clickableLocation}

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -178,7 +178,6 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     const { classes, courseInMoreInfo } = props;
 
     if (!courseInMoreInfo.isCustomEvent) {
-        console.log(courseInMoreInfo);
         const { term, instructors, sectionCode, title, finalExam, locations, sectionType } = courseInMoreInfo;
 
         let finalExamString = '';

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -49,9 +49,6 @@ export function getCoursesPerBuilding() {
         (buildingCode) => buildingCatalogue[locationIds[buildingCode]] != null
     );
 
-    console.log(validBuildingCodes);
-    console.log(courseEvents);
-
     const coursesPerBuilding: Record<string, (CourseEvent & Building & MarkerContent)[]> = {};
 
     validBuildingCodes.forEach((buildingCode) => {

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -73,7 +73,6 @@ export function getCoursesPerBuilding() {
                 return markerData;
             });
     });
-    console.log(coursesPerBuilding);
 
     return coursesPerBuilding;
 }

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -41,9 +41,7 @@ interface MarkerContent {
 export function getCoursesPerBuilding() {
     const courseEvents = AppStore.getCourseEventsInCalendar();
 
-    const allBuildingCodes = courseEvents
-        .map((event) => event.bldg.map((location) => location.building))
-        courseEvents.flatMap(event => event.bldg.map(location => location.building))
+    const allBuildingCodes = courseEvents.flatMap((event) => event.locations.map((location) => location.building));
 
     const uniqueBuildingCodes = new Set(allBuildingCodes);
 
@@ -51,14 +49,17 @@ export function getCoursesPerBuilding() {
         (buildingCode) => buildingCatalogue[locationIds[buildingCode]] != null
     );
 
+    console.log(validBuildingCodes);
+    console.log(courseEvents);
+
     const coursesPerBuilding: Record<string, (CourseEvent & Building & MarkerContent)[]> = {};
 
     validBuildingCodes.forEach((buildingCode) => {
         coursesPerBuilding[buildingCode] = courseEvents
-            .filter((event) => event.bldg.map((bldg) => bldg.building).includes(buildingCode))
+            .filter((event) => event.locations.map((location) => location.building).includes(buildingCode))
             .map((event) => {
                 const locationData = buildingCatalogue[locationIds[buildingCode]];
-                const key = `${event.title} ${event.sectionType} @ ${event.bldg}`;
+                const key = `${event.title} ${event.sectionType} @ ${event.locations[0]}`;
                 const acronym = locationData.name.substring(
                     locationData.name.indexOf('(') + 1,
                     locationData.name.indexOf(')')
@@ -75,6 +76,8 @@ export function getCoursesPerBuilding() {
                 return markerData;
             });
     });
+    console.log(coursesPerBuilding);
+
     return coursesPerBuilding;
 }
 
@@ -254,10 +257,12 @@ export default function CourseMap() {
                     // TODO Handle multiple buildings between class comparisons on markers.
                     const coursesSameBuildingPrior = markersToDisplay
                         .slice(0, index)
-                        .filter((m) => m.bldg.map((location) => location.building).includes(marker.bldg[0].building));
+                        .filter((m) =>
+                            m.locations.map((location) => location.building).includes(marker.locations[0].building)
+                        );
 
-                    const allRoomsInBuilding = marker.bldg
-                        .filter((location) => location.building == marker.bldg[0].building)
+                    const allRoomsInBuilding = marker.locations
+                        .filter((location) => location.building == marker.locations[0].building)
                         .reduce((roomList, location) => [...roomList, location.room], [] as string[]);
 
                     return (
@@ -272,7 +277,7 @@ export default function CourseMap() {
                                         Class: {marker.title} {marker.sectionType}
                                     </Typography>
                                     <Typography variant="body2">
-                                        Room{allRoomsInBuilding.length > 1 && 's'}: {marker.bldg[0].building}{' '}
+                                        Room{allRoomsInBuilding.length > 1 && 's'}: {marker.locations[0].building}{' '}
                                         {allRoomsInBuilding.join('/')}
                                     </Typography>
                                 </Box>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -201,19 +201,24 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
-                const [buildingName = ''] = meeting.bldg[0].split(' ');
-                const buildingId = locationIds[buildingName];
+                console.log(meeting);
                 return meeting.bldg[0] !== 'TBA' ? (
-                    <Fragment key={meeting.timeIsTBA + meeting.bldg[0]}>
-                        <Link
-                            className={classes.clickableLocation}
-                            to={`/map?location=${buildingId}`}
-                            onClick={focusMap}
-                        >
-                            {meeting.bldg}
-                        </Link>
-                        <br />
-                    </Fragment>
+                    meeting.bldg.map((bldg) => {
+                        const [buildingName = ''] = bldg.split(' ');
+                        const buildingId = locationIds[buildingName];
+                        return (
+                            <Fragment key={meeting.timeIsTBA + bldg}>
+                                <Link
+                                    className={classes.clickableLocation}
+                                    to={`/map?location=${buildingId}`}
+                                    onClick={focusMap}
+                                >
+                                    {bldg}
+                                </Link>
+                                <br />
+                            </Fragment>
+                        );
+                    })
                 ) : (
                     <Box>{meeting.bldg}</Box>
                 );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -201,7 +201,6 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
-                console.log(meeting);
                 return meeting.bldg[0] !== 'TBA' ? (
                     meeting.bldg.map((bldg) => {
                         const [buildingName = ''] = bldg.split(' ');

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -8,8 +8,8 @@ const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 
 const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
-export function getBuilding(bldg: string): Location {
-    const [building = '', room = ''] = bldg.split(' ');
+export function getLocation(location: string): Location {
+    const [building = '', room = ''] = location.split(' ');
     return { building, room };
 }
 
@@ -39,19 +39,24 @@ export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): 
                     .map((day, index) => (day ? index : undefined))
                     .filter(notNull);
 
+                // Intermediate formatting to subtract `bldg` attribute in favor of `locations`
+                const { bldg: _, ...finalExam } = course.section.finalExam;
+                finalExam.locations = course.section.finalExam.bldg?.map(getLocation);
+
                 return dayIndicesOccurring.map((dayIndex) => {
                     return {
                         color: course.section.color,
                         term: course.term,
                         title: `${course.deptCode} ${course.courseNumber}`,
                         courseTitle: course.courseTitle,
-                        bldg: meeting.bldg.map(getBuilding),
+                        locations: meeting.bldg.map(getLocation),
+                        showLocationInfo: false,
                         instructors: course.section.instructors,
                         sectionCode: course.section.sectionCode,
                         sectionType: course.section.sectionType,
                         start: new Date(2018, 0, dayIndex, startHour, startMin),
                         end: new Date(2018, 0, dayIndex, endHour, endMin),
-                        finalExam: course.section.finalExam,
+                        finalExam,
                         isCustomEvent: false,
                     };
                 });
@@ -89,22 +94,23 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              */
             const dayIndicesOcurring = weekdaysOccurring.map((day, index) => (day ? index : undefined)).filter(notNull);
 
-            return dayIndicesOcurring.map((dayIndex) => {
-                return {
-                    color: course.section.color,
-                    term: course.term,
-                    title: `${course.deptCode} ${course.courseNumber}`,
-                    courseTitle: course.courseTitle,
-                    bldg: course.section.meetings[0].bldg.map(getBuilding),
-                    instructors: course.section.instructors,
-                    sectionCode: course.section.sectionCode,
-                    sectionType: 'Fin',
-                    start: new Date(2018, 0, dayIndex - 1, startHour, startMin),
-                    end: new Date(2018, 0, dayIndex - 1, endHour, endMin),
-                    finalExam: course.section.finalExam,
-                    isCustomEvent: false,
-                };
-            });
+            return dayIndicesOcurring.map((dayIndex) => ({
+                color: course.section.color,
+                term: course.term,
+                title: `${course.deptCode} ${course.courseNumber}`,
+                courseTitle: course.courseTitle,
+                locations: finalExam.bldg
+                    ? finalExam.bldg.map(getLocation)
+                    : course.section.meetings[0].bldg.map(getLocation),
+                showLocationInfo: true,
+                instructors: course.section.instructors,
+                sectionCode: course.section.sectionCode,
+                sectionType: 'Fin',
+                start: new Date(2018, 0, dayIndex - 1, startHour, startMin),
+                end: new Date(2018, 0, dayIndex - 1, endHour, endMin),
+                finalExam: course.section.finalExam,
+                isCustomEvent: false,
+            }));
         });
 }
 

--- a/apps/antalmanac/tests/calendarize-helpers.test.ts
+++ b/apps/antalmanac/tests/calendarize-helpers.test.ts
@@ -21,7 +21,7 @@ describe('calendarize-helpers', () => {
                 meetings: [
                     {
                         timeIsTBA: false,
-                        bldg: [],
+                        locations: [],
                         days: 'MWF',
                         startTime: {
                             hour: 1,
@@ -46,7 +46,7 @@ describe('calendarize-helpers', () => {
                         hour: 3,
                         minute: 4,
                     },
-                    bldg: [],
+                    locations: [],
                 },
                 maxCapacity: 'placeholderMaxCapacity',
                 numCurrentlyEnrolled: {
@@ -68,7 +68,7 @@ describe('calendarize-helpers', () => {
     // 3 of the same event
     const calendarizedCourses = [
         {
-            bldg: [],
+            locations: [],
             color: 'placeholderColor',
             term: 'placeholderTerm',
             title: 'placeholderDeptCode placeholderCourseNumber',
@@ -91,12 +91,12 @@ describe('calendarize-helpers', () => {
                     hour: 3,
                     minute: 4,
                 },
-                bldg: [],
+                locations: [],
             },
             isCustomEvent: false,
         },
         {
-            bldg: [],
+            locations: [],
             color: 'placeholderColor',
             term: 'placeholderTerm',
             title: 'placeholderDeptCode placeholderCourseNumber',
@@ -119,12 +119,12 @@ describe('calendarize-helpers', () => {
                     hour: 3,
                     minute: 4,
                 },
-                bldg: [],
+                locations: [],
             },
             isCustomEvent: false,
         },
         {
-            bldg: [],
+            locations: [],
             color: 'placeholderColor',
             term: 'placeholderTerm',
             title: 'placeholderDeptCode placeholderCourseNumber',
@@ -147,7 +147,7 @@ describe('calendarize-helpers', () => {
                     hour: 3,
                     minute: 4,
                 },
-                bldg: [],
+                locations: [],
             },
             isCustomEvent: false,
         },
@@ -155,7 +155,7 @@ describe('calendarize-helpers', () => {
 
     const calendarizedCourseFinals = [
         {
-            bldg: [],
+            locations: [],
             color: 'placeholderColor',
             term: 'placeholderTerm',
             title: 'placeholderDeptCode placeholderCourseNumber',
@@ -178,7 +178,7 @@ describe('calendarize-helpers', () => {
                     hour: 3,
                     minute: 4,
                 },
-                bldg: [],
+                locations: [],
             },
             isCustomEvent: false,
         },


### PR DESCRIPTION
Notable:
- `CourseEvent` type now has `showLocationInfo` bool, mostly used because events in finals mode show "x locations" and don't pop up details for what those locations actually are. When true, a calendar event shows the actual locations comma-separated; when false, it shows "x locations" or the only location.
- `bldg` has been changed to `locations` everywhere for semantic consistency; a few cases remain for `bldg` where it comes directly from the api and there would be more cross-cutting concerns to deal with beyond the scope of multiple locations
- calendarize tests have also been adjusted to use new `locations` terminology