### PR TITLE
fix: Swap Popover to Tooltip for Restrictions Cell

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -14,7 +14,6 @@ import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import classNames from 'classnames';
-import { bindHover, bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AASection } from '@packages/antalmanac-types';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -374,7 +374,6 @@ interface RestrictionsCellProps {
 
 const RestrictionsCell = withStyles(styles)((props: RestrictionsCellProps) => {
     const { classes, restrictions } = props;
-    const popupState = usePopupState({ popupId: 'RestrictionsCellPopup', variant: 'popover' });
 
     const parseRestrictions = (restrictionCode: string) => {
         return restrictionCode.split(' ').map((code, index) => {
@@ -393,25 +392,17 @@ const RestrictionsCell = withStyles(styles)((props: RestrictionsCellProps) => {
     return (
         <NoPaddingTableCell className={classes.cell}>
             <Box>
-                <Typography {...bindHover(popupState)}>
-                    <a
-                        href="https://www.reg.uci.edu/enrollment/restrict_codes.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        {restrictions}
-                    </a>
-                </Typography>
-                <Popover
-                    {...bindPopover(popupState)}
-                    className={classes.popover}
-                    classes={{ paper: classes.paper }}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                    disableRestoreFocus
-                >
-                    <Typography>{parseRestrictions(restrictions)}</Typography>
-                </Popover>
+                <Tooltip title={<Typography>{parseRestrictions(restrictions)}</Typography>}>
+                    <Typography>
+                        <a
+                            href="https://www.reg.uci.edu/enrollment/restrict_codes.html"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {restrictions}
+                        </a>
+                    </Typography>
+                </Tooltip>
             </Box>
         </NoPaddingTableCell>
     );


### PR DESCRIPTION
## Summary
Swapped out a Popover component for a Tooltip

## Test Plan
1. Make sure that functionality is now as expected; Scrolling, non-focusing, and other expected behaviors should be working

## Issues
Closes #798

<!-- [Optional]
## Future Followup
-->
