### PR TITLE
feat: Add 24 Hour Time Format

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -2,10 +2,8 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import './calendar.css';
 
 import { Box, ClickAwayListener, Popper } from '@material-ui/core';
-import { Theme, withStyles } from '@material-ui/core/styles';
-import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import moment from 'moment';
-import { PureComponent, SyntheticEvent } from 'react';
+import { SyntheticEvent, useEffect, useState } from 'react';
 import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calendar';
 
 import CalendarToolbar from './CalendarToolbar';
@@ -14,128 +12,102 @@ import AppStore from '$stores/AppStore';
 
 const localizer = momentLocalizer(moment);
 
-/*
-This is the composition structure of everything in components/Calendar, updated as of PR #411
-I did the file restructure for the folder based on this tree, so thought I 
-might as well include it since I made it. The file structure is close but doesn't
-match exactly.
-
-CalendarRoot
-    CourseCalendarEvent
-    CalendarToolbar
-        CustomEventDialog
-            DaySelector
-            ScheduleSelector
-        ScreenshotButton
-        ExportCalendar
-        ScheduleNameDialog (reused below)
-        EditSchedule
-            ScheduleNameDialog (reused above)
-            DeleteScheduleDialog
-*/
-
-const styles: Styles<Theme, object> = {
-    container: {
-        margin: '0px 4px',
-        borderRadius: '1px',
-    },
-    firstLineContainer: {
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: 'space-between',
-        fontWeight: 500,
-        fontSize: '0.8rem',
-    },
-    sectionType: {
-        fontSize: '0.8rem',
-    },
-    secondLineContainer: {
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: 'space-between',
-        fontSize: '0.7rem',
-    },
-    customEventContainer: {
-        marginTop: 2,
-        marginBottom: 2,
-        fontSize: '0.85rem',
-    },
-    customEventTitle: {
-        fontWeight: 500,
-    },
+const AntAlmanacEvent = ({ event }: { event: CalendarEvent }) => {
+    return event.isCustomEvent ? (
+        <Box style={{ marginTop: 2, marginBottom: 2, fontSize: '0.85rem' }}>
+            <Box style={{ fontWeight: 500 }}>{event.title}</Box>
+        </Box>
+    ) : (
+        <Box>
+            <Box
+                style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    justifyContent: 'space-between',
+                    fontWeight: 500,
+                    fontSize: '0.8rem',
+                }}
+            >
+                <Box>{event.title}</Box>
+                <Box style={{ fontSize: '0.8rem' }}> {event.sectionType}</Box>
+            </Box>
+            <Box style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', fontSize: '0.7rem' }}>
+                <Box>
+                    {event.showLocationInfo
+                        ? event.locations.map((location) => `${location.building} ${location.room}`).join(', ')
+                        : event.locations.length > 1
+                        ? `${event.locations.length} Locations`
+                        : `${event.locations[0].building} ${event.locations[0].room}`}
+                </Box>
+                <Box>{event.sectionCode}</Box>
+            </Box>
+        </Box>
+    );
 };
 
-const AntAlmanacEvent =
-    ({ classes }: { classes: ClassNameMap }) =>
-    // eslint-disable-next-line react/display-name
-    ({ event }: { event: CalendarEvent }) => {
-        return event.isCustomEvent ? (
-            <div className={classes.customEventContainer}>
-                <div className={classes.customEventTitle}>{event.title}</div>
-            </div>
-        ) : (
-            <div>
-                <div className={classes.firstLineContainer}>
-                    <div> {event.title}</div>
-                    <div className={classes.sectionType}> {event.sectionType}</div>
-                </div>
-                <div className={classes.secondLineContainer}>
-                    <div>
-                        {event.showLocationInfo
-                            ? event.locations.map((location) => `${location.building} ${location.room}`).join(', ')
-                            : event.locations.length > 1
-                            ? `${event.locations.length} Locations`
-                            : `${event.locations[0].building} ${event.locations[0].room}`}
-                    </div>
-                    <div>{event.sectionCode}</div>
-                </div>
-            </div>
-        );
-    };
 interface ScheduleCalendarProps {
-    classes: ClassNameMap;
     isMobile: boolean;
 }
 
-interface ScheduleCalendarState {
-    screenshotting: boolean;
-    anchorEl: HTMLElement | null;
-    showFinalsSchedule: boolean;
-    moreInfoOpen: false;
-    courseInMoreInfo: CalendarEvent | null;
-    calendarEventKey: number | null;
-    eventsInCalendar: CalendarEvent[];
-    finalsEventsInCalendar: CalendarEvent[];
-    currentScheduleIndex: number;
-    scheduleNames: string[];
-}
-class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCalendarState> {
-    state: ScheduleCalendarState = {
-        screenshotting: false,
-        anchorEl: null,
-        showFinalsSchedule: false,
-        moreInfoOpen: false,
-        courseInMoreInfo: null,
-        calendarEventKey: null,
-        eventsInCalendar: AppStore.getEventsInCalendar(),
-        finalsEventsInCalendar: AppStore.getFinalEventsInCalendar(),
-        currentScheduleIndex: AppStore.getCurrentScheduleIndex(),
-        scheduleNames: AppStore.getScheduleNames(),
+export default function ScheduleCalendar(props: ScheduleCalendarProps) {
+    const { isMobile } = props;
+
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const [showFinalsSchedule, setShowFinalsSchedule] = useState(false);
+    const [courseInMoreInfo, setCourseInMoreInfo] = useState<CalendarEvent | null>(null);
+    const [calendarEventKey, setCalendarEventKey] = useState<number | null>(null);
+    const [eventsInCalendar, setEventsInCalendar] = useState(AppStore.getEventsInCalendar());
+    const [finalsEventsInCalendar, setFinalEventsInCalendar] = useState(AppStore.getFinalEventsInCalendar());
+    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+
+    const getEventsForCalendar = () => {
+        return showFinalsSchedule ? finalsEventsInCalendar : eventsInCalendar;
     };
 
-    static eventStyleGetter = (event: CalendarEvent) => {
+    const handleClosePopover = () => {
+        setAnchorEl(null);
+    };
+
+    const toggleDisplayFinalsSchedule = () => {
+        handleClosePopover();
+
+        setShowFinalsSchedule((prevState) => !prevState);
+    };
+
+    const handleEventClick = (event: CalendarEvent, e: SyntheticEvent<HTMLElement, Event>) => {
+        const { currentTarget } = e;
+        e.stopPropagation();
+
+        if (event.isCustomEvent || event.sectionType !== 'Fin') {
+            setAnchorEl((prevAnchorEl) => (prevAnchorEl === currentTarget ? null : currentTarget));
+            setCourseInMoreInfo(event);
+            setCalendarEventKey(Math.random());
+        }
+    };
+
+    /**
+     * Finds the earliest start time and returns that or 7AM, whichever is earlier
+     * @returns A date with the earliest time or 7AM
+     */
+    const getStartTime = () => {
+        const eventStartHours = getEventsForCalendar().map((event) => event.start.getHours());
+        return new Date(2018, 0, 1, Math.min(7, Math.min(...eventStartHours)));
+    };
+
+    const eventStyleGetter = (event: CalendarEvent) => {
         return {
             style: {
                 backgroundColor: event.color,
                 cursor: 'pointer',
                 borderStyle: 'none',
                 borderRadius: '4px',
-                color: this.colorContrastSufficient(event.color) ? 'white' : 'black',
+                color: colorContrastSufficient(event.color) ? 'white' : 'black',
             },
         };
     };
 
-    static colorContrastSufficient = (bg: string) => {
+    const colorContrastSufficient = (bg: string) => {
         // This equation is taken from w3c, does not use the colour difference part
         const minBrightnessDiff = 125;
 
@@ -156,176 +128,112 @@ class ScheduleCalendar extends PureComponent<ScheduleCalendarProps, ScheduleCale
         return Math.abs(bgBrightness - textBrightness) > minBrightnessDiff;
     };
 
-    toggleDisplayFinalsSchedule = () => {
-        this.handleClosePopover();
+    const events = getEventsForCalendar();
+    const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
+    const calendarStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
 
-        this.setState((prevState) => {
-            return { showFinalsSchedule: !prevState.showFinalsSchedule };
-        });
-    };
+    // If a final is on a Saturday or Sunday, let the calendar start on Saturday
+    moment.updateLocale('es-us', {
+        week: {
+            dow: hasWeekendCourse && showFinalsSchedule ? 6 : 0,
+        },
+    });
 
-    updateEventsInCalendar = (close = true) => {
-        this.setState({
-            currentScheduleIndex: AppStore.getCurrentScheduleIndex(),
-            eventsInCalendar: AppStore.getEventsInCalendar(),
-            finalsEventsInCalendar: AppStore.getFinalEventsInCalendar(),
-        });
-        if (close) this.handleClosePopover();
-    };
+    useEffect(() => {
+        const updateEventsInCalendar = () => {
+            setCurrentScheduleIndex(AppStore.getCurrentScheduleIndex());
+            setEventsInCalendar(AppStore.getEventsInCalendar());
+            setFinalEventsInCalendar(AppStore.getFinalEventsInCalendar());
 
-    updateScheduleNames = () => {
-        this.setState({
-            scheduleNames: AppStore.getScheduleNames(),
-        });
-    };
-
-    componentDidMount = () => {
-        AppStore.on('addedCoursesChange', this.updateEventsInCalendar);
-        AppStore.on('customEventsChange', this.updateEventsInCalendar);
-        AppStore.on('colorChange', this.updateEventsInCalendar);
-        AppStore.on('currentScheduleIndexChange', this.updateEventsInCalendar);
-        AppStore.on('scheduleNamesChange', this.updateScheduleNames);
-    };
-
-    componentWillUnmount = () => {
-        AppStore.removeListener('addedCoursesChange', this.updateEventsInCalendar);
-        AppStore.removeListener('customEventsChange', this.updateEventsInCalendar);
-        AppStore.removeListener('colorChange', this.updateEventsInCalendar);
-        AppStore.removeListener('currentScheduleIndexChange', this.updateEventsInCalendar);
-        AppStore.removeListener('scheduleNamesChange', this.updateScheduleNames);
-    };
-
-    handleTakeScreenshot = (html2CanvasScreenshot: () => void) => {
-        // This function takes a screenshot of the user's schedule
-
-        this.setState({ screenshotting: true }, () => {
-            // Take the picture
-            html2CanvasScreenshot();
-
-            this.setState({ screenshotting: false });
-        });
-    };
-
-    handleEventClick = (event: CalendarEvent, e: SyntheticEvent<HTMLElement, Event>) => {
-        const { currentTarget } = e;
-        e.stopPropagation();
-
-        if (event.isCustomEvent || event.sectionType !== 'Fin') {
-            this.setState((prevState) => ({
-                anchorEl: prevState.anchorEl === currentTarget ? null : currentTarget,
-                courseInMoreInfo: event,
-                calendarEventKey: Math.random(),
-            }));
-        }
-    };
-
-    handleClosePopover = () => {
-        this.setState({ anchorEl: null });
-    };
-
-    getEventsForCalendar = () => {
-        return this.state.showFinalsSchedule ? this.state.finalsEventsInCalendar : this.state.eventsInCalendar;
-    };
-
-    getStartTime = () => {
-        const eventStartHours = this.getEventsForCalendar().map((event) => event.start.getHours());
-        // If the earliest event has an earlier start time than 7am, return its hour;
-        // otherwise, just make 7am the start time
-        return new Date(2018, 0, 1, Math.min(7, Math.min(...eventStartHours)));
-    };
-
-    render() {
-        const { classes, isMobile } = this.props;
-        const events = this.getEventsForCalendar();
-        const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
-        const calStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
-
-        // If a final is on a Saturday or Sunday, let the calendar start on Saturday
-        moment.updateLocale('es-us', {
-            week: {
-                dow: hasWeekendCourse && this.state.showFinalsSchedule ? 6 : 0,
-            },
-        });
-
-        const handleOnView = () => {
-            return;
+            handleClosePopover();
         };
 
-        return (
-            <div className={classes.container} style={isMobile ? { height: 'calc(100% - 50px)' } : undefined}>
-                <CalendarToolbar
-                    currentScheduleIndex={this.state.currentScheduleIndex}
-                    toggleDisplayFinalsSchedule={this.toggleDisplayFinalsSchedule}
-                    showFinalsSchedule={this.state.showFinalsSchedule}
-                    scheduleNames={this.state.scheduleNames}
-                />
-                <div
-                    id="screenshot"
-                    style={
-                        !this.state.screenshotting
-                            ? calStyling
-                            : {
-                                  height: '100%',
-                                  width: '1000px',
-                              }
-                    }
-                >
-                    <Popper
-                        anchorEl={this.state.anchorEl}
-                        placement="right"
-                        modifiers={{
-                            offset: {
-                                enabled: true,
-                                offset: '0, 10',
-                            },
-                            flip: {
-                                enabled: true,
-                            },
-                            preventOverflow: {
-                                enabled: true,
-                                boundariesElement: 'scrollParent',
-                            },
-                        }}
-                        open={Boolean(this.state.anchorEl)}
-                    >
-                        <ClickAwayListener onClickAway={this.handleClosePopover}>
-                            <Box>
-                                <CourseCalendarEvent
-                                    key={this.state.calendarEventKey}
-                                    closePopover={this.handleClosePopover}
-                                    courseInMoreInfo={this.state.courseInMoreInfo as CalendarEvent}
-                                    scheduleNames={this.state.scheduleNames}
-                                />
-                            </Box>
-                        </ClickAwayListener>
-                    </Popper>
-                    <Calendar<CalendarEvent, object>
-                        localizer={localizer}
-                        toolbar={false}
-                        formats={{
-                            timeGutterFormat: (date: Date, culture?: string, localizer?: DateLocalizer) =>
-                                date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, 'h A', culture),
-                            dayFormat: 'ddd',
-                        }}
-                        views={[Views.WEEK, Views.WORK_WEEK]}
-                        defaultView={Views.WORK_WEEK}
-                        view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
-                        onView={handleOnView}
-                        step={15}
-                        timeslots={2}
-                        defaultDate={new Date(2018, 0, 1)}
-                        min={this.getStartTime()}
-                        max={new Date(2018, 0, 1, 23)}
-                        events={events}
-                        eventPropGetter={ScheduleCalendar.eventStyleGetter}
-                        showMultiDayTimes={false}
-                        components={{ event: AntAlmanacEvent({ classes }) }}
-                        onSelectEvent={this.handleEventClick}
-                    />
-                </div>
-            </div>
-        );
-    }
-}
+        const updateScheduleNames = () => {
+            setScheduleNames(AppStore.getScheduleNames());
+        };
 
-export default withStyles(styles)(ScheduleCalendar);
+        AppStore.on('addedCoursesChange', updateEventsInCalendar);
+        AppStore.on('customEventsChange', updateEventsInCalendar);
+        AppStore.on('colorChange', updateEventsInCalendar);
+        AppStore.on('currentScheduleIndexChange', updateEventsInCalendar);
+        AppStore.on('scheduleNamesChange', updateScheduleNames);
+
+        return () => {
+            AppStore.off('addedCoursesChange', updateEventsInCalendar);
+            AppStore.off('customEventsChange', updateEventsInCalendar);
+            AppStore.off('colorChange', updateEventsInCalendar);
+            AppStore.off('currentScheduleIndexChange', updateEventsInCalendar);
+            AppStore.off('scheduleNamesChange', updateScheduleNames);
+        };
+    }, []);
+
+    return (
+        <Box
+            style={{
+                height: isMobile ? 'calc(100% - 50px)' : undefined,
+                margin: '0px 4px',
+                borderRadius: '1px',
+            }}
+        >
+            <CalendarToolbar
+                currentScheduleIndex={currentScheduleIndex}
+                toggleDisplayFinalsSchedule={toggleDisplayFinalsSchedule}
+                showFinalsSchedule={showFinalsSchedule}
+                scheduleNames={scheduleNames}
+            />
+            <Box id="screenshot" style={calendarStyling}>
+                <Popper
+                    anchorEl={anchorEl}
+                    placement="right"
+                    modifiers={{
+                        offset: {
+                            enabled: true,
+                            offset: '0, 10',
+                        },
+                        flip: {
+                            enabled: true,
+                        },
+                        preventOverflow: {
+                            enabled: true,
+                            boundariesElement: 'scrollParent',
+                        },
+                    }}
+                    open={Boolean(anchorEl)}
+                >
+                    <ClickAwayListener onClickAway={handleClosePopover}>
+                        <Box>
+                            <CourseCalendarEvent
+                                key={calendarEventKey}
+                                closePopover={handleClosePopover}
+                                courseInMoreInfo={courseInMoreInfo as CalendarEvent}
+                                scheduleNames={scheduleNames}
+                            />
+                        </Box>
+                    </ClickAwayListener>
+                </Popper>
+                <Calendar<CalendarEvent, object>
+                    localizer={localizer}
+                    toolbar={false}
+                    formats={{
+                        timeGutterFormat: (date: Date, culture?: string, localizer?: DateLocalizer) =>
+                            date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, 'h A', culture),
+                        dayFormat: 'ddd',
+                    }}
+                    views={[Views.WEEK, Views.WORK_WEEK]}
+                    defaultView={Views.WORK_WEEK}
+                    view={hasWeekendCourse ? Views.WEEK : Views.WORK_WEEK}
+                    step={15}
+                    timeslots={2}
+                    defaultDate={new Date(2018, 0, 1)}
+                    min={getStartTime()}
+                    max={new Date(2018, 0, 1, 23)}
+                    events={events}
+                    eventPropGetter={eventStyleGetter}
+                    showMultiDayTimes={false}
+                    components={{ event: AntAlmanacEvent }}
+                    onSelectEvent={handleEventClick}
+                />
+            </Box>
+        </Box>
+    );
+}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -62,7 +62,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
-    const { timeFormat } = useTimeFormatStore();
+    const { isMilitaryTime } = useTimeFormatStore();
 
     const getEventsForCalendar = () => {
         return showFinalsSchedule ? finalsEventsInCalendar : eventsInCalendar;
@@ -134,7 +134,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const events = getEventsForCalendar();
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
     const calendarStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
-    const calendarTimeFormat = timeFormat ? 'HH:mm' : 'h A';
+    const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
 
     // If a final is on a Saturday or Sunday, let the calendar start on Saturday
     moment.updateLocale('es-us', {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -9,6 +9,7 @@ import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calen
 import CalendarToolbar from './CalendarToolbar';
 import CourseCalendarEvent, { CalendarEvent } from './CourseCalendarEvent';
 import AppStore from '$stores/AppStore';
+import { useTimeFormatStore } from '$stores/TimeStore';
 
 const localizer = momentLocalizer(moment);
 
@@ -60,6 +61,8 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [finalsEventsInCalendar, setFinalEventsInCalendar] = useState(AppStore.getFinalEventsInCalendar());
     const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+
+    const { timeFormat } = useTimeFormatStore();
 
     const getEventsForCalendar = () => {
         return showFinalsSchedule ? finalsEventsInCalendar : eventsInCalendar;
@@ -131,6 +134,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const events = getEventsForCalendar();
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
     const calendarStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
+    const calendarTimeFormat = timeFormat ? 'HH:mm' : 'h A';
 
     // If a final is on a Saturday or Sunday, let the calendar start on Saturday
     moment.updateLocale('es-us', {
@@ -216,8 +220,20 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
                     toolbar={false}
                     formats={{
                         timeGutterFormat: (date: Date, culture?: string, localizer?: DateLocalizer) =>
-                            date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, 'h A', culture),
+                            date.getMinutes() > 0 || !localizer
+                                ? ''
+                                : localizer.format(date, calendarTimeFormat, culture),
                         dayFormat: 'ddd',
+                        eventTimeRangeFormat: (
+                            range: { start: Date; end: Date },
+                            culture?: string,
+                            localizer?: DateLocalizer
+                        ) =>
+                            !localizer
+                                ? ''
+                                : localizer.format(range.start, calendarTimeFormat, culture) +
+                                  ' - ' +
+                                  localizer.format(range.end, calendarTimeFormat, culture),
                     }}
                     views={[Views.WEEK, Views.WORK_WEEK]}
                     defaultView={Views.WORK_WEEK}

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -14,7 +14,8 @@ import { clickToCopy, isDarkMode } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
 import locationIds from '$lib/location_ids';
 import { useTabStore } from '$stores/TabStore';
-import { translate24To12HourTime } from '$stores/calendarizeHelpers';
+import { formatTimes } from '$stores/calendarizeHelpers';
+import { useTimeFormatStore } from '$stores/TimeStore';
 
 const styles: Styles<Theme, object> = {
     courseContainer: {
@@ -170,6 +171,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     }, []);
 
     const { setActiveTab } = useTabStore();
+    const { timeFormat } = useTimeFormatStore();
 
     const focusMap = useCallback(() => {
         setActiveTab(2);
@@ -188,7 +190,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
             finalExamString = 'Final TBA';
         } else {
             if (finalExam.startTime && finalExam.endTime && finalExam.month && finalExam.locations) {
-                const timeString = translate24To12HourTime(finalExam.startTime, finalExam.endTime);
+                const timeString = formatTimes(finalExam.startTime, finalExam.endTime, timeFormat);
                 const locationString = `at ${finalExam.locations
                     .map((location) => `${location.building} ${location.room}`)
                     .join(', ')}`;

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -171,7 +171,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
     }, []);
 
     const { setActiveTab } = useTabStore();
-    const { timeFormat } = useTimeFormatStore();
+    const { isMilitaryTime } = useTimeFormatStore();
 
     const focusMap = useCallback(() => {
         setActiveTab(2);
@@ -190,7 +190,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
             finalExamString = 'Final TBA';
         } else {
             if (finalExam.startTime && finalExam.endTime && finalExam.month && finalExam.locations) {
-                const timeString = formatTimes(finalExam.startTime, finalExam.endTime, timeFormat);
+                const timeString = formatTimes(finalExam.startTime, finalExam.endTime, isMilitaryTime);
                 const locationString = `at ${finalExam.locations
                     .map((location) => `${location.building} ${location.room}`)
                     .join(', ')}`;

--- a/apps/antalmanac/src/components/Calendar/calendar.css
+++ b/apps/antalmanac/src/components/Calendar/calendar.css
@@ -34,6 +34,15 @@
 
 .rbc-label {
     font-size: 0.9rem;
+    width: 41.8438px;
+}
+
+.rbc-time-header-gutter {
+    width: 42px;
+}
+
+.rbc-time-gutter {
+    width: 42px;
 }
 
 @media (min-resolution: 96dpi) {

--- a/apps/antalmanac/src/components/Calendar/calendar.css
+++ b/apps/antalmanac/src/components/Calendar/calendar.css
@@ -34,7 +34,6 @@
 
 .rbc-label {
     font-size: 0.9rem;
-    width: 41.8438px;
 }
 
 .rbc-time-header-gutter {

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -43,12 +43,12 @@ interface CustomAppBarProps {
 }
 
 const components = [
-    <SettingsMenu key="settings" />,
     <ImportStudyList key="studylist" />,
     <Export key="export" />,
     <Feedback key="feedback" />,
     <News key="news" />,
     <AboutPage key="about" />,
+    <SettingsMenu key="settings" />,
 ];
 
 const Header = ({ classes }: CustomAppBarProps) => {

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -1,16 +1,33 @@
-import { Button, FormControl, FormControlLabel, Paper, Popover, Radio, RadioGroup } from '@material-ui/core';
+import {
+    Box,
+    Button,
+    FormControl,
+    FormControlLabel,
+    Paper,
+    Popover,
+    Radio,
+    RadioGroup,
+    Typography,
+} from '@material-ui/core';
 import { Settings } from '@material-ui/icons';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 
 import { toggleTheme } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
+import { useTimeFormatStore } from '$stores/TimeStore';
 
 function SettingsMenu() {
     const [anchorEl, setAnchorEl] = useState<HTMLElement>();
     const [theme, setTheme] = useState(AppStore.getTheme());
 
+    const { isMilitaryTime } = useTimeFormatStore();
+
     const handleThemeChange = () => {
         setTheme(AppStore.getTheme());
+    };
+
+    const handleTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+        useTimeFormatStore.getState().setTimeFormat(event.target.value == 'true');
     };
 
     useEffect(() => {
@@ -47,14 +64,31 @@ function SettingsMenu() {
                     horizontal: 'center',
                 }}
             >
-                <Paper style={{ padding: '0.5rem', minWidth: '12.25rem' }}>
-                    <FormControl>
-                        <RadioGroup aria-label="theme" name="theme" value={theme} onChange={toggleTheme}>
-                            <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
-                            <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
-                            <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
-                        </RadioGroup>
-                    </FormControl>
+                <Paper style={{ padding: '1rem', display: 'flex', gap: 10 }}>
+                    <Box>
+                        <Typography variant="h6">Theme</Typography>
+                        <FormControl>
+                            <RadioGroup aria-label="theme" name="theme" value={theme} onChange={toggleTheme}>
+                                <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
+                                <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
+                                <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
+                            </RadioGroup>
+                        </FormControl>
+                    </Box>
+                    <Box>
+                        <Typography variant="h6">Time Format</Typography>
+                        <FormControl>
+                            <RadioGroup
+                                aria-label="theme"
+                                name="theme"
+                                value={isMilitaryTime}
+                                onChange={handleTimeChange}
+                            >
+                                <FormControlLabel value={false} control={<Radio color="primary" />} label="12 Hour" />
+                                <FormControlLabel value={true} control={<Radio color="primary" />} label="24 Hour" />
+                            </RadioGroup>
+                        </FormControl>
+                    </Box>
                 </Paper>
             </Popover>
         </>

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -1,79 +1,64 @@
 import { Button, FormControl, FormControlLabel, Paper, Popover, Radio, RadioGroup } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import Brightness4Icon from '@material-ui/icons/Brightness4';
-import { PureComponent } from 'react';
+import { Settings } from '@material-ui/icons';
+import { useEffect, useState } from 'react';
 
 import { toggleTheme } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
 
-const styles = {
-    container: {
-        padding: '0.5rem',
-        minWidth: '12.25rem',
-    },
-    betaBadge: { transform: 'scale(1) translate(95%, -50%)' },
-};
+function SettingsMenu() {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+    const [theme, setTheme] = useState(AppStore.getTheme());
 
-interface SettingsState {
-    anchorEl?: HTMLElement;
-    theme: string;
-}
-
-class SettingsMenu extends PureComponent<{ classes: ClassNameMap }, SettingsState> {
-    state: SettingsState = {
-        anchorEl: undefined,
-        theme: AppStore.getTheme(),
+    const handleThemeChange = () => {
+        setTheme(AppStore.getTheme());
     };
 
-    componentDidMount = () => {
-        AppStore.on('themeToggle', () => {
-            this.setState({ theme: AppStore.getTheme() });
-        });
-    };
+    useEffect(() => {
+        AppStore.on('themeToggle', handleThemeChange);
 
-    render() {
-        const { classes } = this.props;
+        return () => {
+            AppStore.off('themeToggle', handleThemeChange);
+        };
+    }, []);
 
-        return (
-            <>
-                <Button
-                    onClick={(event) => {
-                        this.setState({ anchorEl: event.currentTarget });
-                    }}
-                    color="inherit"
-                    startIcon={<Brightness4Icon />}
-                >
-                    Theme
-                </Button>
-                <Popover
-                    open={Boolean(this.state.anchorEl)}
-                    anchorEl={this.state.anchorEl}
-                    onClose={() => {
-                        this.setState({ anchorEl: undefined });
-                    }}
-                    anchorOrigin={{
-                        vertical: 'bottom',
-                        horizontal: 'center',
-                    }}
-                    transformOrigin={{
-                        vertical: 'top',
-                        horizontal: 'center',
-                    }}
-                >
-                    <Paper className={classes.container}>
-                        <FormControl>
-                            <RadioGroup aria-label="theme" name="theme" value={this.state.theme} onChange={toggleTheme}>
-                                <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
-                                <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
-                                <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
-                            </RadioGroup>
-                        </FormControl>
-                    </Paper>
-                </Popover>
-            </>
-        );
-    }
+    return (
+        <>
+            <Button
+                onClick={(event) => {
+                    setAnchorEl(event.currentTarget);
+                }}
+                color="inherit"
+                startIcon={<Settings />}
+            >
+                Settings
+            </Button>
+            <Popover
+                open={Boolean(anchorEl)}
+                anchorEl={anchorEl}
+                onClose={() => {
+                    setAnchorEl(undefined);
+                }}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'center',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'center',
+                }}
+            >
+                <Paper style={{ padding: '0.5rem', minWidth: '12.25rem' }}>
+                    <FormControl>
+                        <RadioGroup aria-label="theme" name="theme" value={theme} onChange={toggleTheme}>
+                            <FormControlLabel value="light" control={<Radio color="primary" />} label="Light" />
+                            <FormControlLabel value="dark" control={<Radio color="primary" />} label="Dark" />
+                            <FormControlLabel value="auto" control={<Radio color="primary" />} label="Automatic" />
+                        </RadioGroup>
+                    </FormControl>
+                </Paper>
+            </Popover>
+        </>
+    );
 }
 
-export default withStyles(styles)(SettingsMenu);
+export default SettingsMenu;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -15,7 +15,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import classNames from 'classnames';
 import { bindHover, bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
-import { Fragment, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AASection } from '@packages/antalmanac-types';
 import { WebsocSectionEnrollment, WebsocSectionMeeting } from 'peterportal-api-next-types';
@@ -32,8 +32,9 @@ import Grades from '$lib/grades';
 import AppStore from '$stores/AppStore';
 import { useTabStore } from '$stores/TabStore';
 import locationIds from '$lib/location_ids';
-import { normalizeTime, parseDaysString, translate24To12HourTime } from '$stores/calendarizeHelpers';
+import { normalizeTime, parseDaysString, formatTimes } from '$stores/calendarizeHelpers';
 import useColumnStore, { type SectionTableColumn } from '$stores/ColumnStore';
+import { useTimeFormatStore } from '$stores/TimeStore';
 
 const styles: Styles<Theme, object> = (theme) => ({
     sectionCode: {
@@ -424,6 +425,8 @@ interface DayAndTimeCellProps {
 const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
     const { classes, meetings } = props;
 
+    const { timeFormat } = useTimeFormatStore();
+
     return (
         <NoPaddingTableCell className={classes.cell}>
             {meetings.map((meeting) => {
@@ -432,7 +435,7 @@ const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
                 }
 
                 if (meeting.startTime && meeting.endTime) {
-                    const timeString = translate24To12HourTime(meeting.startTime, meeting.endTime);
+                    const timeString = formatTimes(meeting.startTime, meeting.endTime, timeFormat);
 
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
                 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -425,7 +425,7 @@ interface DayAndTimeCellProps {
 const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
     const { classes, meetings } = props;
 
-    const { timeFormat } = useTimeFormatStore();
+    const { isMilitaryTime } = useTimeFormatStore();
 
     return (
         <NoPaddingTableCell className={classes.cell}>
@@ -435,7 +435,7 @@ const DayAndTimeCell = withStyles(styles)((props: DayAndTimeCellProps) => {
                 }
 
                 if (meeting.startTime && meeting.endTime) {
-                    const timeString = formatTimes(meeting.startTime, meeting.endTime, timeFormat);
+                    const timeString = formatTimes(meeting.startTime, meeting.endTime, isMilitaryTime);
 
                     return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
                 }

--- a/apps/antalmanac/src/stores/TimeStore.ts
+++ b/apps/antalmanac/src/stores/TimeStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+export interface TimeFormatStore {
+    timeFormat: boolean;
+    setTimeFormat: (militaryTime: boolean) => void;
+}
+
+export const useTimeFormatStore = create<TimeFormatStore>((set) => {
+    const timeFormat = !(typeof Storage !== 'undefined' && window.localStorage.getItem('show24HourTime') === 'true');
+
+    return {
+        timeFormat,
+        setTimeFormat: (timeFormat) => {
+            if (typeof Storage !== 'undefined') {
+                window.localStorage.setItem('show24HourTime', timeFormat.toString());
+            }
+            set({ timeFormat });
+        },
+    };
+});

--- a/apps/antalmanac/src/stores/TimeStore.ts
+++ b/apps/antalmanac/src/stores/TimeStore.ts
@@ -1,20 +1,22 @@
 import { create } from 'zustand';
 
 export interface TimeFormatStore {
-    timeFormat: boolean;
+    isMilitaryTime: boolean;
     setTimeFormat: (militaryTime: boolean) => void;
 }
 
 export const useTimeFormatStore = create<TimeFormatStore>((set) => {
-    const timeFormat = !(typeof Storage !== 'undefined' && window.localStorage.getItem('show24HourTime') === 'true');
+    const isMilitaryTime = !(
+        typeof Storage !== 'undefined' && window.localStorage.getItem('show24HourTime') === 'true'
+    );
 
     return {
-        timeFormat,
+        isMilitaryTime,
         setTimeFormat: (timeFormat) => {
             if (typeof Storage !== 'undefined') {
                 window.localStorage.setItem('show24HourTime', timeFormat.toString());
             }
-            set({ timeFormat });
+            set({ isMilitaryTime });
         },
     };
 });

--- a/apps/antalmanac/src/stores/TimeStore.ts
+++ b/apps/antalmanac/src/stores/TimeStore.ts
@@ -6,15 +6,13 @@ export interface TimeFormatStore {
 }
 
 export const useTimeFormatStore = create<TimeFormatStore>((set) => {
-    const isMilitaryTime = !(
-        typeof Storage !== 'undefined' && window.localStorage.getItem('show24HourTime') === 'true'
-    );
+    const isMilitaryTime = typeof Storage !== 'undefined' && window.localStorage.getItem('show24HourTime') == 'true';
 
     return {
         isMilitaryTime,
-        setTimeFormat: (timeFormat) => {
+        setTimeFormat: (isMilitaryTime) => {
             if (typeof Storage !== 'undefined') {
-                window.localStorage.setItem('show24HourTime', timeFormat.toString());
+                window.localStorage.setItem('show24HourTime', isMilitaryTime.toString());
             }
             set({ isMilitaryTime });
         },

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -205,9 +205,16 @@ export function normalizeTime(options: NormalizeTimeOptions): NormalizedWebSOCTi
     return { startTime, endTime };
 }
 
-export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMinute): string | undefined {
+export function formatTimes(startTime: HourMinute, endTime: HourMinute, timeFormat: boolean): string | undefined {
     if (!startTime || !endTime) {
         return;
+    }
+
+    const formattedStartMinute = startTime.minute.toString().padStart(2, '0');
+    const formattedEndMinute = endTime.minute.toString().padStart(2, '0');
+
+    if (timeFormat) {
+        return `${startTime.hour}:${formattedStartMinute} - ${endTime.hour}:${formattedEndMinute}`;
     }
 
     const timeSuffix = endTime.hour >= 12 ? 'PM' : 'AM';
@@ -215,11 +222,8 @@ export function translate24To12HourTime(startTime?: HourMinute, endTime?: HourMi
     const formattedStartHour = `${startTime.hour > 12 ? startTime.hour - 12 : startTime.hour}`;
     const formattedEndHour = `${endTime.hour > 12 ? endTime.hour - 12 : endTime.hour}`;
 
-    const formattedStartMinute = `${startTime.minute}`;
-    const formattedEndMinute = `${endTime.minute}`;
-
-    const meetingStartTime = `${formattedStartHour}:${formattedStartMinute.padStart(2, '0')}`;
-    const meetingEndTime = `${formattedEndHour}:${formattedEndMinute.padStart(2, '0')}`;
+    const meetingStartTime = `${formattedStartHour}:${formattedStartMinute}`;
+    const meetingEndTime = `${formattedEndHour}:${formattedEndMinute}`;
 
     return `${meetingStartTime} - ${meetingEndTime} ${timeSuffix}`;
 }


### PR DESCRIPTION
## Summary
1. Refactor the Calendar Component
2. Update `translate24To12HourTime` to `formatTimes`, adding a `timeFormat` param so it knows which format to return the times in. Applies to Right Pane (Search/Added)
3. Add additional props to the RBC component to enable 24 hour time for both gutter and event labels
4. Refactor Theme/Settings Menu
5. Add Theme and Time to the (new) Settings Menu

## Screenshots

Light Mode, Full App:
<img width="1728" alt="24 Hour Format" src="https://github.com/icssc/AntAlmanac/assets/100006999/78d6ac93-de68-4256-844a-efc5ae24d96b">
Dark Mode, Calendar:
<img width="855" alt="Screenshot 2023-11-09 at 2 18 13 AM" src="https://github.com/icssc/AntAlmanac/assets/100006999/fa8f921c-1a5a-4d42-ba08-bbea850be488">

![chrome-capture-2023-10-9](https://github.com/icssc/AntAlmanac/assets/100006999/95559363-c6ef-4065-8340-ba5d0253c49f)


## Test Plan
1. Light/Dark Mode
2. Existing Calendar functionality should be unchanged (swapping schedules, clicking events, creating events, etc)
3. Toggling between time formats should be seamless

## Issues
Closes #637

## Future Followup
1. Implement a newly redesigned settings menu!
