### PR TITLE
feat: Hide Search Pane Horizontal Scroll

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -17,6 +17,7 @@ const styles: Styles<Theme, object> = {
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
+        overflowX: 'hidden',
     },
     container: {
         display: 'flex',


### PR DESCRIPTION
## Summary
Added `overflowX: hidden` to the search pane.

## Test Plan
Make sure that on mobile / smaller screens, nothing ends up clipped

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
