### PR TITLE
Remove underline from location link

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -62,6 +62,7 @@ const styles: Styles<Theme, object> = (theme) => ({
         border: 'none',
         padding: '0 !important',
         fontSize: '0.85rem', // Not sure why this is not inherited
+        textDecoration: 'none',
     },
     paper: {
         padding: theme.spacing(),
@@ -207,7 +208,7 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
                         return (
                             <Fragment key={meeting.timeIsTBA + bldg}>
                                 <Link
-                                    className={classes.clickableLocation}
+                                    className={classes.mapLink}
                                     to={`/map?location=${buildingId}`}
                                     onClick={focusMap}
                                 >

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -18,7 +18,6 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { clickToCopy, CourseDetails, isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 import { useTabStore } from '$stores/TabStore';
-import { mobileContext } from '$components/MobileHome';
 import locationIds from '$lib/location_ids';
 import { normalizeTime, parseDaysString, translate24To12HourTime } from '$stores/calendarizeHelpers';
 


### PR DESCRIPTION
## Summary
Location links should not be underlined. Since they don't lead away from the page, they should look less like URLs. I also fixed the class name for the link, so it changes color in dark mode appropriately now.

## Test Plan
See that it looks as expected.

## Issues

Closes #698 #673
