### PR TITLE
Make it clear you import a .ics file to other calendars.

### DIFF
--- a/apps/antalmanac/src/components/AppBar/Exports/ExportCalendar.tsx
+++ b/apps/antalmanac/src/components/AppBar/Exports/ExportCalendar.tsx
@@ -4,7 +4,7 @@ import { Download } from '@mui/icons-material';
 import { exportCalendar } from '$lib/download';
 
 const ExportCalendarButton = () => (
-    <Tooltip title="Download Calendar as an .ics file. You can import tis file to Google or Apple calendars.">
+    <Tooltip title="Download Calendar as a .ics file. You can import this file to Google or Apple calendars.">
         <Button onClick={exportCalendar} variant="outlined" size="small" startIcon={<Download fontSize="small" />}>
             Download
         </Button>

--- a/apps/antalmanac/src/components/AppBar/Exports/ExportCalendar.tsx
+++ b/apps/antalmanac/src/components/AppBar/Exports/ExportCalendar.tsx
@@ -4,7 +4,7 @@ import { Download } from '@mui/icons-material';
 import { exportCalendar } from '$lib/download';
 
 const ExportCalendarButton = () => (
-    <Tooltip title="Download Calendar as an .ics file">
+    <Tooltip title="Download Calendar as an .ics file. You can import tis file to Google or Apple calendars.">
         <Button onClick={exportCalendar} variant="outlined" size="small" startIcon={<Download fontSize="small" />}>
             Download
         </Button>


### PR DESCRIPTION
## Summary
Change the tooltip on the export/download button to mention that you can import the `.ics` file to Google or Apple calendars. Had this idea cause one of my friends didn't know you could do this and was asking when we were gonna implement export to google calendar.
## Test Plan
make sure it works in staging
