### PR TITLE
45/55 Ratio Calendar Split

### DIFF
--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -23,7 +23,7 @@ export default function Home() {
                 <MobileHome />
             ) : (
                 <Split
-                    sizes={[50, 50]}
+                    sizes={[45, 55]}
                     minSize={100}
                     expandToMin={false}
                     gutterSize={10}


### PR DESCRIPTION
## Summary
Adjusted the panel ratio of calendar to information from 50/50 to 45/55 proportionally.

## Screenshots
Before (50/50):
![before](https://github.com/icssc/AntAlmanac/assets/105406853/024c9d6b-5b27-4d39-93ce-594f335354da)

After (45/55):
![After](https://github.com/icssc/AntAlmanac/assets/105406853/bb1052d9-7738-4c6d-8f78-2e7f3c497a33)

## Test Plan
Observe new initial ratio on light and dark mode.

## Issues

Closes #780 