### PR TITLE
fix: Column Toggle Select Element Positioning

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -67,7 +67,7 @@ export function ColumnToggleButton() {
         store.setSelectedColumns,
     ]);
     const [anchorEl, setAnchorEl] = useState<HTMLElement>();
-    const open = useMemo(() => Boolean(anchorEl), [anchorEl]);
+    const open = Boolean(anchorEl);
 
     const handleChange = useCallback(
         (e: SelectChangeEvent<SectionTableColumn[]>) => {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
     Box,
     Checkbox,
@@ -10,6 +10,7 @@ import {
     Tooltip,
     type SelectChangeEvent,
     type SxProps,
+    Popover,
 } from '@mui/material';
 import { ArrowBack, Visibility, Refresh } from '@mui/icons-material';
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
@@ -65,20 +66,24 @@ export function ColumnToggleButton() {
         store.selectedColumns,
         store.setSelectedColumns,
     ]);
-    const [open, setOpen] = useState(false);
+    const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+    const open = useMemo(() => Boolean(anchorEl), [anchorEl]);
 
-    const handleChange = useCallback((e: SelectChangeEvent<SectionTableColumn[]>) => {
-        if (typeof e.target.value !== 'string') {
-            setSelectedColumns(e.target.value);
-        }
+    const handleChange = useCallback(
+        (e: SelectChangeEvent<SectionTableColumn[]>) => {
+            if (typeof e.target.value !== 'string') {
+                setSelectedColumns(e.target.value);
+            }
+        },
+        [setSelectedColumns]
+    );
+
+    const handleClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
     }, []);
 
-    const handleOpen = useCallback(() => {
-        setOpen(true);
-    }, [setOpen]);
-
     const handleClose = useCallback(() => {
-        setOpen(false);
+        setAnchorEl(undefined);
     }, []);
 
     const selectedColumnNames = useMemo(
@@ -89,28 +94,31 @@ export function ColumnToggleButton() {
     return (
         <>
             <Tooltip title="Show/Hide Columns">
-                <IconButton onClick={handleOpen} sx={buttonSx}>
+                <IconButton onClick={handleClick} sx={buttonSx}>
                     <Visibility />
                 </IconButton>
             </Tooltip>
-            <FormControl>
-                <Select
-                    multiple
-                    value={selectedColumnNames}
-                    open={open}
-                    onChange={handleChange}
-                    onClose={handleClose}
-                    renderValue={renderEmptySelectValue}
-                    sx={{ visibility: 'hidden', position: 'absolute' }}
-                >
-                    {COLUMN_LABEL_ENTRIES.map(([column, label], index) => (
-                        <MenuItem key={column} value={column}>
-                            <Checkbox checked={selectedColumns[index]} color="default" />
-                            <ListItemText primary={label} />
-                        </MenuItem>
-                    ))}
-                </Select>
-            </FormControl>
+
+            <Popover open={open} anchorEl={anchorEl} onClose={handleClose} sx={{ visibility: 'hidden' }}>
+                <FormControl>
+                    <Select
+                        multiple
+                        value={selectedColumnNames}
+                        open={open}
+                        onChange={handleChange}
+                        onClose={handleClose}
+                        renderValue={renderEmptySelectValue}
+                        MenuProps={{ anchorEl }}
+                    >
+                        {COLUMN_LABEL_ENTRIES.map(([column, label], index) => (
+                            <MenuItem key={column} value={column}>
+                                <Checkbox checked={selectedColumns[index]} color="default" />
+                                <ListItemText primary={label} />
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+            </Popover>
         </>
     );
 }


### PR DESCRIPTION
## Summary
The Select element was positioned to a `visibility: 'hidden'` FormControl, not the IconButton as it should have. This creates an off-centered visual experience.

Before:
![](https://user-images.githubusercontent.com/100006999/277142385-82976f9e-59a7-4c01-bdb6-32d7ae25a19b.png)

After:
<img width="706" alt="Screenshot 2023-10-21 at 7 35 03 PM" src="https://github.com/icssc/AntAlmanac/assets/100006999/a244570f-e846-44f0-8faf-8cdec9d5d876">

## Test Plan
1. This change is primarily visual in nature, so confirm that the positioning is correct on mobile and on desktop
2. Additionally, there was some bugginess while adding the Popover and Select, so make sure that selecting and deselecting elements doesn't reposition the element (it shouldn't)

## Issues
Closes #753

<!-- [Optional]
## Future Followup
-->
