### PR TITLE
Add Winter 2024 to Term Data

### DIFF
--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -18,6 +18,7 @@ class Term {
  * Months are 0-indexed
  */
 const termData = [
+    new Term('2024 Winter', '2024 Winter Quarter', [2023, 0, 8]),
     new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28]),
     new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),
     new Term('2023 Summer10wk', '2023 10-wk Summer', [2023, 5, 26]),


### PR DESCRIPTION
## Summary
1. Add winter 2024 to term data so we can search for it (API already has the data 🤩) 

## Test Plan
1. It's one line diff xD, just make sure [I didn't typo or something](https://www.reg.uci.edu/calendars/quarterly/2023-2024/quarterly23-24.html)
2. Actually make sure that courses are addable and searchable correctly

## Issues
Closes a very quick user request from the Discord

<!-- [Optional]
## Future Followup
-->
