### PR TITLE
Title Includes "UCI Schedule Planner"

### DIFF
--- a/apps/antalmanac/index.html
+++ b/apps/antalmanac/index.html
@@ -68,7 +68,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-        <title>AntAlmanac</title>
+        <title>AntAlmanac — UCI Schedule Planner</title>
         <!-- Global site tag (gtag.js) - Google Analytics -->
 
         <!-- console.log for recruitment -->


### PR DESCRIPTION
## Summary
Update the title metadata from "AntAlmanac" to "AntAlmanac — UCI Schedule Planner" with the aim to improve SEO.

## Test Plan
View it in prod. It's just a one-line text edit (famous last words).

## Issues

Closes #614 


