### PR TITLE
Thinner section table scroll bar

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -104,7 +104,7 @@ function EnrollmentColumnHeader(props: EnrollmentColumnHeaderProps) {
 function SectionTable(props: SectionTableProps) {
     const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory } = props;
 
-    const [selectedColumns, activeColumns] = useColumnStore((store) => [store.selectedColumns, store.activeColumns]);
+    const [activeColumns] = useColumnStore((store) => [store.activeColumns]);
 
     const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT})`);
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -21,6 +21,7 @@ import { SectionTableProps } from './SectionTable.types';
 import SectionTableBody from './SectionTableBody';
 import useColumnStore, { SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import analyticsEnum from '$lib/analytics';
+import { GlobalStyles } from '@mui/material';
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
@@ -127,6 +128,7 @@ function SectionTable(props: SectionTableProps) {
 
     return (
         <>
+            <GlobalStyles styles={{'*::-webkit-scrollbar': {height: '8px'}}}/>
             <Box style={{ display: 'flex', gap: 4, marginTop: 4, marginBottom: 8 }}>
                 <CourseInfoBar
                     deptCode={courseDetails.deptCode}


### PR DESCRIPTION
## Summary
Make horizontal scroll bar thin to match the rest of the app.

<img width="496" alt="image" src="https://github.com/icssc/AntAlmanac/assets/64875104/a42052f9-5dcf-4ba5-80ce-9684f8cc89e4">


## Test Plan
Make sure that it shows up properly and that it's usable.

## Issues

Closes #735 

## Future Followup

Maybe have one side scroll for all sections like ZotCourse.
