### PR TITLE
Open error snackbar when we get an error during search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -18,6 +18,7 @@ import AppStore from '$stores/AppStore';
 import { isDarkMode, queryWebsoc, queryWebsocMultiple } from '$lib/helpers';
 import Grades from '$lib/grades';
 import analyticsEnum from '$lib/analytics';
+import { openSnackbar } from '$actions/AppStoreActions';
 
 function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocDepartment | AACourse)[] {
     const courseColors = AppStore.getAddedCourses().reduce((accumulator, { section }) => {
@@ -40,7 +41,7 @@ function flattenSOCObject(SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
 
         return accumulator;
     }, []);
-};
+}
 const RecruitmentBanner = () => {
     const [bannerVisibility, setBannerVisibility] = React.useState<boolean>(true);
 
@@ -195,7 +196,9 @@ export function CourseRenderPane() {
             setError(false);
             setCourseData(flattenSOCObject(websocJsonResp));
         } catch (error) {
+            console.error(error);
             setError(true);
+            openSnackbar('error', 'We ran into an error while looking up class info');
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## Summary
Open an error snackbar and log to console when we get an error during search. This shouldn't trigger when we legitimately can't find 
## Test Plan
Search up a class not offered this quarter, and it shouldn't open the error snackbar. Rn the API is flaky so if you search enough times you'll be able to see an error, and verify on the network tab the request didn't work.