### PR TITLE
test: Add setup file, handle matchMedia

### DIFF
--- a/apps/antalmanac/tests/setup/setup.ts
+++ b/apps/antalmanac/tests/setup/setup.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(), // deprecated
+        removeListener: vi.fn(), // deprecated
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});

--- a/apps/antalmanac/vite.config.ts
+++ b/apps/antalmanac/vite.config.ts
@@ -23,4 +23,8 @@ export default defineConfig({
     server: {
         host: 'localhost',
     },
+    test: {
+        environment: 'jsdom',
+        setupFiles: [resolve(__dirname, 'tests/setup/setup.ts')],
+    },
 });


### PR DESCRIPTION
## Summary
Added in a `setup.ts` file to mock the window.matchMedia function. JSDOM does not support it, resulting in our tests breaking.

## Test Plan
Tests should run clean

## Issues
Closes #827 

<!-- [Optional]
## Future Followup
-->