### PR TITLE
Fix the duplicate calendar events bug

### DIFF
--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -90,6 +90,10 @@ class AppStore extends EventEmitter {
         return this.schedule.getCalendarizedEvents();
     }
 
+    getEventsWithFinalsInCalendar() {
+        return [...this.schedule.getCalendarizedEvents(), ...this.schedule.getCalendarizedFinals()];
+    }
+
     getCourseEventsInCalendar() {
         return this.schedule.getCalendarizedCourseEvents();
     }

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -49,7 +49,10 @@ export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): 
                         title: `${course.deptCode} ${course.courseNumber}`,
                         courseTitle: course.courseTitle,
                         locations: meeting.bldg.map(getLocation).map((location: Location) => {
-                            return { ...location, days: meeting.days === null ? undefined : meeting.days };
+                            return {
+                                ...location,
+                                days: meeting.days === null ? undefined : COURSE_WEEK_DAYS[dayIndex],
+                            };
                         }),
                         showLocationInfo: false,
                         instructors: course.section.instructors,
@@ -99,12 +102,19 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              */
             const dayIndicesOcurring = weekdaysOccurring.map((day, index) => (day ? index : undefined)).filter(notNull);
 
+            const locationsWithNoDays = bldg ? bldg.map(getLocation) : course.section.meetings[0].bldg.map(getLocation);
+
             return dayIndicesOcurring.map((dayIndex) => ({
                 color: course.section.color,
                 term: course.term,
                 title: `${course.deptCode} ${course.courseNumber}`,
                 courseTitle: course.courseTitle,
-                locations: bldg ? bldg.map(getLocation) : course.section.meetings[0].bldg.map(getLocation),
+                locations: locationsWithNoDays.map((location: Location) => {
+                    return {
+                        ...location,
+                        days: COURSE_WEEK_DAYS[dayIndex],
+                    };
+                }),
                 showLocationInfo: true,
                 instructors: course.section.instructors,
                 sectionCode: course.section.sectionCode,

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -51,7 +51,7 @@ export function calendarizeCourseEvents(currentCourses: ScheduleCourse[] = []): 
                         locations: meeting.bldg.map(getLocation).map((location: Location) => {
                             return {
                                 ...location,
-                                days: meeting.days === null ? undefined : COURSE_WEEK_DAYS[dayIndex],
+                                ...(meeting.days && { days: COURSE_WEEK_DAYS[dayIndex] }),
                             };
                         }),
                         showLocationInfo: false,

--- a/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
+++ b/apps/antalmanac/tests/__snapshots__/download-ics.test.ts.snap
@@ -27,7 +27,7 @@ Taught by placeholderInstructor1/placeholderInstructor2",
     "title": "placeholderDeptCode placeholderCourseNumber placeholderSectionType",
   },
   {
-    "description": "Final Exam for placeholderSectionType placeholderCourseTitle",
+    "description": "Final Exam for placeholderCourseTitle",
     "end": [
       2023,
       3,

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -15,6 +15,8 @@ describe('download-ics', () => {
                 title: 'placeholderDeptCode placeholderCourseNumber',
                 locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
                 showLocationInfo: true,
+                // We don't use finalExam anymore for calendar file export,
+                // instead, FinalExamEvent is used
                 finalExam: {
                     examStatus: 'SCHEDULED_FINAL',
                     dayOfWeek: 'Mon',
@@ -37,6 +39,36 @@ describe('download-ics', () => {
                 sectionType: 'placeholderSectionType',
                 term: '2023 Fall', // Cannot be a random placeholder; it has to be in `quarterStartDates` otherwise it'll be undefined
             },
+            // FinalExamEvent
+            {
+                color: 'placeholderColor',
+                start: new Date(2023, 9, 29, 1, 2),
+                end: new Date(2023, 9, 29, 3, 4),
+                title: 'placeholderDeptCode placeholderCourseNumber',
+                locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
+                showLocationInfo: true,
+                finalExam: {
+                    examStatus: 'SCHEDULED_FINAL',
+                    dayOfWeek: 'Mon',
+                    month: 2,
+                    day: 3,
+                    startTime: {
+                        hour: 1,
+                        minute: 2,
+                    },
+                    endTime: {
+                        hour: 3,
+                        minute: 4,
+                    },
+                    locations: [{ building: 'placeholderFinalLocation', room: 'placeholderFinalRoom' }],
+                },
+                courseTitle: 'placeholderCourseTitle',
+                instructors: ['placeholderInstructor1', 'placeholderInstructor2'],
+                isCustomEvent: false,
+                sectionCode: 'placeholderSectionCode',
+                sectionType: 'Fin',
+                term: '2023 Fall', // Cannot be a random placeholder; it has to be in `quarterStartDates` otherwise it'll be undefined
+            },
             // CustomEvent
             {
                 color: 'placeholderColor',
@@ -46,6 +78,7 @@ describe('download-ics', () => {
                 customEventID: 123,
                 isCustomEvent: true,
                 days: ['M', 'W', 'F'],
+                building: 'placeholderCustomEventBuilding',
             },
         ];
 


### PR DESCRIPTION
## Summary
This change fixes the bug caused by looping over events' location.days when the calendarizeHelper has already returned events for each day.
For example, class A occurs every MWF, the calendarizeHelper returns **(event for Monday)** -> {..., location: {..., days: "MWF"}}, also events for **Wednesday** and **Friday** with the same location field.
Therefore, we will finally get 3*3=9 calendar events.
Finals are also added repetitively.
## Test Plan
Passed the vite test. Also tested manually.
## Issues

Closes https://github.com/icssc/AntAlmanac/issues/816

<!-- [Optional]
## Future Followup
-->
