### PR TITLE
Add workflow to mark issues and PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '28 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,5 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-close: -1
+        days-before-issue-stale: 90
+        days-before-pr-stale: 30


### PR DESCRIPTION
## Summary
With this workflow, if an issue or PR has had no activity for 60 days, it will be marked as stale, which is basically a reminder for us to look at it again so nothing gets forgotten. It's 60 days because that's the default, if anyone has a compelling reason to change that I'd be down.
## Test Plan
Just wait for it to mark something as stale 🤷‍♂️