### PR TITLE
Consistently disabled gpa column on added tab

### DIFF
--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import useTabStore from './TabStore';
 
 /**
  * Search results are displayed in a tabular format.
@@ -50,14 +51,24 @@ interface ColumnStore {
     setColumnEnabled: (column: SectionTableColumn, state: boolean) => void;
 }
 
+// Don't enable GPA column if the user is on the Added tab
+const enabledColumnsInitial = SECTION_TABLE_COLUMNS.map(
+    (col) => !(window.location.pathname.split('/').slice(1)[0] === 'added' && col === 'gpa')
+);
+console.log(window.location.pathname.split('/').slice(1)[0] === 'added')
+const selectedColumnsInitial = SECTION_TABLE_COLUMNS.map(() => true);
+const activeColumnsInitial = SECTION_TABLE_COLUMNS.filter(
+    (_, index) => enabledColumnsInitial[index] && selectedColumnsInitial[index]
+);
+
 /**
  * Store of columns that are currently being displayed in the search results.
  */
 export const useColumnStore = create<ColumnStore>((set, get) => {
     return {
-        enabledColumns: SECTION_TABLE_COLUMNS.map(() => true),
-        selectedColumns: SECTION_TABLE_COLUMNS.map(() => true),
-        activeColumns: Array.from(SECTION_TABLE_COLUMNS),
+        enabledColumns: enabledColumnsInitial,
+        selectedColumns: selectedColumnsInitial,
+        activeColumns: activeColumnsInitial,
         setSelectedColumns: (columns: SectionTableColumn[]) => {
             set(() => {
                 const selectedColumns = SECTION_TABLE_COLUMNS.map((column) => columns.includes(column));

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -55,7 +55,6 @@ interface ColumnStore {
 const enabledColumnsInitial = SECTION_TABLE_COLUMNS.map(
     (col) => !(window.location.pathname.split('/').slice(1)[0] === 'added' && col === 'gpa')
 );
-console.log(window.location.pathname.split('/').slice(1)[0] === 'added')
 const selectedColumnsInitial = SECTION_TABLE_COLUMNS.map(() => true);
 const activeColumnsInitial = SECTION_TABLE_COLUMNS.filter(
     (_, index) => enabledColumnsInitial[index] && selectedColumnsInitial[index]


### PR DESCRIPTION
## Summary
The GPA column should not display in the `added` tab, but the code previously did not account for when you enter the page directly into the added tab via URL routing. This PR fixes that.

## Test Plan
1) Have a schedule name loaded in `localStorage` that has classes added.
2) Visit the page on `/added`
3) Confirm that the GPA column is not there

## Issues

Closes #744 
