### PR TITLE
refactor: made course pane components functional

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 
 import RightPaneStore from '../RightPaneStore';
 import CoursePaneButtonRow from './CoursePaneButtonRow';
@@ -9,8 +9,7 @@ import { openSnackbar } from '$actions/AppStoreActions';
 import { clearCache } from '$lib/course-helpers';
 
 function RightPane() {
-    // A key that's used to re-render the search results.
-    const [count, setCount] = useState(0);
+    const [key, forceUpdate] = useReducer((currentCount) => currentCount + 1, 0);
 
     const toggleSearch = useCallback(() => {
         if (
@@ -20,8 +19,7 @@ function RightPane() {
             RightPaneStore.getFormData().instructor !== ''
         ) {
             RightPaneStore.toggleSearch();
-
-            setCount((currentCount) => currentCount + 1);
+            forceUpdate();
         } else {
             openSnackbar(
                 'error',
@@ -36,7 +34,7 @@ function RightPane() {
             action: analyticsEnum.classSearch.actions.REFRESH,
         });
         clearCache();
-        setCount((currentCount) => currentCount + 1);
+        forceUpdate();
     }, []);
 
     useEffect(() => {
@@ -47,7 +45,7 @@ function RightPane() {
             ) {
                 event.preventDefault();
                 RightPaneStore.toggleSearch();
-                setCount((currentCount) => currentCount + 1);
+                forceUpdate();
             }
         };
 
@@ -68,7 +66,7 @@ function RightPane() {
             {RightPaneStore.getDoDisplaySearch() ? (
                 <SearchForm toggleSearch={toggleSearch} />
             ) : (
-                <CourseRenderPane key={count} />
+                <CourseRenderPane key={key} />
             )}
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -12,8 +12,6 @@ function RightPane() {
     // A key that's used to re-render the search results.
     const [count, setCount] = useState(0);
 
-    // const [searchParams, setSearchParams] = useSearchParams()
-
     const toggleSearch = useCallback(() => {
         if (
             RightPaneStore.getFormData().ge !== 'ANY' ||

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -41,7 +41,7 @@ function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
         return accumulator;
     }, []);
 }
-function RecruitmentBanner() {
+const RecruitmentBanner = () => {
     const [bannerVisibility, setBannerVisibility] = React.useState<boolean>(true);
 
     // Display recruitment banner if more than 11 weeks (in ms) has passed since last dismissal
@@ -87,7 +87,7 @@ function RecruitmentBanner() {
             ) : null}{' '}
         </div>
     );
-}
+};
 
 /* TODO: all this typecasting in the conditionals is pretty messy, but type guards don't really work in this context
  *  for reasons that are currently beyond me (probably something in the transpiling process that JS doesn't like).

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,8 +1,6 @@
-import { IconButton, Theme } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
+import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
-import React, { PureComponent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
 import { Alert } from '@mui/material';
@@ -21,66 +19,12 @@ import { isDarkMode, queryWebsocMultiple } from '$lib/helpers';
 import analyticsEnum from '$lib/analytics';
 import { queryWebsoc } from '$lib/course-helpers';
 
-const styles: Styles<Theme, object> = (theme) => ({
-    course: {
-        paddingLeft: theme.spacing(2),
-        paddingRight: theme.spacing(2),
-        [theme.breakpoints.up('sm')]: {
-            paddingLeft: theme.spacing(3),
-            paddingRight: theme.spacing(3),
-        },
-        paddingTop: theme.spacing(),
-        paddingBottom: theme.spacing(),
-        display: 'flex',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-        minHeight: theme.spacing(6),
-        cursor: 'pointer',
-    },
-    text: {
-        flexGrow: 1,
-        display: 'inline',
-        width: '100%',
-    },
-    ad: {
-        flexGrow: 1,
-        display: 'inline',
-        width: '100%',
-    },
-    icon: {
-        cursor: 'pointer',
-        marginLeft: theme.spacing(),
-    },
-    root: {
-        height: '100%',
-        overflowY: 'scroll',
-        position: 'relative',
-    },
-    noResultsDiv: {
-        height: '100%',
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    loadingGifStyle: {
-        height: '100%',
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    spacing: {
-        height: '50px',
-        marginBottom: '5px',
-    },
-});
-
-const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocDepartment | AACourse)[] => {
+function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocDepartment | AACourse)[] {
     const courseColors = AppStore.getAddedCourses().reduce((accumulator, { section }) => {
         accumulator[section.sectionCode] = section.color;
         return accumulator;
     }, {} as { [key: string]: string });
+
     return SOCObject.schools.reduce((accumulator: (WebsocSchool | WebsocDepartment | AACourse)[], school) => {
         accumulator.push(school);
 
@@ -97,9 +41,10 @@ const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
 
         return accumulator;
     }, []);
-};
-const RecruitmentBanner = () => {
-    const [bannerVisibility, setBannerVisibility] = React.useState<boolean>(true);
+}
+
+function RecruitmentBanner() {
+    const [bannerVisibility, setBannerVisibility] = useState(true);
 
     // Display recruitment banner if more than 11 weeks (in ms) has passed since last dismissal
     const recruitmentDismissalTime = window.localStorage.getItem('recruitmentDismissalTime');
@@ -144,11 +89,13 @@ const RecruitmentBanner = () => {
             ) : null}{' '}
         </div>
     );
-};
+}
 
-/* TODO: all this typecasting in the conditionals is pretty messy, but type guards don't really work in this context
- *  for reasons that are currently beyond me (probably something in the transpiling process that JS doesn't like).
- *  If you can find a way to make this cleaner, do it.
+/*
+ * TODO: all this typecasting in the conditionals is pretty messy,
+ * but type guards don't really work in this context
+ * for reasons that are currently beyond me (probably something in the transpiling process that JS doesn't like).
+ * If you can find a way to make this cleaner, do it.
  */
 const SectionTableWrapped = (
     index: number,
@@ -192,135 +139,137 @@ const SectionTableWrapped = (
     return <div>{component}</div>;
 };
 
-interface CourseRenderPaneProps {
-    classes: ClassNameMap;
-}
+export function CourseRenderPane() {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+    const [courseData, setCourseData] = useState<(WebsocSchool | WebsocDepartment | AACourse)[]>([]);
 
-interface CourseRenderPaneState {
-    courseData: (WebsocSchool | WebsocDepartment | AACourse)[];
-    loading: boolean;
-    error: boolean;
-    scheduleNames: string[];
-}
+    const loadCourses = useCallback(async () => {
+        setLoading(true);
 
-class CourseRenderPane extends PureComponent<CourseRenderPaneProps, CourseRenderPaneState> {
-    state: CourseRenderPaneState = {
-        courseData: [],
-        loading: true,
-        error: false,
-        scheduleNames: AppStore.getScheduleNames(),
-    };
+        const formData = RightPaneStore.getFormData();
 
-    loadCourses = () => {
-        this.setState({ loading: true }, async () => {
-            const formData = RightPaneStore.getFormData();
+        const params = {
+            department: formData.deptValue,
+            term: formData.term,
+            ge: formData.ge,
+            courseNumber: formData.courseNumber,
+            sectionCodes: formData.sectionCode,
+            instructorName: formData.instructor,
+            units: formData.units,
+            endTime: formData.endTime,
+            startTime: formData.startTime,
+            fullCourses: formData.coursesFull,
+            building: formData.building,
+            room: formData.room,
+            division: formData.division,
+        };
 
-            const params = {
-                department: formData.deptValue,
-                term: formData.term,
-                ge: formData.ge,
-                courseNumber: formData.courseNumber,
-                sectionCodes: formData.sectionCode,
-                instructorName: formData.instructor,
-                units: formData.units,
-                endTime: formData.endTime,
-                startTime: formData.startTime,
-                fullCourses: formData.coursesFull,
-                building: formData.building,
-                room: formData.room,
-                division: formData.division,
-            };
+        try {
+            // If params has a comma, it means that we are searching for multiple units.
+            const socObject = params.units.includes(',')
+                ? await queryWebsocMultiple(params, 'units')
+                : await queryWebsoc(params);
 
-            try {
-                let jsonResp;
-                if (params.units.includes(',')) {
-                    jsonResp = await queryWebsocMultiple(params, 'units');
-                } else {
-                    jsonResp = await queryWebsoc(params);
-                }
-                this.setState({
-                    loading: false,
-                    error: false,
-                    courseData: flattenSOCObject(jsonResp),
-                });
-            } catch (error) {
-                this.setState({
-                    loading: false,
-                    error: true,
-                });
-            }
-        });
-    };
+            setError(false);
+            setCourseData(flattenSOCObject(socObject));
+        } catch (error) {
+            setError(true);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
 
-    componentDidMount() {
-        this.loadCourses();
-        AppStore.on('scheduleNamesChange', this.updateScheduleNames);
+    useEffect(() => {
+        loadCourses();
+    }, []);
+
+    useEffect(() => {
+        const updateScheduleNames = () => {
+            setScheduleNames(AppStore.getScheduleNames());
+        };
+
+        AppStore.on('scheduleNamesChange', updateScheduleNames);
+
+        return () => {
+            AppStore.off('scheduleNamesChange', updateScheduleNames);
+        };
+    }, []);
+
+    if (loading) {
+        return (
+            <div
+                style={{
+                    height: '100%',
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                }}
+            >
+                <img src={isDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
+            </div>
+        );
     }
 
-    componentWillUnmount() {
-        AppStore.removeListener('scheduleNamesChange', this.updateScheduleNames);
-    }
-
-    updateScheduleNames = () => {
-        this.setState({ scheduleNames: AppStore.getScheduleNames() });
-    };
-
-    render() {
-        const { classes } = this.props;
-        let currentView;
-
-        if (this.state.loading) {
-            currentView = (
-                <div className={classes.loadingGifStyle}>
-                    <img src={isDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
+    if (error) {
+        return (
+            <div
+                style={{
+                    height: '100%',
+                    overflowY: 'scroll',
+                    position: 'relative',
+                }}
+            >
+                <div
+                    style={{
+                        height: '100%',
+                        width: '100%',
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                    }}
+                >
+                    <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
                 </div>
-            );
-        } else if (!this.state.error) {
-            const renderData = {
-                courseData: this.state.courseData,
-                scheduleNames: this.state.scheduleNames,
-            };
+            </div>
+        );
+    }
 
-            currentView = (
-                <>
-                    <RecruitmentBanner />
-                    <div className={classes.root} style={{ position: 'relative' }}>
-                        <div className={classes.spacing} />
-                        {this.state.courseData.length === 0 ? (
-                            <div className={classes.noResultsDiv}>
-                                <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
-                            </div>
-                        ) : (
-                            this.state.courseData.map(
-                                (_: WebsocSchool | WebsocDepartment | AACourse, index: number) => {
-                                    let heightEstimate = 200;
-                                    if ((this.state.courseData[index] as AACourse).sections !== undefined)
-                                        heightEstimate =
-                                            (this.state.courseData[index] as AACourse).sections.length * 60 + 20 + 40;
-
-                                    return (
-                                        <LazyLoad once key={index} overflow height={heightEstimate} offset={500}>
-                                            {SectionTableWrapped(index, renderData)}
-                                        </LazyLoad>
-                                    );
-                                }
-                            )
-                        )}
-                    </div>
-                </>
-            );
-        } else {
-            currentView = (
-                <div className={classes.root}>
-                    <div className={classes.noResultsDiv}>
+    return (
+        <>
+            <RecruitmentBanner />
+            <div style={{ height: '100%', overflowY: 'scroll', position: 'relative' }}>
+                <div style={{ height: '50px', marginBottom: '5px' }} />
+                {courseData.length === 0 ? (
+                    <div
+                        style={{
+                            height: '100%',
+                            width: '100%',
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                        }}
+                    >
                         <img src={isDarkMode() ? darkNoNothing : noNothing} alt="No Results Found" />
                     </div>
-                </div>
-            );
-        }
+                ) : (
+                    courseData.map((_, index: number) => {
+                        let heightEstimate = 200;
+                        if ((courseData[index] as AACourse).sections !== undefined)
+                            heightEstimate = (courseData[index] as AACourse).sections.length * 60 + 20 + 40;
 
-        return currentView;
-    }
+                        return (
+                            <LazyLoad once key={index} overflow height={heightEstimate} offset={500}>
+                                {SectionTableWrapped(index, { courseData, scheduleNames })}
+                            </LazyLoad>
+                        );
+                    })
+                )}
+            </div>
+        </>
+    );
 }
 
-export default withStyles(styles)(CourseRenderPane);
+export default CourseRenderPane;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
 import { Alert } from '@mui/material';
@@ -24,7 +24,6 @@ function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
         accumulator[section.sectionCode] = section.color;
         return accumulator;
     }, {} as { [key: string]: string });
-
     return SOCObject.schools.reduce((accumulator: (WebsocSchool | WebsocDepartment | AACourse)[], school) => {
         accumulator.push(school);
 
@@ -42,9 +41,8 @@ function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
         return accumulator;
     }, []);
 }
-
 function RecruitmentBanner() {
-    const [bannerVisibility, setBannerVisibility] = useState(true);
+    const [bannerVisibility, setBannerVisibility] = React.useState<boolean>(true);
 
     // Display recruitment banner if more than 11 weeks (in ms) has passed since last dismissal
     const recruitmentDismissalTime = window.localStorage.getItem('recruitmentDismissalTime');
@@ -91,11 +89,9 @@ function RecruitmentBanner() {
     );
 }
 
-/*
- * TODO: all this typecasting in the conditionals is pretty messy,
- * but type guards don't really work in this context
- * for reasons that are currently beyond me (probably something in the transpiling process that JS doesn't like).
- * If you can find a way to make this cleaner, do it.
+/* TODO: all this typecasting in the conditionals is pretty messy, but type guards don't really work in this context
+ *  for reasons that are currently beyond me (probably something in the transpiling process that JS doesn't like).
+ *  If you can find a way to make this cleaner, do it.
  */
 const SectionTableWrapped = (
     index: number,

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -40,7 +40,7 @@ function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
 
         return accumulator;
     }, []);
-}
+};
 const RecruitmentBanner = () => {
     const [bannerVisibility, setBannerVisibility] = React.useState<boolean>(true);
 


### PR DESCRIPTION
## Summary
If we want to support more sophisticated searching, then we'd want to integrate better with react-router so that we can manage state in the URL. This is in regards to #558 and the work that's being done on a [fork by Carlos](https://github.com/calejvaldez/AntAlmanac/commit/e172c1d3baa4d5c76b31fc0525ac7b03a80d2b1f)

The core component logic has been mostly preserved and optimized for functional components.

## Test Plan
I can write tests, if anybody wants me to. Some tests I can think of at the top of my head are:
- Displays the search results only when the conditions are met (i.e. selected a course, specified the proper advanced search parameters, etc.)
- Returns to search when a key is pressed and conditions are met