### PR TITLE
Parallelize Schedule Load Websoc Requests

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -463,13 +463,8 @@ export class Schedules {
             const courseInfoDict = new Map<string, { [sectionCode: string]: CourseInfo }>();
 
             const websocRequests = Object.entries(courseDict).map(async ([term, courseSet]) => {
-                const sectionCodes = Array.from(courseSet);
-                const courseInfo = getCourseInfo(
-                    await queryWebsoc({
-                        term: term,
-                        sectionCodes: sectionCodes.join(','),
-                    })
-                );
+                const sectionCodes = Array.from(courseSet).join(',');
+                const courseInfo = getCourseInfo(await queryWebsoc({ term, sectionCodes }));
                 courseInfoDict.set(term, courseInfo);
             });
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -461,9 +461,9 @@ export class Schedules {
 
             // Get the course info for each course
             const courseInfoDict = new Map<string, { [sectionCode: string]: CourseInfo }>();
-            for (const [term, courseSet] of Object.entries(courseDict)) {
+
+            const websocRequests = Object.entries(courseDict).map(async ([term, courseSet]) => {
                 const sectionCodes = Array.from(courseSet);
-                // Code from ImportStudyList
                 const courseInfo = getCourseInfo(
                     await queryWebsoc({
                         term: term,
@@ -471,10 +471,13 @@ export class Schedules {
                     })
                 );
                 courseInfoDict.set(term, courseInfo);
-            }
+            });
+
+            await Promise.all(websocRequests);
 
             // Map course info to courses and transform shortened schedule to normal schedule
             for (const shortCourseSchedule of saveState.schedules) {
+                console.log(shortCourseSchedule);
                 const courses: ScheduleCourse[] = [];
                 for (const shortCourse of shortCourseSchedule.courses) {
                     const courseInfoMap = courseInfoDict.get(shortCourse.term);

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -477,7 +477,6 @@ export class Schedules {
 
             // Map course info to courses and transform shortened schedule to normal schedule
             for (const shortCourseSchedule of saveState.schedules) {
-                console.log(shortCourseSchedule);
                 const courses: ScheduleCourse[] = [];
                 for (const shortCourse of shortCourseSchedule.courses) {
                     const courseInfoMap = courseInfoDict.get(shortCourse.term);


### PR DESCRIPTION
## Summary
Saves a bunch of time on schedule loading by making PPAPI requests for different terms concurrently.

Before:
![image](https://github.com/icssc/AntAlmanac/assets/48658337/9af60850-75b5-4a0d-bcdf-6af4dd2fe35d)

After:
![image](https://github.com/icssc/AntAlmanac/assets/48658337/e89f1788-23f4-428d-abe0-8d713d4a4dcb)

## Test Plan
Verify with network inspector that requests are being done concurrently, and also that nothing breaks.

## Issues
Closes #712 

<!-- [Optional]
## Future Followup
-->
