### PR TITLE
feat: Add warning text to save modal

### DIFF
--- a/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
+++ b/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
@@ -101,10 +101,8 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
                         <DialogContentText>
                             Enter your unique user ID here to {this.props.actionName.toLowerCase()} your schedule.
                         </DialogContentText>
-                        <DialogContentText>
-                            <span style={{ color: 'red' }}>
-                                Make sure the user ID is unique and secret, or someone else can overwrite your schedule.
-                            </span>
+                        <DialogContentText style={{ color: 'red' }}>
+                            Make sure the user ID is unique and secret, or someone else can overwrite your schedule.
                         </DialogContentText>
                         <TextField
                             // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
+++ b/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
@@ -99,13 +99,18 @@ class LoadSaveButtonBase extends PureComponent<LoadSaveButtonBaseProps, LoadSave
                     <DialogTitle>{this.props.actionName}</DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Enter your username here to {this.props.actionName.toLowerCase()} your schedule.
+                            Enter your unique user ID here to {this.props.actionName.toLowerCase()} your schedule.
+                        </DialogContentText>
+                        <DialogContentText>
+                            <span style={{ color: 'red' }}>
+                                Make sure the user ID is unique and secret, or someone else can overwrite your schedule.
+                            </span>
                         </DialogContentText>
                         <TextField
                             // eslint-disable-next-line jsx-a11y/no-autofocus
                             autoFocus
                             margin="dense"
-                            label="User ID"
+                            label="Unique User ID"
                             type="text"
                             fullWidth
                             placeholder="Enter here"


### PR DESCRIPTION
## Summary
Added warning for users to use a unique user ID in red text
![modalfix](https://github.com/icssc/AntAlmanac/assets/88558727/3679b2ce-dd6c-4bc8-acf4-461cb05f9b0b)


## Test Plan
1. Check on default modal
2. Check if responsive on mobile

Note: using span for red text, probably a better convention

## Issues

Closes #845 

<!-- [Optional]
## Future Followup
-->
