### PR TITLE
Fix Added Pane Course Grouping

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -54,7 +54,9 @@ function getCourses() {
     for (const course of currentCourses) {
         let formattedCourse = formattedCourses.find(
             (needleCourse) =>
-                needleCourse.courseNumber === course.courseNumber && needleCourse.deptCode === course.deptCode
+                needleCourse.courseNumber === course.courseNumber &&
+                needleCourse.deptCode === course.deptCode &&
+                needleCourse.courseTitle === course.courseTitle
         );
 
         if (formattedCourse) {
@@ -306,7 +308,7 @@ function AddedSectionsGrid() {
                 <Grid container spacing={2} padding={0}>
                     {courses.map((course) => {
                         return (
-                            <Grid item md={12} xs={12} key={course.deptCode + course.courseNumber}>
+                            <Grid item md={12} xs={12} key={course.deptCode + course.courseNumber + course.courseTitle}>
                                 <SectionTableLazyWrapper
                                     courseDetails={course}
                                     term={course.term}


### PR DESCRIPTION
## Summary
<img width="548" alt="Screenshot 2023-09-28 at 8 04 25 PM" src="https://github.com/icssc/AntAlmanac/assets/100006999/6a7b486a-701f-4d64-85c0-93cf63c8cfff">

This piece of filtering was too general for the courses that shared the same courseNumber and deptCode (EECS 298, BIO SCI 199, etc). Because they all have different course titles, however, the fix is simply to narrow down the filter even more with `.courseTitle`.

Old Code ->
```typescript
        let formattedCourse = formattedCourses.find(
            (needleCourse) =>
                needleCourse.courseNumber === course.courseNumber && needleCourse.deptCode === course.deptCode
```

## Test Plan
Make sure courses like BIO SCI 199 are properly grouped, as well as that no other functionality has been broken.

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
