### PR TITLE
Refactor functions used for ExportCalendar

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -102,7 +102,7 @@ export interface Location {
     /**
      * If the location only applies on specific days, this is non-null.
      */
-    days?: string[];
+    days: string | null;
 }
 
 export interface CourseEvent extends CommonCalendarEvent {
@@ -138,6 +138,7 @@ export interface CourseEvent extends CommonCalendarEvent {
 export interface CustomEvent extends CommonCalendarEvent {
     customEventID: number;
     isCustomEvent: true;
+    days: string[];
 }
 
 export type CalendarEvent = CourseEvent | CustomEvent;

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -102,27 +102,29 @@ export interface Location {
     /**
      * If the location only applies on specific days, this is non-null.
      */
-    days: string | null;
+    days?: string;
+}
+
+export interface FinalExam {
+    examStatus: 'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL';
+    dayOfWeek: 'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null;
+    month: number | null;
+    day: number | null;
+    startTime: {
+        hour: number;
+        minute: number;
+    } | null;
+    endTime: {
+        hour: number;
+        minute: number;
+    } | null;
+    locations: Location[] | null;
 }
 
 export interface CourseEvent extends CommonCalendarEvent {
     locations: Location[];
     showLocationInfo: boolean;
-    finalExam: {
-        examStatus: 'NO_FINAL' | 'TBA_FINAL' | 'SCHEDULED_FINAL';
-        dayOfWeek: 'Sun' | 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | null;
-        month: number | null;
-        day: number | null;
-        startTime: {
-            hour: number;
-            minute: number;
-        } | null;
-        endTime: {
-            hour: number;
-            minute: number;
-        } | null;
-        locations: Location[] | null;
-    };
+    finalExam: FinalExam;
     courseTitle: string;
     instructors: string[];
     isCustomEvent: false;

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -110,16 +110,6 @@ export function dateToIcs(date: Date) {
     ] as YearMonthDay;
 }
 
-export function dateToDateTimeArray(date: Date) {
-    return [
-        date.getFullYear(),
-        date.getMonth() + 1, // Add 1 month since it is 0-indexed
-        date.getDate(),
-        date.getHours(),
-        date.getMinutes(),
-    ] as DateTimeArray;
-}
-
 /**
  * Get the start and end datetime of the first class.
  *

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -290,8 +290,8 @@ export function getEventsFromCourses(events = AppStore.getEventsInCalendar()): E
                         productId: 'antalmanac/ics',
                         startOutputType: 'local' as const,
                         endOutputType: 'local' as const,
-                        title: `${title} ${sectionType} Final Exam`,
-                        description: `Final Exam for ${courseTitle}`,
+                        title: `${title} Final Exam`,
+                        description: `Final Exam for ${sectionType} ${courseTitle}`,
                         start: getExamTime(finalExam, getYear(term))[0]!,
                         end: getExamTime(finalExam, getYear(term))[1]!,
                     });

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -10,7 +10,7 @@ const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
 export function getLocation(location: string): Location {
     const [building = '', room = ''] = location.split(' ');
-    return { building, room, days: null };
+    return { building, room };
 }
 
 export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
@@ -137,7 +137,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
                 isCustomEvent: true,
                 end: new Date(2018, 0, dayIndex, endHour, endMin),
                 title: customEvent.title,
-                days: days,
+                days,
             };
         });
     });

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -49,7 +49,7 @@ export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): 
                         title: `${course.deptCode} ${course.courseNumber}`,
                         courseTitle: course.courseTitle,
                         locations: meeting.bldg.map(getLocation).map((location: Location) => {
-                            return { ...location, days: meeting.days };
+                            return { ...location, days: meeting.days === null ? undefined : meeting.days };
                         }),
                         showLocationInfo: false,
                         instructors: course.section.instructors,
@@ -123,6 +123,11 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
 export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
     return currentCustomEvents.flatMap((customEvent) => {
         const dayIndiciesOcurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
+        /**
+         * Only include the day strings that the custom event occurs.
+         *
+         * @example [1, 3, 5] -> ['M', 'W', 'F']
+         */
         const days = dayIndiciesOcurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
         return dayIndiciesOcurring.map((dayIndex) => {
             const startHour = parseInt(customEvent.start.slice(0, 2), 10);

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -10,7 +10,7 @@ const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
 export function getLocation(location: string): Location {
     const [building = '', room = ''] = location.split(' ');
-    return { building, room };
+    return { building, room, days: null };
 }
 
 export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): CourseEvent[] {
@@ -48,7 +48,9 @@ export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): 
                         term: course.term,
                         title: `${course.deptCode} ${course.courseNumber}`,
                         courseTitle: course.courseTitle,
-                        locations: meeting.bldg.map(getLocation),
+                        locations: meeting.bldg.map(getLocation).map((location: Location) => {
+                            return { ...location, days: meeting.days };
+                        }),
                         showLocationInfo: false,
                         instructors: course.section.instructors,
                         sectionCode: course.section.sectionCode,
@@ -121,7 +123,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
 export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
     return currentCustomEvents.flatMap((customEvent) => {
         const dayIndiciesOcurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
-
+        const days = dayIndiciesOcurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
         return dayIndiciesOcurring.map((dayIndex) => {
             const startHour = parseInt(customEvent.start.slice(0, 2), 10);
             const startMin = parseInt(customEvent.start.slice(3, 5), 10);
@@ -135,6 +137,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
                 isCustomEvent: true,
                 end: new Date(2018, 0, dayIndex, endHour, endMin),
                 title: customEvent.title,
+                days: days,
             };
         });
     });

--- a/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
+++ b/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
@@ -1,0 +1,72 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`download-ics > converts schedule courses to events for the ics library 1`] = `
+[
+  {
+    "description": "placeholderCourseTitle
+Taught by placeholderInstructor1/placeholderInstructor2",
+    "end": [
+      2023,
+      9,
+      29,
+      3,
+      4,
+    ],
+    "endOutputType": "local",
+    "location": "placeholderLocation placeholderRoom",
+    "productId": "antalmanac/ics",
+    "recurrenceRule": "FREQ=WEEKLY;BYDAY=FR,MO,WE;INTERVAL=1;COUNT=31",
+    "start": [
+      2023,
+      9,
+      29,
+      1,
+      2,
+    ],
+    "startOutputType": "local",
+    "title": "placeholderDeptCode placeholderCourseNumber placeholderSectionType",
+  },
+  {
+    "description": "Final Exam for placeholderSectionType placeholderCourseTitle",
+    "end": [
+      2023,
+      3,
+      3,
+      3,
+      4,
+    ],
+    "endOutputType": "local",
+    "productId": "antalmanac/ics",
+    "start": [
+      2023,
+      3,
+      3,
+      1,
+      2,
+    ],
+    "startOutputType": "local",
+    "title": "placeholderDeptCode placeholderCourseNumber Final Exam",
+  },
+  {
+    "end": [
+      2023,
+      9,
+      29,
+      3,
+      4,
+    ],
+    "endOutputType": "local",
+    "productId": "antalmanac/ics",
+    "recurrenceRule": "FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=1;COUNT=31",
+    "start": [
+      2023,
+      9,
+      29,
+      1,
+      2,
+    ],
+    "startOutputType": "local",
+    "title": "placeholderCustomEventTitle",
+  },
+]
+`;

--- a/apps/antalmanac/tests/calendarize-helpers.test.ts
+++ b/apps/antalmanac/tests/calendarize-helpers.test.ts
@@ -208,6 +208,7 @@ describe('calendarize-helpers', () => {
             start: new Date(2018, 0, 0, 1, 2),
             end: new Date(2018, 0, 0, 3, 4),
             title: 'title',
+            days: ['Su', 'Tu', 'Th', 'Sa'],
         },
         {
             isCustomEvent: true,
@@ -216,6 +217,7 @@ describe('calendarize-helpers', () => {
             start: new Date(2018, 0, 2, 1, 2),
             end: new Date(2018, 0, 2, 3, 4),
             title: 'title',
+            days: ['Su', 'Tu', 'Th', 'Sa'],
         },
         {
             isCustomEvent: true,
@@ -224,6 +226,7 @@ describe('calendarize-helpers', () => {
             start: new Date(2018, 0, 4, 1, 2),
             end: new Date(2018, 0, 4, 3, 4),
             title: 'title',
+            days: ['Su', 'Tu', 'Th', 'Sa'],
         },
         {
             isCustomEvent: true,
@@ -232,6 +235,7 @@ describe('calendarize-helpers', () => {
             start: new Date(2018, 0, 6, 1, 2),
             end: new Date(2018, 0, 6, 3, 4),
             title: 'title',
+            days: ['Su', 'Tu', 'Th', 'Sa'],
         },
     ];
 

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -2,11 +2,11 @@ import { EventAttributes } from 'ics';
 import type { Schedule } from '@packages/antalmanac-types';
 import { describe, test, expect } from 'vitest';
 import { getEventsFromCourses } from '$lib/download';
-import { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
+import { CalendarEvent } from '$components/Calendar/CourseCalendarEvent';
 
 describe('download-ics', () => {
     test('converts schedule courses to events for the ics library', () => {
-        const courses: (CourseEvent | CustomEvent)[] = [
+        const courses: CalendarEvent[] = [
             // CourseEvent
             {
                 color: 'placeholderColor',
@@ -46,40 +46,6 @@ describe('download-ics', () => {
                 customEventID: 123,
                 isCustomEvent: true,
                 days: ['M', 'W', 'F'],
-            },
-        ];
-
-        const expectedResult: EventAttributes[] = [
-            {
-                productId: 'antalmanac/ics',
-                startOutputType: 'local',
-                endOutputType: 'local',
-                title: 'placeholderDeptCode placeholderCourseNumber placeholderSectionType',
-                description: 'placeholderCourseTitle\nTaught by placeholderInstructor1/placeholderInstructor2',
-                location: 'placeholderLocation placeholderRoom',
-                start: [2023, 9, 29, 1, 2],
-                end: [2023, 9, 29, 3, 4],
-                recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR,MO,WE;INTERVAL=1;COUNT=31',
-            },
-            {
-                productId: 'antalmanac/ics',
-                startOutputType: 'local',
-                endOutputType: 'local',
-                title: 'placeholderDeptCode placeholderCourseNumber Final Exam',
-                description: 'Final Exam for placeholderSectionType placeholderCourseTitle',
-                start: [2023, 3, 3, 1, 2],
-                end: [2023, 3, 3, 3, 4],
-            },
-            {
-                productId: 'antalmanac/ics',
-                startOutputType: 'local',
-                endOutputType: 'local',
-                title: 'placeholderCustomEventTitle',
-                // TODO: Add location to custom events, waiting for https://github.com/icssc/AntAlmanac/issues/249
-                // location: `${location.building} ${location.room}`,
-                start: [2023, 9, 29, 1, 2],
-                end: [2023, 9, 29, 3, 4],
-                recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=1;COUNT=31',
             },
         ];
 

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -85,7 +85,7 @@ describe('download-ics', () => {
 
         const result = getEventsFromCourses(courses);
 
-        expect(result).toEqual(expectedResult);
+        expect(result).toMatchSnapshot();
     });
 
     test('ics file has the correct contents', () => {

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -2,67 +2,50 @@ import { EventAttributes } from 'ics';
 import type { Schedule } from '@packages/antalmanac-types';
 import { describe, test, expect } from 'vitest';
 import { getEventsFromCourses } from '$lib/download';
+import { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 
 describe('download-ics', () => {
     test('converts schedule courses to events for the ics library', () => {
-        const courses: Schedule['courses'] = [
+        const courses: (CourseEvent | CustomEvent)[] = [
+            // CourseEvent
             {
-                courseComment: 'placeholderCourseComment',
-                courseNumber: 'placeholderCourseNumber',
-                courseTitle: 'placeholderCourseTitle',
-                deptCode: 'placeholderDeptCode',
-                prerequisiteLink: 'placeholderPrerequisiteLink',
-                section: {
-                    color: 'placeholderColor',
-                    sectionCode: 'placeholderSectionCode',
-                    sectionType: 'placeholderSectionType',
-                    sectionNum: 'placeholderSectionNum',
-                    units: 'placeholderUnits',
-                    instructors: ['placeholderInstructor1', 'placeholderInstructor2'],
-                    meetings: [
-                        {
-                            timeIsTBA: false,
-                            bldg: ['placeholderLocation'],
-                            days: 'MWF',
-                            startTime: {
-                                hour: 1,
-                                minute: 2,
-                            },
-                            endTime: {
-                                hour: 3,
-                                minute: 4,
-                            },
-                        },
-                    ],
-                    finalExam: {
-                        examStatus: 'SCHEDULED_FINAL',
-                        dayOfWeek: 'Sun',
-                        month: 2,
-                        day: 3,
-                        startTime: {
-                            hour: 1,
-                            minute: 2,
-                        },
-                        endTime: {
-                            hour: 3,
-                            minute: 4,
-                        },
-                        bldg: [],
+                color: 'placeholderColor',
+                start: new Date(2023, 9, 29, 1, 2),
+                end: new Date(2023, 9, 29, 3, 4),
+                title: 'placeholderDeptCode placeholderCourseNumber',
+                locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
+                showLocationInfo: true,
+                finalExam: {
+                    examStatus: 'SCHEDULED_FINAL',
+                    dayOfWeek: 'Mon',
+                    month: 2,
+                    day: 3,
+                    startTime: {
+                        hour: 1,
+                        minute: 2,
                     },
-                    maxCapacity: 'placeholderMaxCapacity',
-                    numCurrentlyEnrolled: {
-                        totalEnrolled: 'placeholderTotalEnrolled',
-                        sectionEnrolled: 'placeholderSectionEnrolled',
+                    endTime: {
+                        hour: 3,
+                        minute: 4,
                     },
-                    numOnWaitlist: 'placeholderNumOnWaitlist',
-                    numWaitlistCap: 'placeholderNumWaitlistCap',
-                    numRequested: 'placeholderNumRequested',
-                    numNewOnlyReserved: 'placeholderNumNewOnlyReserved',
-                    restrictions: 'placeholderRestrictions',
-                    status: 'OPEN',
-                    sectionComment: 'placeholderSectionComment',
+                    locations: [{ building: 'placeholderFinalLocation', room: 'placeholderFinalRoom', days: null }],
                 },
+                courseTitle: 'placeholderCourseTitle',
+                instructors: ['placeholderInstructor1', 'placeholderInstructor2'],
+                isCustomEvent: false,
+                sectionCode: 'placeholderSectionCode',
+                sectionType: 'placeholderSectionType',
                 term: '2023 Fall', // Cannot be a random placeholder; it has to be in `quarterStartDates` otherwise it'll be undefined
+            },
+            // CustomEvent
+            {
+                color: 'placeholderColor',
+                start: new Date(2023, 9, 29, 1, 2),
+                end: new Date(2023, 9, 29, 3, 4),
+                title: 'placeholderCustomEventTitle',
+                customEventID: 123,
+                isCustomEvent: true,
+                days: ['M', 'W', 'F'],
             },
         ];
 
@@ -73,7 +56,7 @@ describe('download-ics', () => {
                 endOutputType: 'local',
                 title: 'placeholderDeptCode placeholderCourseNumber placeholderSectionType',
                 description: 'placeholderCourseTitle\nTaught by placeholderInstructor1/placeholderInstructor2',
-                location: 'placeholderLocation',
+                location: 'placeholderLocation placeholderRoom',
                 start: [2023, 9, 29, 1, 2],
                 end: [2023, 9, 29, 3, 4],
                 recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR,MO,WE;INTERVAL=1;COUNT=31',
@@ -83,13 +66,25 @@ describe('download-ics', () => {
                 startOutputType: 'local',
                 endOutputType: 'local',
                 title: 'placeholderDeptCode placeholderCourseNumber Final Exam',
-                description: 'Final Exam for placeholderCourseTitle',
+                description: 'Final Exam for placeholderSectionType placeholderCourseTitle',
                 start: [2023, 3, 3, 1, 2],
                 end: [2023, 3, 3, 3, 4],
+            },
+            {
+                productId: 'antalmanac/ics',
+                startOutputType: 'local',
+                endOutputType: 'local',
+                title: 'placeholderCustomEventTitle',
+                // TODO: Add location to custom events, waiting for https://github.com/icssc/AntAlmanac/issues/249
+                // location: `${location.building} ${location.room}`,
+                start: [2023, 9, 29, 1, 2],
+                end: [2023, 9, 29, 3, 4],
+                recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=1;COUNT=31',
             },
         ];
 
         const result = getEventsFromCourses(courses);
+        console.log(result);
 
         expect(result).toEqual(expectedResult);
     });

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -28,7 +28,7 @@ describe('download-ics', () => {
                         hour: 3,
                         minute: 4,
                     },
-                    locations: [{ building: 'placeholderFinalLocation', room: 'placeholderFinalRoom', days: null }],
+                    locations: [{ building: 'placeholderFinalLocation', room: 'placeholderFinalRoom' }],
                 },
                 courseTitle: 'placeholderCourseTitle',
                 instructors: ['placeholderInstructor1', 'placeholderInstructor2'],
@@ -84,7 +84,6 @@ describe('download-ics', () => {
         ];
 
         const result = getEventsFromCourses(courses);
-        console.log(result);
 
         expect(result).toEqual(expectedResult);
     });


### PR DESCRIPTION
## Summary
This change does refactoring to have ExportCalendar use `getEventsInCalendar` instead of `getCurrentCourses`

## Test Plan
Tests passed. I also added some courses and custom events to test manully. Works fine.

## Issues

Closes https://github.com/icssc/AntAlmanac/issues/147


## Future Followup

1. Add `location` to customEvent when https://github.com/icssc/AntAlmanac/issues/249 is done.
2. Find a way to get the term for the corresponding custom event. Now we are using the default term.
