### PR TITLE
add setting for 24 hour time

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -12,6 +12,7 @@ import AppThemev5Provider from './providers/Themev5';
 
 import Home from './routes/Home';
 import Feedback from './routes/Feedback';
+import Show24HourTimeProvider from '$providers/Show24HourTime';
 
 const BrowserRouter = createBrowserRouter([
     {
@@ -45,9 +46,11 @@ export default function App() {
         <AppQueryProvider>
             <AppThemeProvider>
                 <AppThemev5Provider>
-                    <SnackbarProvider>
-                        <RouterProvider router={BrowserRouter} />
-                    </SnackbarProvider>
+                    <Show24HourTimeProvider>
+                        <SnackbarProvider>
+                            <RouterProvider router={BrowserRouter} />
+                        </SnackbarProvider>
+                    </Show24HourTimeProvider>
                 </AppThemev5Provider>
             </AppThemeProvider>
         </AppQueryProvider>

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -198,6 +198,15 @@ export const toggleTheme = (radioGroupEvent: React.ChangeEvent<HTMLInputElement>
     });
 };
 
+export const toggleShow24HourTime = (radioGroupEvent: React.ChangeEvent<HTMLInputElement>) => {
+    AppStore.toggleShow24HourTime(radioGroupEvent.target.value === 'true');
+    logAnalytics({
+        category: analyticsEnum.nav.title,
+        action: analyticsEnum.nav.actions.CHANGE_TIME_FORMAT,
+        label: radioGroupEvent.target.value,
+    });
+};
+
 export const addSchedule = (scheduleName: string) => {
     AppStore.addSchedule(scheduleName);
 };

--- a/apps/antalmanac/src/components/AppBar/CustomAppBar.tsx
+++ b/apps/antalmanac/src/components/AppBar/CustomAppBar.tsx
@@ -14,6 +14,7 @@ import SettingsMenu from './SettingsMenu';
 import Export from './Exports/Export';
 import { ReactComponent as Logo } from './logo.svg';
 import { ReactComponent as MobileLogo } from './mobile-logo.svg';
+import TimeFormatMenu from './TimeFormatMenu';
 
 const styles = {
     appBar: {
@@ -44,6 +45,7 @@ interface CustomAppBarProps {
 
 const components = [
     <SettingsMenu key="settings" />,
+    <TimeFormatMenu key="timeformat" />,
     <ImportStudyList key="studylist" />,
     <Export key="export" />,
     <Feedback key="feedback" />,

--- a/apps/antalmanac/src/components/AppBar/TimeFormatMenu.tsx
+++ b/apps/antalmanac/src/components/AppBar/TimeFormatMenu.tsx
@@ -1,0 +1,83 @@
+import { Button, FormControl, FormControlLabel, Paper, Popover, Radio, RadioGroup } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import { ClassNameMap } from '@material-ui/core/styles/withStyles';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import { PureComponent } from 'react';
+
+import { toggleShow24HourTime } from '$actions/AppStoreActions';
+import AppStore from '$stores/AppStore';
+
+const styles = {
+    container: {
+        padding: '0.5rem',
+        minWidth: '12.25rem',
+    },
+    betaBadge: { transform: 'scale(1) translate(95%, -50%)' },
+};
+
+interface TimeFormatSettingsState {
+    anchorEl?: HTMLElement;
+    show24HourTime: boolean;
+}
+
+class TimeFormatMenu extends PureComponent<{ classes: ClassNameMap }, TimeFormatSettingsState> {
+    state: TimeFormatSettingsState = {
+        anchorEl: undefined,
+        show24HourTime: AppStore.getShow24HourTime(),
+    };
+
+    componentDidMount = () => {
+        AppStore.on('show24HourToggle', () => {
+            this.setState({ show24HourTime: AppStore.getShow24HourTime() });
+        });
+    };
+
+    render() {
+        const { classes } = this.props;
+
+        return (
+            <>
+                <Button
+                    onClick={(event) => {
+                        this.setState({ anchorEl: event.currentTarget });
+                    }}
+                    color="inherit"
+                    startIcon={<AccessTimeIcon />}
+                >
+                    Time Format
+                </Button>
+                <Popover
+                    open={Boolean(this.state.anchorEl)}
+                    anchorEl={this.state.anchorEl}
+                    onClose={() => {
+                        this.setState({ anchorEl: undefined });
+                    }}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'center',
+                    }}
+                    transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'center',
+                    }}
+                >
+                    <Paper className={classes.container}>
+                        <FormControl>
+                            <RadioGroup
+                                aria-label="show24HourTime"
+                                name="show24HourTime"
+                                value={this.state.show24HourTime.toString()}
+                                onChange={toggleShow24HourTime}
+                            >
+                                <FormControlLabel value="false" control={<Radio color="primary" />} label="12-hour" />
+                                <FormControlLabel value="true" control={<Radio color="primary" />} label="24-hour" />
+                            </RadioGroup>
+                        </FormControl>
+                    </Paper>
+                </Popover>
+            </>
+        );
+    }
+}
+
+export default withStyles(styles)(TimeFormatMenu);

--- a/apps/antalmanac/src/lib/analytics.ts
+++ b/apps/antalmanac/src/lib/analytics.ts
@@ -28,6 +28,7 @@ const analyticsEnum = {
             CLICK_NOTIFICATIONS: 'Click Notifications',
             CLICK_ABOUT: 'Click About Page',
             CHANGE_THEME: 'Change Theme', // Label is the theme changed to
+            CHANGE_TIME_FORMAT: 'Change Time Format', // label is whether or not to show 24 Hour time (true for 24-hour time, false for 12-hour time)
             IMPORT_STUDY_LIST: 'Import Study List', // Value is the percentage of courses successfully imported (decimal value)
             LOAD_SCHEDULE: 'Load Schedule', // Value is 1 if the user checked "remember me", 0 otherwise
             SAVE_SCHEDULE: 'Save Schedule', // Value is 1 if the user checked "remember me", 0 otherwise

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -203,6 +203,10 @@ export function isDarkMode() {
     }
 }
 
+export function is24HourTime() {
+    return AppStore.getShow24HourTime();
+}
+
 /**
  * @param courseNumber A string that represents the course number of a course (eg. '122A', '121')
  * @returns This function returns an int or number with a decimal representation of the passed in string (eg. courseNumAsDecimal('122A') returns 122.1, courseNumAsDecimal('121') returns 121)

--- a/apps/antalmanac/src/providers/Show24HourTime.tsx
+++ b/apps/antalmanac/src/providers/Show24HourTime.tsx
@@ -1,0 +1,38 @@
+import { createContext, useEffect, useState } from 'react';
+import AppStore from '$stores/AppStore';
+import { is24HourTime } from '$lib/helpers';
+
+interface Props {
+    children?: React.ReactNode;
+}
+
+type TimeFormatContextType = {
+    context: boolean;
+    setContext: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const defaultTimeFormatContextState = {
+    context: false,
+    setContext: () => {
+        return false;
+    },
+};
+
+const Show24HourTimeContext = createContext<TimeFormatContextType>(defaultTimeFormatContextState);
+
+export default function Show24HourTimeProvider(props: Props) {
+    const [on24HourTime, setShow24HourTime] = useState(is24HourTime());
+
+    useEffect(() => {
+        console.log('using effect');
+        AppStore.on('show24HourToggle', () => {
+            setShow24HourTime(is24HourTime());
+        });
+    }, []);
+
+    return (
+        <Show24HourTimeContext.Provider value={{ context: on24HourTime, setContext: setShow24HourTime }}>
+            {props.children}
+        </Show24HourTimeContext.Provider>
+    );
+}

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -27,6 +27,7 @@ class AppStore extends EventEmitter {
     finalsEventsInCalendar: CourseEvent[];
     unsavedChanges: boolean;
     skeletonMode: boolean;
+    show24HourTime: boolean;
 
     constructor() {
         super();
@@ -44,6 +45,11 @@ class AppStore extends EventEmitter {
         this.unsavedChanges = false;
         this.skeletonMode = false;
         this.theme = getCurrentTheme();
+        this.show24HourTime = (() => {
+            const show24HourTime =
+                typeof Storage === 'undefined' ? false : window.localStorage.getItem('show24HourTime') === 'true';
+            return show24HourTime === null ? false : show24HourTime;
+        })();
 
         if (typeof window !== 'undefined') {
             window.addEventListener('beforeunload', (event) => {
@@ -120,6 +126,10 @@ class AppStore extends EventEmitter {
 
     getTheme() {
         return this.theme;
+    }
+
+    getShow24HourTime() {
+        return this.show24HourTime;
     }
 
     getAddedSectionCodes() {
@@ -304,6 +314,12 @@ class AppStore extends EventEmitter {
         this.theme = theme;
         this.emit('themeToggle');
         window.localStorage.setItem('theme', theme);
+    }
+
+    toggleShow24HourTime(show24HourTime: boolean) {
+        this.show24HourTime = show24HourTime;
+        this.emit('show24HourToggle');
+        window.localStorage.setItem('show24HourTime', show24HourTime.toString());
     }
 
     updateScheduleNote(newScheduleNote: string, scheduleIndex: number) {

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -223,3 +223,20 @@ export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMi
 
     return `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
 }
+
+export function keep24HourTime(startTime?: HourMinute, endTime?: HourMinute): string | undefined {
+    if (!startTime || !endTime) {
+        return;
+    }
+
+    const formattedStartHour = `${startTime.hour}`;
+    const formattedEndHour = `${endTime.hour}`;
+
+    const formattedStartMinute = `${startTime.minute}`;
+    const formattedEndMinute = `${endTime.minute}`;
+
+    const meetingStartTime = `${formattedStartHour}:${formattedStartMinute.padStart(2, '0')}`;
+    const meetingEndTime = `${formattedEndHour}:${formattedEndMinute.padStart(2, '0')}`;
+
+    return `${meetingStartTime} - ${meetingEndTime}`;
+}


### PR DESCRIPTION
## Summary
Adds a setting for toggling between 24-hour time and 12-hour time

## Test Plan
Manual. Observe if times in the calendar gutter, events (i.e. classes, custom events, and finals), and right pane (i.e. class timings) change when the "Time Format" setting is toggled.

## Issues
Closes #637
