### PR TITLE
feat: create hover view

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -79,13 +79,13 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const { isMilitaryTime } = useTimeFormatStore();
-    const { hoveredCourse } = useHoveredStore();
+    const { hoveredCourseEvents } = useHoveredStore();
 
     const getEventsForCalendar = () => {
         return showFinalsSchedule
             ? finalsEventsInCalendar
-            : hoveredCourse
-              ? [...eventsInCalendar, hoveredCourse]
+            : hoveredCourseEvents
+              ? [...eventsInCalendar, ...hoveredCourseEvents]
               : eventsInCalendar;
     };
 

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -11,6 +11,7 @@ import CourseCalendarEvent, { CalendarEvent } from './CourseCalendarEvent';
 import AppStore from '$stores/AppStore';
 import locationIds from '$lib/location_ids';
 import { useTimeFormatStore } from '$stores/SettingsStore';
+import { useHoveredStore } from '$stores/HoveredStore';
 
 const localizer = momentLocalizer(moment);
 
@@ -52,8 +53,8 @@ const AntAlmanacEvent = ({ event }: { event: CalendarEvent }) => {
                     {event.showLocationInfo
                         ? event.locations.map((location) => `${location.building} ${location.room}`).join(', ')
                         : event.locations.length > 1
-                        ? `${event.locations.length} Locations`
-                        : `${event.locations[0].building} ${event.locations[0].room}`}
+                          ? `${event.locations.length} Locations`
+                          : `${event.locations[0].building} ${event.locations[0].room}`}
                 </Box>
                 <Box>{event.sectionCode}</Box>
             </Box>
@@ -78,9 +79,14 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const { isMilitaryTime } = useTimeFormatStore();
+    const { hoveredCourse } = useHoveredStore();
 
     const getEventsForCalendar = () => {
-        return showFinalsSchedule ? finalsEventsInCalendar : eventsInCalendar;
+        return showFinalsSchedule
+            ? finalsEventsInCalendar
+            : hoveredCourse
+              ? [...eventsInCalendar, hoveredCourse]
+              : eventsInCalendar;
     };
 
     const handleClosePopover = () => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -135,7 +135,9 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
         // This equation is taken from w3c, does not use the colour difference part
         const minBrightnessDiff = 125;
 
-        const backgroundRegexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(bg) as RegExpExecArray; // returns {hex, r, g, b}
+        const backgroundRegexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+            bg.slice(0, 7)
+        ) as RegExpExecArray; // returns {hex, r, g, b}
         const backgroundRGB = {
             r: parseInt(backgroundRegexResult[1], 16),
             g: parseInt(backgroundRegexResult[2], 16),

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -148,7 +148,7 @@ function ExperimentalMenu() {
             <Box display="flex" justifyContent="space-between" width={1}>
                 <Box display="flex" alignItems="center" style={{ gap: 4 }}>
                     <Typography variant="h6" style={{ display: 'flex', alignItems: 'center', alignContent: 'center' }}>
-                        Preview Mode
+                        Hover to Preview
                     </Typography>
                     <Tooltip title={<Typography>Hover over courses to preview them in your calendar!</Typography>}>
                         <Help />

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useState } from 'react';
-import { Box, Button, ButtonGroup, Divider, Drawer, IconButton, Typography, useMediaQuery } from '@material-ui/core';
+import { Box, Button, ButtonGroup, Drawer, IconButton, Switch, Typography, useMediaQuery } from '@material-ui/core';
+import { Divider, Stack } from '@mui/material';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { Close, DarkMode, LightMode, Settings, SettingsBrightness } from '@mui/icons-material';
 
-import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
+import { usePreviewStore, useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
 
 const lightSelectedStyle: CSSProperties = {
     backgroundColor: '#F0F7FF',
@@ -135,6 +136,25 @@ function TimeMenu() {
     );
 }
 
+function ExperimentalMenu() {
+    const [previewMode, setPreviewMode] = usePreviewStore((store) => [store.previewMode, store.setPreviewMode]);
+
+    const handlePreviewChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setPreviewMode(event.target.checked);
+    };
+
+    return (
+        <Stack sx={{ padding: '1rem 1rem 0 1rem', width: '100%', display: 'flex' }} alignItems="middle">
+            <Box display="flex" justifyContent="space-between" width={1}>
+                <Typography variant="h6" style={{ display: 'flex', alignItems: 'center', alignContent: 'center' }}>
+                    Preview Mode
+                </Typography>
+                <Switch color="primary" value={previewMode} checked={previewMode} onChange={handlePreviewChange} />
+            </Box>
+        </Stack>
+    );
+}
+
 function SettingsMenu() {
     const [drawerOpen, setDrawerOpen] = useState(false);
     const isMobileScreen = useMediaQuery('(max-width:750px)');
@@ -174,10 +194,16 @@ function SettingsMenu() {
                             <Close fontSize="inherit" />
                         </IconButton>
                     </Box>
-                    <Divider />
 
+                    <Divider />
                     <ThemeMenu />
                     <TimeMenu />
+
+                    <Divider style={{ marginTop: '16px' }}>
+                        <Typography variant="h6">Experimental Features</Typography>
+                    </Divider>
+
+                    <ExperimentalMenu />
                 </Box>
             </Drawer>
         </>

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -34,7 +34,7 @@ function ThemeMenu() {
     };
 
     return (
-        <Box sx={{ padding: '1rem 1rem 0 1rem', width: '100%' }}>
+        <Box sx={{ padding: '0 1rem', width: '100%' }}>
             <Typography variant="h6" style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
                 Theme
             </Typography>
@@ -92,7 +92,7 @@ function TimeMenu() {
     };
 
     return (
-        <Box sx={{ padding: '1rem 1rem 0 1rem', width: '100%' }}>
+        <Box sx={{ padding: '0 1rem', width: '100%' }}>
             <Typography variant="h6" style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
                 Time
             </Typography>
@@ -186,7 +186,7 @@ function SettingsMenu() {
                             flexDirection: 'row',
                             justifyContent: 'space-between',
                             alignItems: 'center',
-                            padding: '16px',
+                            padding: '12px',
                         }}
                     >
                         <Typography variant="h6">Settings</Typography>
@@ -196,11 +196,12 @@ function SettingsMenu() {
                     </Box>
 
                     <Divider />
+
                     <ThemeMenu />
                     <TimeMenu />
 
                     <Divider style={{ marginTop: '16px' }}>
-                        <Typography variant="h6">Experimental Features</Typography>
+                        <Typography variant="subtitle2">Experimental Features</Typography>
                     </Divider>
 
                     <ExperimentalMenu />

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState } from 'react';
 import { Box, Button, ButtonGroup, Drawer, IconButton, Switch, Typography, useMediaQuery } from '@material-ui/core';
-import { Divider, Stack } from '@mui/material';
+import { Divider, Stack, Tooltip } from '@mui/material';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
-import { Close, DarkMode, LightMode, Settings, SettingsBrightness } from '@mui/icons-material';
+import { Close, DarkMode, Help, LightMode, Settings, SettingsBrightness } from '@mui/icons-material';
 
 import { usePreviewStore, useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
 
@@ -146,9 +146,14 @@ function ExperimentalMenu() {
     return (
         <Stack sx={{ padding: '1rem 1rem 0 1rem', width: '100%', display: 'flex' }} alignItems="middle">
             <Box display="flex" justifyContent="space-between" width={1}>
-                <Typography variant="h6" style={{ display: 'flex', alignItems: 'center', alignContent: 'center' }}>
-                    Preview Mode
-                </Typography>
+                <Box display="flex" alignItems="center" style={{ gap: 4 }}>
+                    <Typography variant="h6" style={{ display: 'flex', alignItems: 'center', alignContent: 'center' }}>
+                        Preview Mode
+                    </Typography>
+                    <Tooltip title={<Typography>Hover over courses to preview them in your calendar!</Typography>}>
+                        <Help />
+                    </Tooltip>
+                </Box>
                 <Switch color="primary" value={previewMode} checked={previewMode} onChange={handlePreviewChange} />
             </Box>
         </Stack>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -515,13 +515,13 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         setCalendarEvents(AppStore.getCourseEventsInCalendar());
     }, [setCalendarEvents]);
 
-    // const [hovered, setHovered] = useState<React.MouseEvent<HTMLTableRowElement>>();
-
     const [hoveredCourse, setHoveredCourse] = useHoveredStore((store) => [store.hoveredCourse, store.setHoveredCourse]);
 
-    const handleHover = useCallback((sectionCode?: string) => {
-        setHoveredCourse(sectionCode);
-    }, []);
+    const handleHover = useCallback(() => {
+        hoveredCourse?.sectionCode == section.sectionCode
+            ? setHoveredCourse(undefined)
+            : setHoveredCourse(section, courseDetails, term);
+    }, [courseDetails, hoveredCourse, section, setHoveredCourse, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {
@@ -598,8 +598,8 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
                 addedCourse ? { addedCourse: addedCourse && allowHighlight } : { scheduleConflict: scheduleConflict }
             )}
             onMouseEnter={handleHover}
-            onMouseLeave={() => handleHover(undefined)}
-            style={{ backgroundColor: hoveredCourse == section.sectionCode ? 'red' : 'blue' }}
+            onMouseLeave={handleHover}
+            style={{ backgroundColor: hoveredCourse?.sectionCode == section.sectionCode ? 'red' : 'blue' }}
         >
             {!addedCourse ? (
                 <ScheduleAddCell

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -33,7 +33,7 @@ import { useTabStore } from '$stores/TabStore';
 import locationIds from '$lib/location_ids';
 import { normalizeTime, parseDaysString, formatTimes } from '$stores/calendarizeHelpers';
 import useColumnStore, { type SectionTableColumn } from '$stores/ColumnStore';
-import { useTimeFormatStore } from '$stores/SettingsStore';
+import { usePreviewStore, useTimeFormatStore } from '$stores/SettingsStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 
 const styles: Styles<Theme, object> = (theme) => ({
@@ -471,6 +471,7 @@ interface SectionTableBodyProps {
     scheduleNames: string[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     sectionCode: CourseCodeCell,
     sectionDetails: SectionDetailsCell,
@@ -520,15 +521,17 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         store.setHoveredCourseEvents,
     ]);
 
+    const { previewMode } = usePreviewStore();
+
     const handleHover = useCallback(() => {
         const alreadyHovered =
             hoveredCourseEvents &&
             hoveredCourseEvents.some((courseEvent) => courseEvent.sectionCode == section.sectionCode);
 
-        alreadyHovered || addedCourse
+        !previewMode || alreadyHovered || addedCourse
             ? setHoveredCourseEvents(undefined)
             : setHoveredCourseEvents(section, courseDetails, term);
-    }, [addedCourse, courseDetails, hoveredCourseEvents, section, setHoveredCourseEvents, term]);
+    }, [addedCourse, courseDetails, hoveredCourseEvents, previewMode, section, setHoveredCourseEvents, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -515,13 +515,17 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         setCalendarEvents(AppStore.getCourseEventsInCalendar());
     }, [setCalendarEvents]);
 
-    const [hoveredCourse, setHoveredCourse] = useHoveredStore((store) => [store.hoveredCourse, store.setHoveredCourse]);
+    const [hoveredCourseEvents, setHoveredCourseEvents] = useHoveredStore((store) => [
+        store.hoveredCourseEvents,
+        store.setHoveredCourseEvents,
+    ]);
 
     const handleHover = useCallback(() => {
-        hoveredCourse?.sectionCode == section.sectionCode
-            ? setHoveredCourse(undefined)
-            : setHoveredCourse(section, courseDetails, term);
-    }, [courseDetails, hoveredCourse, section, setHoveredCourse, term]);
+        const alreadyHovered = hoveredCourseEvents && hoveredCourseEvents[0].sectionCode == section.sectionCode;
+        alreadyHovered || addedCourse
+            ? setHoveredCourseEvents(undefined)
+            : setHoveredCourseEvents(section, courseDetails, term);
+    }, [addedCourse, courseDetails, hoveredCourseEvents, section, setHoveredCourseEvents, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {
@@ -599,7 +603,6 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             )}
             onMouseEnter={handleHover}
             onMouseLeave={handleHover}
-            style={{ backgroundColor: hoveredCourse?.sectionCode == section.sectionCode ? 'red' : 'blue' }}
         >
             {!addedCourse ? (
                 <ScheduleAddCell

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -521,7 +521,10 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     ]);
 
     const handleHover = useCallback(() => {
-        const alreadyHovered = hoveredCourseEvents && hoveredCourseEvents[0].sectionCode == section.sectionCode;
+        const alreadyHovered =
+            hoveredCourseEvents &&
+            hoveredCourseEvents.some((courseEvent) => courseEvent.sectionCode == section.sectionCode);
+
         alreadyHovered || addedCourse
             ? setHoveredCourseEvents(undefined)
             : setHoveredCourseEvents(section, courseDetails, term);

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -1,0 +1,19 @@
+import { ScheduleCourse } from '@packages/antalmanac-types';
+import { create } from 'zustand';
+import { CourseDetails } from '$lib/course_data.types';
+
+export interface HoveredStore {
+    hoveredCourse: ScheduleCourse | undefined;
+    setHoveredCourse: (section: any, courseDetails: CourseDetails, term: string, scheduleIndex: number) => void;
+}
+
+export const useHoveredStore = create<HoveredStore>((set) => {
+    const hoveredSectionCode = undefined;
+
+    return {
+        hoveredCourse: hoveredSectionCode,
+        setHoveredCourse: (hoveredCourse) => {
+            set({ hoveredCourse });
+        },
+    };
+});

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -21,7 +21,7 @@ export const useHoveredStore = create<HoveredStore>((set) => {
                                   ...courseDetails,
                                   section: {
                                       ...section,
-                                      color: '#808080',
+                                      color: '#80808080',
                                   },
                                   term,
                               },

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -5,27 +5,27 @@ import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CourseDetails } from '$lib/course_data.types';
 
 export interface HoveredStore {
-    hoveredCourse: CourseEvent | undefined;
-    setHoveredCourse: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
+    hoveredCourseEvents: CourseEvent[] | undefined;
+    setHoveredCourseEvents: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
 }
 
 export const useHoveredStore = create<HoveredStore>((set) => {
     return {
-        hoveredCourse: undefined,
-        setHoveredCourse: (section, courseDetails, term) => {
+        hoveredCourseEvents: undefined,
+        setHoveredCourseEvents: (section, courseDetails, term) => {
             set({
-                hoveredCourse:
+                hoveredCourseEvents:
                     section && courseDetails && term
                         ? calendarizeCourseEvents([
                               {
                                   ...courseDetails,
                                   section: {
                                       ...section,
-                                      color: '#0000FF',
+                                      color: '#808080',
                                   },
                                   term,
                               },
-                          ])[0]
+                          ])
                         : undefined,
             });
         },

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -1,19 +1,33 @@
-import { ScheduleCourse } from '@packages/antalmanac-types';
 import { create } from 'zustand';
+import { AASection } from '@packages/antalmanac-types';
+import { calendarizeCourseEvents } from './calendarizeHelpers';
+import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CourseDetails } from '$lib/course_data.types';
 
 export interface HoveredStore {
-    hoveredCourse: ScheduleCourse | undefined;
-    setHoveredCourse: (section: any, courseDetails: CourseDetails, term: string, scheduleIndex: number) => void;
+    hoveredCourse: CourseEvent | undefined;
+    setHoveredCourse: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
 }
 
 export const useHoveredStore = create<HoveredStore>((set) => {
-    const hoveredSectionCode = undefined;
-
     return {
-        hoveredCourse: hoveredSectionCode,
-        setHoveredCourse: (hoveredCourse) => {
-            set({ hoveredCourse });
+        hoveredCourse: undefined,
+        setHoveredCourse: (section, courseDetails, term) => {
+            set({
+                hoveredCourse:
+                    section && courseDetails && term
+                        ? calendarizeCourseEvents([
+                              {
+                                  ...courseDetails,
+                                  section: {
+                                      ...section,
+                                      color: '#0000FF',
+                                  },
+                                  term,
+                              },
+                          ])[0]
+                        : undefined,
+            });
         },
     };
 });

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -20,8 +20,8 @@ export const useThemeStore = create<ThemeStore>((set) => {
         themeSetting !== 'system'
             ? themeSetting
             : window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light';
+              ? 'dark'
+              : 'light';
 
     return {
         themeSetting: themeSetting as 'light' | 'dark' | 'system',
@@ -35,8 +35,8 @@ export const useThemeStore = create<ThemeStore>((set) => {
                 themeSetting !== 'system'
                     ? themeSetting
                     : window.matchMedia('(prefers-color-scheme: dark)').matches
-                    ? 'dark'
-                    : 'light';
+                      ? 'dark'
+                      : 'light';
 
             set({ appTheme: appTheme, themeSetting: themeSetting });
 
@@ -64,6 +64,25 @@ export const useTimeFormatStore = create<TimeFormatStore>((set) => {
                 window.localStorage.setItem('show24HourTime', isMilitaryTime.toString());
             }
             set({ isMilitaryTime });
+        },
+    };
+});
+export interface PreviewStore {
+    previewMode: boolean;
+    setPreviewMode: (previewMode: boolean) => void;
+}
+
+export const usePreviewStore = create<PreviewStore>((set) => {
+    const previewMode = typeof Storage !== 'undefined' && window.localStorage.getItem('previewMode') == 'true';
+
+    return {
+        previewMode: previewMode,
+        setPreviewMode: (previewMode) => {
+            if (typeof Storage !== 'undefined') {
+                window.localStorage.setItem('previewMode', previewMode.toString());
+            }
+
+            set({ previewMode: previewMode });
         },
     };
 });


### PR DESCRIPTION
## ~~WIP~~ To-Dos
- [x] Show all meetings of the section
- [x] Handle hovered sections that are already added
- [x] Disable in added pane (possibly solved by task 2)
- [x] Make not an eyesore

## Summary
1. Implement a `HoveredStore` to store the currently hovered course
2. `SectionTableBody` will access and update `HoveredStore` when a section is hovered
3. Hovered Courses will be appended to events passed to the Calendar

![chrome-capture-2023-11-6 (1)](https://github.com/icssc/AntAlmanac/assets/100006999/dd71f4c7-378f-4ea9-b6be-3dbdf78c75e4)

## Test Plan
1. Check that it correctly displays the course on the calendar
2. Light and Dark mode compatibility
3. Doesn't activate on Added Pane
4. Doesn't activate on already added courses

## Issues
Closes #828 

## Future Followup
1. Remove the schedule conflict feature, since this covers much of the same functionality? Unsure on this (since SC is my baby 🥺, but it's a valid question) 
