### PR TITLE
feat: Create Snackbar When Copying Schedules

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -187,7 +187,7 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (name: string, to: number, options?: CallbackOptions) => {
+export const copySchedule = (to: number, options?: CallbackOptions) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -190,11 +190,10 @@ export const copySchedule = (name: string, to: number) => {
 
     try {
         AppStore.copySchedule(to);
+        openSnackbar('success', `Schedule copied to ${name}.`);
     } catch (error) {
         openSnackbar('error', `Could not copy schedule to ${name}.`);
     }
-
-    openSnackbar('success', `Schedule copied to ${name}.`);
 };
 
 export const toggleTheme = (radioGroupEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -195,9 +195,9 @@ export const copySchedule = (name: string, to: number, options?: CallbackOptions
 
     try {
         AppStore.copySchedule(to);
-        options?.onSuccess(name);
+        options?.onSuccess(to);
     } catch (error) {
-        options?.onError(name);
+        options?.onError(to);
     }
 };
 

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -12,7 +12,7 @@ import AppStore from '$stores/AppStore';
 import trpc from '$lib/api/trpc';
 import { courseNumAsDecimal } from '$lib/analytics';
 
-export interface CallbackOptions {
+export interface CopyScheduleOptions {
     onSuccess: (index: number) => unknown;
     onError: (index: number) => unknown;
 }

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -12,6 +12,11 @@ import AppStore from '$stores/AppStore';
 import trpc from '$lib/api/trpc';
 import { courseNumAsDecimal } from '$lib/analytics';
 
+export interface CallbackOptions {
+    onSuccess: (name?: string) => unknown;
+    onError: (name?: string) => unknown;
+}
+
 export const addCourse = (
     section: WebsocSection,
     courseDetails: CourseDetails,
@@ -182,7 +187,7 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (name: string, to: number) => {
+export const copySchedule = (name: string, to: number, options?: CallbackOptions) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,
@@ -190,9 +195,9 @@ export const copySchedule = (name: string, to: number) => {
 
     try {
         AppStore.copySchedule(to);
-        openSnackbar('success', `Schedule copied to ${name}.`);
+        options?.onSuccess(name);
     } catch (error) {
-        openSnackbar('error', `Could not copy schedule to ${name}.`);
+        options?.onError(name);
     }
 };
 

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -13,8 +13,8 @@ import trpc from '$lib/api/trpc';
 import { courseNumAsDecimal } from '$lib/analytics';
 
 export interface CallbackOptions {
-    onSuccess: (name?: string) => unknown;
-    onError: (name?: string) => unknown;
+    onSuccess: (index: number) => unknown;
+    onError: (index: number) => unknown;
 }
 
 export const addCourse = (

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -187,7 +187,7 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (to: number, options?: CallbackOptions) => {
+export const copySchedule = (to: number, options?: CopyScheduleOptions) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -182,13 +182,19 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (to: number) => {
+export const copySchedule = (name: string, to: number) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,
     });
 
-    AppStore.copySchedule(to);
+    try {
+        AppStore.copySchedule(to);
+    } catch (error) {
+        openSnackbar('error', `Could not copy schedule to ${name}.`);
+    }
+
+    openSnackbar('success', `Schedule copied to ${name}.`);
 };
 
 export const toggleTheme = (radioGroupEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -100,9 +100,9 @@ function handleClear() {
     }
 }
 
-function createCopyHandler(index: number) {
+function createCopyHandler(name: string, index: number) {
     return () => {
-        copySchedule(index);
+        copySchedule(name, index);
     };
 }
 
@@ -148,12 +148,14 @@ function CopyScheduleButton() {
                             <MenuItem
                                 key={index}
                                 disabled={AppStore.getCurrentScheduleIndex() === index}
-                                onClick={createCopyHandler(index)}
+                                onClick={createCopyHandler(name, index)}
                             >
                                 Copy to {name}
                             </MenuItem>
                         ))}
-                        <MenuItem onClick={createCopyHandler(scheduleNames.length)}>Copy to All Schedules</MenuItem>
+                        <MenuItem onClick={createCopyHandler('All Schedules', scheduleNames.length)}>
+                            Copy to All Schedules
+                        </MenuItem>
                     </Menu>
                 </>
             )}

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -157,7 +157,7 @@ function CopyScheduleButton() {
                             <MenuItem
                                 key={index}
                                 disabled={AppStore.getCurrentScheduleIndex() === index}
-                                onClick={createCopyHandler(name, index, options)}
+                                onClick={createCopyHandler(index, options)}
                             >
                                 Copy to {name}
                             </MenuItem>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -123,18 +123,14 @@ function CopyScheduleButton() {
 
     const options = useMemo(() => {
         return {
-            onSuccess: (index: number) =>
-                enqueueSnackbar(
-                    `Schedule copied to ${index === scheduleNames.length ? 'All Schedules' : scheduleNames[index]}.`,
-                    { variant: 'success' }
-                ),
-            onError: (index: number) =>
-                enqueueSnackbar(
-                    `Could not copy schedule to ${
-                        index === scheduleNames.length ? 'All Schedules' : scheduleNames[index]
-                    }.`,
-                    { variant: 'error' }
-                ),
+            onSuccess: (index: number) => {
+                const name = index === scheduleNames.length ? 'All Schedules' : scheduleNames[index];
+                enqueueSnackbar(`Schedule copied to ${name}.`, { variant: 'success' });
+            },
+            onError: (index: number) => {
+                const name = index === scheduleNames.length ? 'All Schedules' : scheduleNames[index];
+                enqueueSnackbar(`Could not copy schedule to ${name}.`, { variant: 'error' });
+            },
         };
     }, [enqueueSnackbar, scheduleNames]);
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -23,7 +23,7 @@ import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
 import CustomEventDetailView from './CustomEventDetailView';
 import AppStore from '$stores/AppStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
-import { CallbackOptions, clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
+import { CopyScheduleOptions, clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
 import { clickToCopy } from '$lib/helpers';
 
 /**
@@ -101,9 +101,9 @@ function handleClear() {
     }
 }
 
-function createCopyHandler(name: string, index: number, options: CallbackOptions) {
+function createCopyHandler(index: number, options: CopyScheduleOptions) {
     return () => {
-        copySchedule(name, index, options);
+        copySchedule(index, options);
     };
 }
 
@@ -123,10 +123,20 @@ function CopyScheduleButton() {
 
     const options = useMemo(() => {
         return {
-            onSuccess: (index: number) => enqueueSnackbar(`Schedule copied to ${scheduleNames[index]}.`, { variant: 'success' }),
-            onError: (index: number) => enqueueSnackbar(`Could not copy schedule to ${scheduleNames[index]}.`, { variant: 'error' }),
+            onSuccess: (index: number) =>
+                enqueueSnackbar(
+                    `Schedule copied to ${index === scheduleNames.length ? 'All Schedules' : scheduleNames[index]}.`,
+                    { variant: 'success' }
+                ),
+            onError: (index: number) =>
+                enqueueSnackbar(
+                    `Could not copy schedule to ${
+                        index === scheduleNames.length ? 'All Schedules' : scheduleNames[index]
+                    }.`,
+                    { variant: 'error' }
+                ),
         };
-    }, [enqueueSnackbar]);
+    }, [enqueueSnackbar, scheduleNames]);
 
     useEffect(() => {
         /**
@@ -162,7 +172,7 @@ function CopyScheduleButton() {
                                 Copy to {name}
                             </MenuItem>
                         ))}
-                        <MenuItem onClick={createCopyHandler('All Schedules', scheduleNames.length, options)}>
+                        <MenuItem onClick={createCopyHandler(scheduleNames.length, options)}>
                             Copy to All Schedules
                         </MenuItem>
                     </Menu>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -123,8 +123,8 @@ function CopyScheduleButton() {
 
     const options = useMemo(() => {
         return {
-            onSuccess: (name?: string) => enqueueSnackbar(`Schedule copied to ${name}.`, { variant: 'success' }),
-            onError: (name?: string) => enqueueSnackbar(`Could not copy schedule to ${name}.`, { variant: 'error' }),
+            onSuccess: (index: number) => enqueueSnackbar(`Schedule copied to ${scheduleNames[index]}.`, { variant: 'success' }),
+            onError: (index: number) => enqueueSnackbar(`Could not copy schedule to ${scheduleNames[index]}.`, { variant: 'error' }),
         };
     }, [enqueueSnackbar]);
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -17,12 +17,13 @@ import {
 import { ContentCopy, DeleteOutline } from '@mui/icons-material';
 import { AACourse } from '@packages/antalmanac-types';
 
+import { useSnackbar } from 'notistack';
 import { ColumnToggleButton } from '../CoursePane/CoursePaneButtonRow';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
 import CustomEventDetailView from './CustomEventDetailView';
 import AppStore from '$stores/AppStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
-import { clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
+import { CallbackOptions, clearSchedules, copySchedule, updateScheduleNote } from '$actions/AppStoreActions';
 import { clickToCopy } from '$lib/helpers';
 
 /**
@@ -100,9 +101,9 @@ function handleClear() {
     }
 }
 
-function createCopyHandler(name: string, index: number) {
+function createCopyHandler(name: string, index: number, options: CallbackOptions) {
     return () => {
-        copySchedule(name, index);
+        copySchedule(name, index, options);
     };
 }
 
@@ -118,6 +119,14 @@ function ClearScheduleButton() {
 
 function CopyScheduleButton() {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+    const { enqueueSnackbar } = useSnackbar();
+
+    const options = useMemo(() => {
+        return {
+            onSuccess: (name?: string) => enqueueSnackbar(`Schedule copied to ${name}.`, { variant: 'success' }),
+            onError: (name?: string) => enqueueSnackbar(`Could not copy schedule to ${name}.`, { variant: 'error' }),
+        };
+    }, [enqueueSnackbar]);
 
     useEffect(() => {
         /**
@@ -148,12 +157,12 @@ function CopyScheduleButton() {
                             <MenuItem
                                 key={index}
                                 disabled={AppStore.getCurrentScheduleIndex() === index}
-                                onClick={createCopyHandler(name, index)}
+                                onClick={createCopyHandler(name, index, options)}
                             >
                                 Copy to {name}
                             </MenuItem>
                         ))}
-                        <MenuItem onClick={createCopyHandler('All Schedules', scheduleNames.length)}>
+                        <MenuItem onClick={createCopyHandler('All Schedules', scheduleNames.length, options)}>
                             Copy to All Schedules
                         </MenuItem>
                     </Menu>


### PR DESCRIPTION
## Summary
1. Open snackbar when copying (appending) schedules; happens on success and on failure

![Snackbar opens on success](https://github.com/icssc/AntAlmanac/assets/100006999/102ec801-963f-46ad-942a-443930f6256c)

## Test Plan
1. Check that the snackbar opens appropriately on success and on failure

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
