### PR TITLE
fix: Color Changing Bug w/ Duplicate Courses

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -254,7 +254,6 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
         return (
             <div className={classes.container} style={isMobile ? { height: 'calc(100% - 50px)' } : undefined}>
                 <CalendarToolbar
-                    onTakeScreenshot={this.handleTakeScreenshot}
                     currentScheduleIndex={this.state.currentScheduleIndex}
                     toggleDisplayFinalsSchedule={this.toggleDisplayFinalsSchedule}
                     showFinalsSchedule={this.state.showFinalsSchedule}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -141,6 +141,14 @@ const SectionTableWrapped = (
     return <div>{component}</div>;
 };
 
+const LoadingMessage = () => {
+    return (
+        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <img src={isDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
+        </Box>
+    );
+};
+
 const ErrorMessage = () => {
     return (
         <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -236,16 +244,7 @@ export default function CourseRenderPane() {
     return (
         <>
             {loading ? (
-                <Box
-                    sx={{
-                        height: '100%',
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                    }}
-                >
-                    <img src={isDarkMode() ? darkModeLoadingGif : loadingGif} alt="Loading courses" />
-                </Box>
+                <LoadingMessage />
             ) : error || courseData.length === 0 ? (
                 <ErrorMessage />
             ) : (

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
 import { Alert, Box, IconButton } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import { AACourse, AASection } from '@packages/antalmanac-types';
-import { WebsocDepartment, WebsocSchool, WebsocAPIResponse, GE } from 'peterportal-api-next-types';
+import { WebsocDepartment, WebsocSchool, WebsocAPIResponse } from 'peterportal-api-next-types';
 import RightPaneStore from '../RightPaneStore';
 import GeDataFetchProvider from '../SectionTable/GEDataFetchProvider';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
@@ -15,7 +15,6 @@ import darkNoNothing from './static/dark-no_results.png';
 import noNothing from './static/no_results.png';
 import AppStore from '$stores/AppStore';
 import { isDarkMode, queryWebsoc, queryWebsocMultiple } from '$lib/helpers';
-import Grades from '$lib/grades';
 import analyticsEnum from '$lib/analytics';
 
 function getColors() {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -207,11 +207,7 @@ const LocationsCell = withStyles(styles)((props: LocationsCellProps) => {
                         const buildingId = locationIds[buildingName];
                         return (
                             <Fragment key={meeting.timeIsTBA + bldg}>
-                                <Link
-                                    className={classes.mapLink}
-                                    to={`/map?location=${buildingId}`}
-                                    onClick={focusMap}
-                                >
+                                <Link className={classes.mapLink} to={`/map?location=${buildingId}`} onClick={focusMap}>
                                     {bldg}
                                 </Link>
                                 <br />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableButtons.tsx
@@ -49,6 +49,7 @@ export const ColorAndDelete = withStyles(styles)((props: ColorAndDeleteProps) =>
                     <Delete fontSize="small" />
                 </IconButton>
                 <ColorPicker
+                    key={AppStore.getCurrentScheduleIndex()}
                     color={color}
                     isCustomEvent={false}
                     sectionCode={sectionCode}

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -148,10 +148,10 @@ export class Schedules {
     }
 
     /**
-     * @return Reference of a course that matches the params
+     * @return A course that matches the params across all schedules
      */
     getExistingCourse(sectionCode: string, term: string) {
-        for (const course of this.getCurrentCourses()) {
+        for (const course of this.getAllCourses()) {
             if (course.section.sectionCode === sectionCode && term === course.term) {
                 return course;
             }
@@ -160,16 +160,15 @@ export class Schedules {
     }
 
     /**
-     * @return An array of references to courses that matches the params
+     * @return A course that matches the params in the current schedule
      */
-    getExistingCourses(sectionCode: string, term: string) {
-        const courses: ScheduleCourse[] = [];
-        for (const course of this.getAllCourses()) {
+    getExistingCourseInSchedule(sectionCode: string, term: string) {
+        for (const course of this.getCurrentCourses()) {
             if (course.section.sectionCode === sectionCode && term === course.term) {
-                courses.push(course);
+                return course;
             }
         }
-        return courses ?? undefined;
+        return undefined;
     }
 
     /**
@@ -185,7 +184,7 @@ export class Schedules {
             this.addUndoState();
         }
 
-        const existingSection = this.getExistingCourse(newCourse.section.sectionCode, newCourse.term);
+        const existingSection = this.getExistingCourseInSchedule(newCourse.section.sectionCode, newCourse.term);
 
         const existsInSchedule = this.doesCourseExistInSchedule(
             newCourse.section.sectionCode,
@@ -235,12 +234,8 @@ export class Schedules {
      */
     changeCourseColor(sectionCode: string, term: string, newColor: string) {
         this.addUndoState();
-        // const courses = this.getExistingCourses(sectionCode, term);
-        // for (const course of courses) {
-        //     course.section.color = newColor;
-        // }
 
-        const course = this.getExistingCourse(sectionCode, term);
+        const course = this.getExistingCourseInSchedule(sectionCode, term);
         if (course) {
             course.section.color = newColor;
         }

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -151,7 +151,7 @@ export class Schedules {
      * @return Reference of a course that matches the params
      */
     getExistingCourse(sectionCode: string, term: string) {
-        for (const course of this.getAllCourses()) {
+        for (const course of this.getCurrentCourses()) {
             if (course.section.sectionCode === sectionCode && term === course.term) {
                 return course;
             }
@@ -235,8 +235,13 @@ export class Schedules {
      */
     changeCourseColor(sectionCode: string, term: string, newColor: string) {
         this.addUndoState();
-        const courses = this.getExistingCourses(sectionCode, term);
-        for (const course of courses) {
+        // const courses = this.getExistingCourses(sectionCode, term);
+        // for (const course of courses) {
+        //     course.section.color = newColor;
+        // }
+
+        const course = this.getExistingCourse(sectionCode, term);
+        if (course) {
             course.section.color = newColor;
         }
     }

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -148,7 +148,7 @@ export class Schedules {
     }
 
     /**
-     * @return Reference of the course that matches the params
+     * @return Reference of a course that matches the params
      */
     getExistingCourse(sectionCode: string, term: string) {
         for (const course of this.getAllCourses()) {
@@ -157,6 +157,19 @@ export class Schedules {
             }
         }
         return undefined;
+    }
+
+    /**
+     * @return An array of references to courses that matches the params
+     */
+    getExistingCourses(sectionCode: string, term: string) {
+        const courses: ScheduleCourse[] = [];
+        for (const course of this.getAllCourses()) {
+            if (course.section.sectionCode === sectionCode && term === course.term) {
+                courses.push(course);
+            }
+        }
+        return courses ?? undefined;
     }
 
     /**
@@ -222,8 +235,8 @@ export class Schedules {
      */
     changeCourseColor(sectionCode: string, term: string, newColor: string) {
         this.addUndoState();
-        const course = this.getExistingCourse(sectionCode, term);
-        if (course) {
+        const courses = this.getExistingCourses(sectionCode, term);
+        for (const course of courses) {
             course.section.color = newColor;
         }
     }


### PR DESCRIPTION
## Summary
[screen-recorder-sat-sep-30-2023-15-39-24 (1).webm](https://github.com/icssc/AntAlmanac/assets/100006999/f8469893-8b38-4c75-a83e-c8621cee04d7)

As shown above (and in #716), changing colors of a course event fails if the same course event exists in a schedule that is lower in index than the one currently being changed. 

**The reason for this is that `getExistingCourse` (shown below) only returned the reference of _a singular_ course that matched the given params.** This meant that courses (which matched the params) in other schedules would not have their colors changed.

```typescript
    /**
     * @return Reference of a course that matches the params
     */
    getExistingCourse(sectionCode: string, term: string) {
        for (const course of this.getAllCourses()) {
            if (course.section.sectionCode === sectionCode && term === course.term) {
                return course;   // <----- the problem
            }
        }
        return undefined;
    }
```

TL;DR Color Picker and Courses will now correctly update their colors (without affecting other schedules and courses)

## Test Plan
1. Create at least two schedules which contain the same course
2. Attempt to change the color on each. Success will be defined by steps 3-6
3. The color of the course in the Calendar should update
4. The color of the course in the Search pane should update
5. The color of the course in the Added pane should update
6. The updated colors should save and be loaded in correctly

## Issues
Closes #716

<!-- [Optional]
## Future Followup
-->
