### PR TITLE
Fix weird columns behavior

### DIFF
--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -72,7 +72,7 @@ export const useColumnStore = create<ColumnStore>((set, get) => {
             set(() => {
                 const selectedColumns = SECTION_TABLE_COLUMNS.map((column) => columns.includes(column));
                 const activeColumns = SECTION_TABLE_COLUMNS.filter(
-                    (_, index) => get().enabledColumns[index] && get().selectedColumns[index]
+                    (_, index) => get().enabledColumns[index] && selectedColumns[index]
                 );
                 return { selectedColumns: selectedColumns, activeColumns: activeColumns };
             });


### PR DESCRIPTION
## Summary
Columns show/hide didn't work properly, per #737. 

CoPilot wrote the code, and I missed the fact that it was reading `prevState` instead of the current value. All my fault, of course, but we should've caught this in review.

## Test Plan
Check that the column toggles work properly in the two panes.

## Issues

Closes #737