### PR TITLE
feat: Hotfix Gutter format

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -135,6 +135,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
     const calendarStyling = isMobile ? { height: `calc(100% - 55px)` } : { height: `calc(100vh - 104px)` };
     const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
+    const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
 
     // If a final is on a Saturday or Sunday, let the calendar start on Saturday
     moment.updateLocale('es-us', {
@@ -222,7 +223,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
                         timeGutterFormat: (date: Date, culture?: string, localizer?: DateLocalizer) =>
                             date.getMinutes() > 0 || !localizer
                                 ? ''
-                                : localizer.format(date, calendarTimeFormat, culture),
+                                : localizer.format(date, calendarGutterTimeFormat, culture),
                         dayFormat: 'ddd',
                         eventTimeRangeFormat: (
                             range: { start: Date; end: Date },


### PR DESCRIPTION
## Summary

Live:
<img width="99" alt="Screenshot 2023-11-09 at 12 45 23 PM" src="https://github.com/icssc/AntAlmanac/assets/100006999/a4b66b95-897a-434c-a064-e40ed0545fe7">

TLDR; gutters need different formatting than the individual events

## Test Plan
1. The time gutter doesn't overflow in 12 or 24 hour
2. Looks good on all mobile devices

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
