### PR TITLE
fix: Correct snapshot for Winter 2024

### DIFF
--- a/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
+++ b/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
@@ -49,7 +49,7 @@ Taught by placeholderInstructor1/placeholderInstructor2",
   },
   {
     "end": [
-      2023,
+      2024,
       1,
       8,
       3,
@@ -59,7 +59,7 @@ Taught by placeholderInstructor1/placeholderInstructor2",
     "productId": "antalmanac/ics",
     "recurrenceRule": "FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=1;COUNT=30",
     "start": [
-      2023,
+      2024,
       1,
       8,
       1,


### PR DESCRIPTION
## Summary
Following #794 which updated the snapshot and #807 which caught the wrong Winter 2024 start date, the snapshot needs to be updated to reflect that :')

## Test Plan
Tests should run clean :)

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
