### PR TITLE
Change colors in manifest

### DIFF
--- a/apps/antalmanac/public/manifest.json
+++ b/apps/antalmanac/public/manifest.json
@@ -10,6 +10,6 @@
     ],
     "start_url": "./index.html",
     "display": "standalone",
-    "theme_color": "#000000",
-    "background_color": "#ffffff"
+    "theme_color": "#305db7",
+    "background_color": "#000000"
 }


### PR DESCRIPTION
## Summary
The goal here is to make the top status bar on mobile the same color as our app bar. Right now it's just black.
## Test Plan
Download the staging instance as a PWA on your phone and see if the colors look fine.