### PR TITLE
Added a listener for colorChange

### DIFF
--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -102,10 +102,12 @@ export default function CourseMap() {
 
         AppStore.on('addedCoursesChange', updateMarkers);
         AppStore.on('currentScheduleIndexChange', updateMarkers);
+        AppStore.on('colorChange', updateMarkers);
 
         return () => {
             AppStore.removeListener('addedCoursesChange', updateMarkers);
             AppStore.removeListener('currentScheduleIndexChange', updateMarkers);
+            AppStore.removeListener('colorChange', updateMarkers);
         };
     }, []);
 


### PR DESCRIPTION
## Summary
This change added a listener for colorChange from Appstore, allowing immediate update of color on map.
## Test Plan
Tested manually. Marker color gets updated expectedly.
![ezgif-5-632d07bff7](https://github.com/icssc/AntAlmanac/assets/110846941/37b5e16b-6e29-490f-85a5-e6531e818e39)
## Issues
Closes #747 