### PR TITLE
Fix wrong term start date

### DIFF
--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -18,7 +18,7 @@ class Term {
  * Months are 0-indexed
  */
 const termData = [
-    new Term('2024 Winter', '2024 Winter Quarter', [2023, 0, 8]),
+    new Term('2024 Winter', '2024 Winter Quarter', [2024, 0, 8]),
     new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28]),
     new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),
     new Term('2023 Summer10wk', '2023 10-wk Summer', [2023, 5, 26]),


### PR DESCRIPTION
## Summary
We put the wrong year. One-line diff.
## Test Plan

Try exporting classes to ics. Ignore the bug that there will be duplicates.
