### PR TITLE
Add Past Enrollment Popup

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Box, Typography, Skeleton } from '@mui/material';
-import { queryEnrollmentHistory, EnrollmentHistory } from '$lib/enrollmentHistory';
+import EnrollmentHistoryHelper, { EnrollmentHistory } from '$lib/enrollmentHistory';
 import { isDarkMode } from '$lib/helpers';
 
 export interface EnrollmentHistoryProps {
@@ -32,15 +32,15 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
             return;
         }
 
-        queryEnrollmentHistory(department, courseNumber, sectionType).then((enrollmentHistory) => {
-            if (enrollmentHistory) {
-                setEnrollmentHistory(enrollmentHistory);
-                console.log(enrollmentHistory);
-                console.log(enrollmentHistory[enrollmentHistory.length - 1].days);
-            }
+        EnrollmentHistoryHelper.queryEnrollmentHistory(department, courseNumber, sectionType).then(
+            (enrollmentHistory) => {
+                if (enrollmentHistory) {
+                    setEnrollmentHistory(enrollmentHistory);
+                }
 
-            setLoading(false);
-        });
+                setLoading(false);
+            }
+        );
     }, [loading, department, courseNumber, sectionType]);
 
     if (loading) {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -10,7 +10,7 @@ export interface EnrollmentHistoryPopupProps {
     courseNumber: string;
 }
 
-const EnrollmentHistoryPopup = ({ department, courseNumber }: EnrollmentHistoryPopupProps) => {
+export function EnrollmentHistoryPopup({ department, courseNumber }: EnrollmentHistoryPopupProps) {
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
     const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT})`);
@@ -20,7 +20,7 @@ const EnrollmentHistoryPopup = ({ department, courseNumber }: EnrollmentHistoryP
     const graphWidth = useMemo(() => (isMobileScreen ? 250 : 450), [isMobileScreen]);
     const graphHeight = useMemo(() => (isMobileScreen ? 175 : 250), [isMobileScreen]);
     const popupTitle = useMemo(() => {
-        if (!enrollmentHistory) {
+        if (enrollmentHistory == null) {
             return 'No past enrollment data found for this course';
         }
 
@@ -54,7 +54,7 @@ const EnrollmentHistoryPopup = ({ department, courseNumber }: EnrollmentHistoryP
         );
     }
 
-    if (!enrollmentHistory) {
+    if (enrollmentHistory == null) {
         return (
             <Box padding={1}>
                 <Typography variant="body1" align="center">
@@ -99,6 +99,4 @@ const EnrollmentHistoryPopup = ({ department, courseNumber }: EnrollmentHistoryP
             </Link>
         </Box>
     );
-};
-
-export default EnrollmentHistoryPopup;
+}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Box, Link, Typography, Skeleton } from '@mui/material';
-import EnrollmentHistoryHelper, { EnrollmentHistory } from '$lib/enrollmentHistory';
+import enrollmentHistoryCache, { EnrollmentHistory } from '$lib/enrollmentHistory';
 import { isDarkMode } from '$lib/helpers';
 
 export interface EnrollmentHistoryPopupProps {
@@ -35,9 +35,9 @@ const EnrollmentHistoryPopup = ({ department, courseNumber, isMobileScreen }: En
             return;
         }
 
-        EnrollmentHistoryHelper.queryEnrollmentHistory(department, courseNumber).then((enrollmentHistory) => {
-            if (enrollmentHistory) {
-                setEnrollmentHistory(enrollmentHistory);
+        enrollmentHistoryCache.queryEnrollmentHistory(department, courseNumber).then((data) => {
+            if (data) {
+                setEnrollmentHistory(data);
             }
             setLoading(false);
         });

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -10,19 +10,20 @@ export interface EnrollmentHistoryPopupProps {
     isMobileScreen: boolean;
 }
 
-const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
-    const { department, courseNumber, isMobileScreen } = props;
+const EnrollmentHistoryPopup = ({ department, courseNumber, isMobileScreen }: EnrollmentHistoryPopupProps) => {
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
 
     const graphWidth = useMemo(() => (isMobileScreen ? 250 : 450), [isMobileScreen]);
     const graphHeight = useMemo(() => (isMobileScreen ? 175 : 250), [isMobileScreen]);
     const popupTitle = useMemo(() => {
-        return enrollmentHistory
-            ? `${department} ${courseNumber} | ${enrollmentHistory.year} ${
-                  enrollmentHistory.quarter
-              } | ${enrollmentHistory.instructors.join(', ')}`
-            : 'No past enrollment data found for this course';
+        if (!enrollmentHistory) {
+            return 'No past enrollment data found for this course';
+        }
+
+        return `${department} ${courseNumber} | ${enrollmentHistory.year} ${
+            enrollmentHistory.quarter
+        } | ${enrollmentHistory.instructors.join(', ')}`;
     }, [courseNumber, department, enrollmentHistory]);
 
     const encodedDept = useMemo(() => encodeURIComponent(department), [department]);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -7,18 +7,17 @@ import { isDarkMode } from '$lib/helpers';
 export interface EnrollmentHistoryPopupProps {
     department: string;
     courseNumber: string;
-    sectionType: string;
     isMobileScreen: boolean;
 }
 
 const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
-    const { department, courseNumber, sectionType, isMobileScreen } = props;
+    const { department, courseNumber, isMobileScreen } = props;
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
 
     const graphWidth = useMemo(() => (isMobileScreen ? 250 : 450), [isMobileScreen]);
     const graphHeight = useMemo(() => (isMobileScreen ? 175 : 250), [isMobileScreen]);
-    const graphTitle = useMemo(() => {
+    const popupTitle = useMemo(() => {
         return enrollmentHistory
             ? `${department} ${courseNumber} | ${enrollmentHistory.year} ${
                   enrollmentHistory.quarter
@@ -35,15 +34,13 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
             return;
         }
 
-        EnrollmentHistoryHelper.queryEnrollmentHistory(department, courseNumber, sectionType).then(
-            (enrollmentHistory) => {
-                if (enrollmentHistory) {
-                    setEnrollmentHistory(enrollmentHistory);
-                }
-                setLoading(false);
+        EnrollmentHistoryHelper.queryEnrollmentHistory(department, courseNumber).then((enrollmentHistory) => {
+            if (enrollmentHistory) {
+                setEnrollmentHistory(enrollmentHistory);
             }
-        );
-    }, [loading, department, courseNumber, sectionType]);
+            setLoading(false);
+        });
+    }, [loading, department, courseNumber]);
 
     if (loading) {
         return (
@@ -57,7 +54,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
         return (
             <Box padding={1}>
                 <Typography variant="body1" align="center">
-                    {graphTitle}
+                    {popupTitle}
                 </Typography>
             </Box>
         );
@@ -75,7 +72,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
                     marginBottom: '.5rem',
                 }}
             >
-                {graphTitle}
+                {popupTitle}
             </Typography>
             <Link
                 href={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseNumber}&courseType=all`}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -4,14 +4,14 @@ import { Box, Link, Typography, Skeleton } from '@mui/material';
 import EnrollmentHistoryHelper, { EnrollmentHistory } from '$lib/enrollmentHistory';
 import { isDarkMode } from '$lib/helpers';
 
-export interface EnrollmentHistoryProps {
+export interface EnrollmentHistoryPopupProps {
     department: string;
     courseNumber: string;
     sectionType: string;
     isMobileScreen: boolean;
 }
 
-const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
+const EnrollmentHistoryPopup = (props: EnrollmentHistoryPopupProps) => {
     const { department, courseNumber, sectionType, isMobileScreen } = props;
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
@@ -57,7 +57,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
         return (
             <Box padding={1}>
                 <Typography variant="body1" align="center">
-                    No past enrollment data found for this course
+                    {graphTitle}
                 </Typography>
             </Box>
         );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
-import { Box, Typography, Skeleton } from '@mui/material';
+import { Box, Link, Typography, Skeleton } from '@mui/material';
 import EnrollmentHistoryHelper, { EnrollmentHistory } from '$lib/enrollmentHistory';
 import { isDarkMode } from '$lib/helpers';
 
@@ -14,14 +14,14 @@ export interface EnrollmentHistoryProps {
 const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
     const { department, courseNumber, sectionType, isMobileScreen } = props;
     const [loading, setLoading] = useState(true);
-    const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory[]>();
+    const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
 
     const graphWidth = isMobileScreen ? 250 : 450;
     const graphHeight = isMobileScreen ? 175 : 250;
     const graphTitle = enrollmentHistory
-        ? `${department} ${courseNumber} |
-    ${enrollmentHistory[enrollmentHistory.length - 1].year} 
-    ${enrollmentHistory[enrollmentHistory.length - 1].quarter}`
+        ? `${department} ${courseNumber} | ${enrollmentHistory.year} ${
+              enrollmentHistory.quarter
+          } | ${enrollmentHistory.instructors.join(', ')}`
         : 'No past enrollment data found for this course';
 
     const axisColor = isDarkMode() ? '#fff' : '#111';
@@ -75,9 +75,16 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
             >
                 {graphTitle}
             </Typography>
-            <Box sx={{ width: graphWidth, height: graphHeight }}>
+            <Link
+                href={`https://zot-tracker.herokuapp.com/?dept=${encodeURIComponent(
+                    department
+                )}&number=${courseNumber}&courseType=all`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ display: 'flex', height: graphHeight, width: graphWidth }}
+            >
                 <ResponsiveContainer width="95%" height="95%">
-                    <LineChart data={enrollmentHistory[enrollmentHistory.length - 1].days}>
+                    <LineChart data={enrollmentHistory.days} style={{ cursor: 'pointer' }}>
                         <CartesianGrid strokeDasharray="3 3" />
                         <XAxis dataKey="date" tick={{ fontSize: 12, fill: axisColor }} />
                         <YAxis tick={{ fontSize: 12, fill: axisColor }} width={40} />
@@ -88,7 +95,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
                         <Line type="monotone" dataKey="waitlist" stroke="#ffc658" name="Waitlist" dot={{ r: 2 }} />
                     </LineChart>
                 </ResponsiveContainer>
-            </Box>
+            </Link>
         </Box>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -25,7 +25,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
         : 'No past enrollment data found for this course';
 
     const axisColor = isDarkMode() ? '#fff' : '#111';
-    const tooltipDateColor = isDarkMode() ? '#111' : '#fff';
+    const tooltipDateColor = '#111';
 
     useEffect(() => {
         if (!loading) {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Box, Link, Typography, Skeleton } from '@mui/material';
 import EnrollmentHistoryHelper, { EnrollmentHistory } from '$lib/enrollmentHistory';
@@ -16,14 +16,17 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
 
-    const graphWidth = isMobileScreen ? 250 : 450;
-    const graphHeight = isMobileScreen ? 175 : 250;
-    const graphTitle = enrollmentHistory
-        ? `${department} ${courseNumber} | ${enrollmentHistory.year} ${
-              enrollmentHistory.quarter
-          } | ${enrollmentHistory.instructors.join(', ')}`
-        : 'No past enrollment data found for this course';
+    const graphWidth = useMemo(() => (isMobileScreen ? 250 : 450), [isMobileScreen]);
+    const graphHeight = useMemo(() => (isMobileScreen ? 175 : 250), [isMobileScreen]);
+    const graphTitle = useMemo(() => {
+        return enrollmentHistory
+            ? `${department} ${courseNumber} | ${enrollmentHistory.year} ${
+                  enrollmentHistory.quarter
+              } | ${enrollmentHistory.instructors.join(', ')}`
+            : 'No past enrollment data found for this course';
+    }, [courseNumber, department, enrollmentHistory]);
 
+    const encodedDept = useMemo(() => encodeURIComponent(department), [department]);
     const axisColor = isDarkMode() ? '#fff' : '#111';
     const tooltipDateColor = '#111';
 
@@ -37,7 +40,6 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
                 if (enrollmentHistory) {
                     setEnrollmentHistory(enrollmentHistory);
                 }
-
                 setLoading(false);
             }
         );
@@ -76,9 +78,7 @@ const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
                 {graphTitle}
             </Typography>
             <Link
-                href={`https://zot-tracker.herokuapp.com/?dept=${encodeURIComponent(
-                    department
-                )}&number=${courseNumber}&courseType=all`}
+                href={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseNumber}&courseType=all`}
                 target="_blank"
                 rel="noopener noreferrer"
                 sx={{ display: 'flex', height: graphHeight, width: graphWidth }}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect } from 'react';
+import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { Box, Typography, Skeleton } from '@mui/material';
+import { queryEnrollmentHistory, EnrollmentHistory } from '$lib/enrollmentHistory';
+import { isDarkMode } from '$lib/helpers';
+
+export interface EnrollmentHistoryProps {
+    department: string;
+    courseNumber: string;
+    sectionType: string;
+    isMobileScreen: boolean;
+}
+
+const EnrollmentHistoryPopup = (props: EnrollmentHistoryProps) => {
+    const { department, courseNumber, sectionType, isMobileScreen } = props;
+    const [loading, setLoading] = useState(true);
+    const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory[]>();
+
+    const graphWidth = isMobileScreen ? 250 : 450;
+    const graphHeight = isMobileScreen ? 175 : 250;
+    const graphTitle = enrollmentHistory
+        ? `${department} ${courseNumber} |
+    ${enrollmentHistory[enrollmentHistory.length - 1].year} 
+    ${enrollmentHistory[enrollmentHistory.length - 1].quarter}`
+        : 'No past enrollment data found for this course';
+
+    const axisColor = isDarkMode() ? '#fff' : '#111';
+    const tooltipDateColor = isDarkMode() ? '#111' : '#fff';
+
+    useEffect(() => {
+        if (!loading) {
+            return;
+        }
+
+        queryEnrollmentHistory(department, courseNumber, sectionType).then((enrollmentHistory) => {
+            if (enrollmentHistory) {
+                setEnrollmentHistory(enrollmentHistory);
+                console.log(enrollmentHistory);
+                console.log(enrollmentHistory[enrollmentHistory.length - 1].days);
+            }
+
+            setLoading(false);
+        });
+    }, [loading, department, courseNumber, sectionType]);
+
+    if (loading) {
+        return (
+            <Box padding={1}>
+                <Skeleton variant="text" animation="wave" height={graphHeight} width={graphWidth} />
+            </Box>
+        );
+    }
+
+    if (!enrollmentHistory) {
+        return (
+            <Box padding={1}>
+                <Typography variant="body1" align="center">
+                    No past enrollment data found for this course
+                </Typography>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ padding: '4px' }}>
+            <Typography
+                sx={{
+                    marginTop: '.5rem',
+                    textAlign: 'center',
+                    fontWeight: 500,
+                    marginRight: '2rem',
+                    marginLeft: '2rem',
+                    marginBottom: '.5rem',
+                }}
+            >
+                {graphTitle}
+            </Typography>
+            <Box sx={{ width: graphWidth, height: graphHeight }}>
+                <ResponsiveContainer width="95%" height="95%">
+                    <LineChart data={enrollmentHistory[enrollmentHistory.length - 1].days}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="date" tick={{ fontSize: 12, fill: axisColor }} />
+                        <YAxis tick={{ fontSize: 12, fill: axisColor }} width={40} />
+                        <Tooltip labelStyle={{ color: tooltipDateColor }} />
+                        <Legend />
+                        <Line type="monotone" dataKey="totalEnrolled" stroke="#8884d8" name="Enrolled" dot={{ r: 2 }} />
+                        <Line type="monotone" dataKey="maxCapacity" stroke="#82ca9d" name="Max" dot={{ r: 2 }} />
+                        <Line type="monotone" dataKey="waitlist" stroke="#ffc658" name="Waitlist" dot={{ r: 2 }} />
+                    </LineChart>
+                </ResponsiveContainer>
+            </Box>
+        </Box>
+    );
+};
+
+export default EnrollmentHistoryPopup;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,18 +1,21 @@
 import { useState, useEffect, useMemo } from 'react';
 import { LineChart, Line, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
-import { Box, Link, Typography, Skeleton } from '@mui/material';
-import enrollmentHistoryCache, { EnrollmentHistory } from '$lib/enrollmentHistory';
+import { Box, Link, Typography, Skeleton, useMediaQuery } from '@mui/material';
+import { MOBILE_BREAKPOINT } from '../../../globals';
+import { DepartmentEnrollmentHistory, EnrollmentHistory } from '$lib/enrollmentHistory';
 import { isDarkMode } from '$lib/helpers';
 
 export interface EnrollmentHistoryPopupProps {
     department: string;
     courseNumber: string;
-    isMobileScreen: boolean;
 }
 
-const EnrollmentHistoryPopup = ({ department, courseNumber, isMobileScreen }: EnrollmentHistoryPopupProps) => {
+const EnrollmentHistoryPopup = ({ department, courseNumber }: EnrollmentHistoryPopupProps) => {
     const [loading, setLoading] = useState(true);
     const [enrollmentHistory, setEnrollmentHistory] = useState<EnrollmentHistory>();
+    const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT})`);
+
+    const deptEnrollmentHistory = useMemo(() => new DepartmentEnrollmentHistory(department), [department]);
 
     const graphWidth = useMemo(() => (isMobileScreen ? 250 : 450), [isMobileScreen]);
     const graphHeight = useMemo(() => (isMobileScreen ? 175 : 250), [isMobileScreen]);
@@ -35,13 +38,13 @@ const EnrollmentHistoryPopup = ({ department, courseNumber, isMobileScreen }: En
             return;
         }
 
-        enrollmentHistoryCache.queryEnrollmentHistory(department, courseNumber).then((data) => {
+        deptEnrollmentHistory.find(courseNumber).then((data) => {
             if (data) {
                 setEnrollmentHistory(data);
             }
             setLoading(false);
         });
-    }, [loading, department, courseNumber]);
+    }, [loading, deptEnrollmentHistory, courseNumber]);
 
     if (loading) {
         return (
@@ -62,7 +65,7 @@ const EnrollmentHistoryPopup = ({ department, courseNumber, isMobileScreen }: En
     }
 
     return (
-        <Box sx={{ padding: '4px' }}>
+        <Box sx={{ padding: 0.5 }}>
             <Typography
                 sx={{
                     marginTop: '.5rem',

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -173,7 +173,6 @@ function SectionTable(props: SectionTableProps) {
                         <EnrollmentHistoryPopup
                             department={courseDetails.deptCode}
                             courseNumber={courseDetails.courseNumber}
-                            isMobileScreen={isMobileScreen}
                         />
                     }
                 />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -178,14 +178,6 @@ function SectionTable(props: SectionTableProps) {
                         />
                     }
                 />
-
-                {/* <CourseInfoButton
-                    analyticsCategory={analyticsCategory}
-                    analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_ENROLLMENT}
-                    text="Past Enrollment"
-                    icon={<ShowChartIcon />}
-                    redirectLink={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseDetails.courseNumber}&courseType=all`}
-                /> */}
             </Box>
 
             <TableContainer component={Paper} style={{ margin: '8px 0px 8px 0px' }} elevation={0} variant="outlined">

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -147,6 +147,7 @@ function SectionTable(props: SectionTableProps) {
                     analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
                     text="Reviews"
                     icon={<RateReview />}
+                    redirectLink={`https://peterportal.org/course/${courseId}`}
                 />
 
                 <CourseInfoButton

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -147,7 +147,6 @@ function SectionTable(props: SectionTableProps) {
                     analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
                     text="Reviews"
                     icon={<RateReview />}
-                    redirectLink={`https://peterportal.org/course/${courseId}`}
                 />
 
                 <CourseInfoButton

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -173,7 +173,6 @@ function SectionTable(props: SectionTableProps) {
                         <EnrollmentHistoryPopup
                             department={courseDetails.deptCode}
                             courseNumber={courseDetails.courseNumber}
-                            sectionType={'Lec'}
                             isMobileScreen={isMobileScreen}
                         />
                     }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
     Box,
+    Button,
     Paper,
     Table,
     TableBody,
@@ -17,6 +18,7 @@ import { GlobalStyles } from '@mui/material';
 import { MOBILE_BREAKPOINT } from '../../../globals';
 import CourseInfoBar from './CourseInfoBar';
 import CourseInfoButton from './CourseInfoButton';
+import EnrollmentHistoryPopup from './EnrollmentHistoryPopup';
 import GradesPopup from './GradesPopup';
 import { SectionTableProps } from './SectionTable.types';
 import SectionTableBody from './SectionTableBody';
@@ -168,8 +170,23 @@ function SectionTable(props: SectionTableProps) {
                     analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_ENROLLMENT}
                     text="Past Enrollment"
                     icon={<ShowChartIcon />}
-                    redirectLink={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseDetails.courseNumber}&courseType=all`}
+                    popupContent={
+                        <EnrollmentHistoryPopup
+                            department={courseDetails.deptCode}
+                            courseNumber={courseDetails.courseNumber}
+                            sectionType={'Lec'}
+                            isMobileScreen={isMobileScreen}
+                        />
+                    }
                 />
+
+                {/* <CourseInfoButton
+                    analyticsCategory={analyticsCategory}
+                    analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_ENROLLMENT}
+                    text="Past Enrollment"
+                    icon={<ShowChartIcon />}
+                    redirectLink={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseDetails.courseNumber}&courseType=all`}
+                /> */}
             </Box>
 
             <TableContainer component={Paper} style={{ margin: '8px 0px 8px 0px' }} elevation={0} variant="outlined">

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -17,7 +17,7 @@ import { GlobalStyles } from '@mui/material';
 import { MOBILE_BREAKPOINT } from '../../../globals';
 import CourseInfoBar from './CourseInfoBar';
 import CourseInfoButton from './CourseInfoButton';
-import EnrollmentHistoryPopup from './EnrollmentHistoryPopup';
+import { EnrollmentHistoryPopup } from './EnrollmentHistoryPopup';
 import GradesPopup from './GradesPopup';
 import { SectionTableProps } from './SectionTable.types';
 import SectionTableBody from './SectionTableBody';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
     Box,
-    Button,
     Paper,
     Table,
     TableBody,

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -88,6 +88,8 @@ class _EnrollmentHistory {
         // in the beginning of the array
         this.sortEnrollmentHistory(parsedEnrollmentHistory);
 
+        // For now, just return the enrollment history of the most recent quarter
+        // instead of the entire list of enrollment histories
         const latestEnrollmentHistory = parsedEnrollmentHistory.length > 0 ? parsedEnrollmentHistory[0] : null;
         this.enrollmentHistoryCache[cacheKey] = latestEnrollmentHistory;
         return latestEnrollmentHistory;

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -1,6 +1,7 @@
 import { queryGraphQL } from './helpers';
 import { termData } from './termData';
 
+// This represents the enrollment history of a course section during one quarter
 export interface EnrollmentHistoryGraphQL {
     year: string;
     quarter: string;
@@ -40,8 +41,7 @@ export interface EnrollmentHistoryDay {
 }
 
 class _EnrollmentHistory {
-    // Each key in the cache will be the department, courseNumber, and sectionType
-    // concatenated with each other
+    // Each key in the cache will be the department and courseNumber concatenated
     enrollmentHistoryCache: Record<string, EnrollmentHistory>;
     termShortNames: string[];
 
@@ -50,18 +50,15 @@ class _EnrollmentHistory {
         this.termShortNames = termData.map((term) => term.shortName);
     }
 
-    queryEnrollmentHistory = async (
-        department: string,
-        courseNumber: string,
-        sectionType: string
-    ): Promise<EnrollmentHistory | null> => {
-        const cacheKey = department + courseNumber + sectionType;
+    queryEnrollmentHistory = async (department: string, courseNumber: string): Promise<EnrollmentHistory | null> => {
+        const cacheKey = department + courseNumber;
         if (cacheKey in this.enrollmentHistoryCache) {
             return this.enrollmentHistoryCache[cacheKey];
         }
 
+        // Query for the enrollment history of all lecture sections that were offered
         const queryString = `{
-            enrollmentHistory(department: "${department}", courseNumber: "${courseNumber}", sectionType: ${sectionType}) {
+            enrollmentHistory(department: "${department}", courseNumber: "${courseNumber}", sectionType: Lec) {
                 year
                 quarter
                 department

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -75,12 +75,7 @@ class _EnrollmentHistory {
             (await queryGraphQL<EnrollmentHistoryGraphQLResponse>(queryString))?.data?.enrollmentHistory ?? null;
 
         if (res && res.length > 0) {
-            // Before caching and returning the response, we need to do
-            // some parsing so that we can pass the data into the graph
             const parsedEnrollmentHistory = this.parseEnrollmentHistoryResponse(res);
-
-            // Sort the enrollment history so that the most recent quarters are
-            // in the beginning of the array
             this.sortEnrollmentHistory(parsedEnrollmentHistory);
 
             // For now, just return the enrollment history of the most recent quarter
@@ -93,6 +88,16 @@ class _EnrollmentHistory {
         return null;
     };
 
+    /**
+     * This function parses enrollment history data from PeterPortal so that
+     * we can pass the data into a recharts graph. For each element in the given
+     * array, merge the dates, totalEnrolledHistory, maxCapacityHistory,
+     * and waitlistHistory arrays into one array that contains the enrollment data
+     * for each day.
+     *
+     * @param res an array of enrollment histories from PeterPortal
+     * @returns an array of enrollment histories that we can use for the graph
+     */
     parseEnrollmentHistoryResponse = (res: EnrollmentHistoryGraphQL[]): EnrollmentHistory[] => {
         const parsedEnrollmentHistory: EnrollmentHistory[] = [];
 
@@ -127,6 +132,13 @@ class _EnrollmentHistory {
         return parsedEnrollmentHistory;
     };
 
+    /**
+     * This function sorts the given array of enrollment histories so that
+     * the most recent quarters are in the beginning of the array.
+     *
+     * @param enrollmentHistory an array where each element represents the enrollment
+     * history of a course section during one quarter
+     */
     sortEnrollmentHistory = (enrollmentHistory: EnrollmentHistory[]) => {
         enrollmentHistory.sort((a, b) => {
             const aTerm = `${a.year} ${a.quarter}`;
@@ -138,5 +150,5 @@ class _EnrollmentHistory {
     };
 }
 
-const enrollmentHistory = new _EnrollmentHistory();
-export default enrollmentHistory;
+const enrollmentHistoryCache = new _EnrollmentHistory();
+export default enrollmentHistoryCache;

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -1,0 +1,90 @@
+import { queryGraphQL } from './helpers';
+
+export interface EnrollmentHistoryGraphQL {
+    year: string;
+    quarter: string;
+    department: string;
+    courseNumber: string;
+    dates: string[];
+    totalEnrolledHistory: string[];
+    maxCapacityHistory: string[];
+    waitlistHistory: string[];
+}
+
+export interface EnrollmentHistoryGraphQLResponse {
+    data: {
+        enrollmentHistory: EnrollmentHistoryGraphQL[];
+    };
+}
+
+// To organize the data and make it easier to graph the enrollment
+// data, we can merge the dates, total enrolled, max capacity,
+// and waitlist data into one array that contains the enrollment data
+// for each day
+export interface EnrollmentHistory {
+    year: string;
+    quarter: string;
+    department: string;
+    courseNumber: string;
+    days: EnrollmentHistoryDay[];
+}
+
+export interface EnrollmentHistoryDay {
+    date: string;
+    totalEnrolled: number;
+    maxCapacity: number;
+    waitlist: number | null;
+}
+
+export const queryEnrollmentHistory = async (
+    department: string,
+    courseNumber: string,
+    sectionType: string
+): Promise<EnrollmentHistory[] | null> => {
+    const queryString = `{
+        enrollmentHistory(department: "${department}", courseNumber: "${courseNumber}", sectionType: ${sectionType}) {
+            year
+            quarter
+            department
+            courseNumber
+            dates
+            totalEnrolledHistory
+            maxCapacityHistory
+            waitlistHistory
+        }
+    }`;
+
+    const res = (await queryGraphQL<EnrollmentHistoryGraphQLResponse>(queryString))?.data?.enrollmentHistory ?? null;
+
+    const enrollmentHistories: EnrollmentHistory[] = [];
+    if (res) {
+        for (const enrollmentHistory of res) {
+            const enrollmentDays: EnrollmentHistoryDay[] = [];
+
+            for (const [i, date] of enrollmentHistory.dates.entries()) {
+                const d = new Date(date);
+                const formattedDate = `${d.getMonth() + 1}/${d.getDate() + 1}/${d.getFullYear()}`;
+
+                enrollmentDays.push({
+                    date: formattedDate,
+                    totalEnrolled: Number(enrollmentHistory.totalEnrolledHistory[i]),
+                    maxCapacity: Number(enrollmentHistory.maxCapacityHistory[i]),
+                    waitlist:
+                        enrollmentHistory.waitlistHistory[i] === 'n/a'
+                            ? null
+                            : Number(enrollmentHistory.waitlistHistory[i]),
+                });
+            }
+
+            enrollmentHistories.push({
+                year: enrollmentHistory.year,
+                quarter: enrollmentHistory.quarter,
+                department: enrollmentHistory.department,
+                courseNumber: enrollmentHistory.courseNumber,
+                days: enrollmentDays,
+            });
+        }
+    }
+
+    return enrollmentHistories;
+};

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -20,10 +20,12 @@ export interface EnrollmentHistoryGraphQLResponse {
     };
 }
 
-// To organize the data and make it easier to graph the enrollment
-// data, we can merge the dates, totalEnrolledHistory, maxCapacityHistory,
-// and waitlistHistory arrays into one array that contains the enrollment data
-// for each day
+/**
+ * To organize the data and make it easier to graph the enrollment
+ * data, we can merge the dates, totalEnrolledHistory, maxCapacityHistory,
+ * and waitlistHistory arrays into one array that contains the enrollment data
+ * for each day
+ */
 export interface EnrollmentHistory {
     year: string;
     quarter: string;
@@ -93,14 +95,14 @@ export class DepartmentEnrollmentHistory {
     }
 
     /**
-     * This function parses enrollment history data from PeterPortal so that
+     * Parses enrollment history data from PeterPortal so that
      * we can pass the data into a recharts graph. For each element in the given
      * array, merge the dates, totalEnrolledHistory, maxCapacityHistory,
      * and waitlistHistory arrays into one array that contains the enrollment data
      * for each day.
      *
-     * @param res an array of enrollment histories from PeterPortal
-     * @returns an array of enrollment histories that we can use for the graph
+     * @param res Array of enrollment histories from PeterPortal
+     * @returns Array of enrollment histories that we can use for the graph
      */
     static parseEnrollmentHistoryResponse(res: EnrollmentHistoryGraphQL[]): EnrollmentHistory[] {
         const parsedEnrollmentHistory: EnrollmentHistory[] = [];
@@ -137,10 +139,10 @@ export class DepartmentEnrollmentHistory {
     }
 
     /**
-     * This function sorts the given array of enrollment histories so that
+     * Sorts the given array of enrollment histories so that
      * the most recent quarters are in the beginning of the array.
      *
-     * @param enrollmentHistory an array where each element represents the enrollment
+     * @param enrollmentHistory Array where each element represents the enrollment
      * history of a course section during one quarter
      */
     static sortEnrollmentHistory(enrollmentHistory: EnrollmentHistory[]) {

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -74,7 +74,7 @@ class _EnrollmentHistory {
         const res =
             (await queryGraphQL<EnrollmentHistoryGraphQLResponse>(queryString))?.data?.enrollmentHistory ?? null;
 
-        if (res) {
+        if (res && res.length > 0) {
             // Before caching and returning the response, we need to do
             // some parsing so that we can pass the data into the graph
             const parsedEnrollmentHistory = this.parseEnrollmentHistoryResponse(res);
@@ -96,34 +96,32 @@ class _EnrollmentHistory {
     parseEnrollmentHistoryResponse = (res: EnrollmentHistoryGraphQL[]): EnrollmentHistory[] => {
         const parsedEnrollmentHistory: EnrollmentHistory[] = [];
 
-        if (res) {
-            for (const enrollmentHistory of res) {
-                const enrollmentDays: EnrollmentHistoryDay[] = [];
+        for (const enrollmentHistory of res) {
+            const enrollmentDays: EnrollmentHistoryDay[] = [];
 
-                for (const [i, date] of enrollmentHistory.dates.entries()) {
-                    const d = new Date(date);
-                    const formattedDate = `${d.getMonth() + 1}/${d.getDate() + 1}/${d.getFullYear()}`;
+            for (const [i, date] of enrollmentHistory.dates.entries()) {
+                const d = new Date(date);
+                const formattedDate = `${d.getMonth() + 1}/${d.getDate() + 1}/${d.getFullYear()}`;
 
-                    enrollmentDays.push({
-                        date: formattedDate,
-                        totalEnrolled: Number(enrollmentHistory.totalEnrolledHistory[i]),
-                        maxCapacity: Number(enrollmentHistory.maxCapacityHistory[i]),
-                        waitlist:
-                            enrollmentHistory.waitlistHistory[i] === 'n/a'
-                                ? null
-                                : Number(enrollmentHistory.waitlistHistory[i]),
-                    });
-                }
-
-                parsedEnrollmentHistory.push({
-                    year: enrollmentHistory.year,
-                    quarter: enrollmentHistory.quarter,
-                    department: enrollmentHistory.department,
-                    courseNumber: enrollmentHistory.courseNumber,
-                    days: enrollmentDays,
-                    instructors: enrollmentHistory.instructors,
+                enrollmentDays.push({
+                    date: formattedDate,
+                    totalEnrolled: Number(enrollmentHistory.totalEnrolledHistory[i]),
+                    maxCapacity: Number(enrollmentHistory.maxCapacityHistory[i]),
+                    waitlist:
+                        enrollmentHistory.waitlistHistory[i] === 'n/a'
+                            ? null
+                            : Number(enrollmentHistory.waitlistHistory[i]),
                 });
             }
+
+            parsedEnrollmentHistory.push({
+                year: enrollmentHistory.year,
+                quarter: enrollmentHistory.quarter,
+                department: enrollmentHistory.department,
+                courseNumber: enrollmentHistory.courseNumber,
+                days: enrollmentDays,
+                instructors: enrollmentHistory.instructors,
+            });
         }
 
         return parsedEnrollmentHistory;

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -47,6 +47,7 @@ class _EnrollmentHistory {
         this.enrollmentHistoryCache = {};
     }
 
+    // TODO: fix return type
     queryEnrollmentHistory = async (
         department: string,
         courseNumber: string,


### PR DESCRIPTION
## Summary
- Now that the enrollment history endpoint is implemented, we can bring back and improve the Past Enrollment popup.
- Currently, the popup just displays the enrollment history of the most recent lecture section offered.

Demo:

https://github.com/icssc/AntAlmanac/assets/78244965/1b6bcee9-cc37-4057-a85f-2fea05f3b124

## TODO

- [X] Make a request to PeterPortal to get the enrollment history, and parse the response
- [X] Create the popup and display an enrollment history graph
- [x] Cache responses
- [x] Add ZotTracker link

## Test Plan
- Verify this works for classes in the most recent quarter (e.g. CS 132).
- Verify this works for classes that haven't been offered very recently (e.g. CS 122D from Spring 2023).
- Verify this works for classes that have never been offered before (force `queryEnrollmentHistory` to return null).
- Make sure it looks good on dark and light mode, as well as mobile.

## Issues

Closes #341 
Closes #182 

## Future Followup
- We should allow the user to see the enrollment history of any lecture that was previously offered: #830 
