### PR TITLE
Grades error does not fail search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -202,7 +202,12 @@ export default function CourseRenderPane(props: { id?: number }) {
                 websocQueryParams.units.includes(',')
                     ? WebSOC.queryMultiple(websocQueryParams, 'units')
                     : WebSOC.query(websocQueryParams),
-                Grades.populateGradesCache(gradesQueryParams),
+                // Catch the error here so that the course pane still loads even if the grades cache fails to populate
+                Grades.populateGradesCache(gradesQueryParams)
+                    .catch((error) => {
+                        console.error(error);
+                        openSnackbar('error', 'Error loading grades information');
+                    }),
             ]);
 
             setError(false);


### PR DESCRIPTION
## Summary
Display an error message but do not fail search when the grades API fails

## Test Plan
1) Block the grades API using FireFox devtools or change the graphql API endpoint.
2) Search and see that course information (except for GPA) still show up as normal

## Issues

Closes #746