### PR TITLE
Fixed Custom Events Loading Onto Map

### DIFF
--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -148,7 +148,7 @@ export default function CourseMap() {
     const [searchParams] = useSearchParams();
     const [selectedDayIndex, setSelectedDay] = useState(0);
     const [markers, setMarkers] = useState(getCoursesPerBuilding());
-    const [customEventMarkers] = useState(getCustomEventPerBuilding());
+    const [customEventMarkers, setCustomEventMarkers] = useState(getCustomEventPerBuilding());
     const [calendarEvents, setCalendarEvents] = useState(AppStore.getCourseEventsInCalendar());
 
     useEffect(() => {
@@ -164,6 +164,22 @@ export default function CourseMap() {
             AppStore.removeListener('addedCoursesChange', updateMarkers);
             AppStore.removeListener('currentScheduleIndexChange', updateMarkers);
             AppStore.removeListener('colorChange', updateMarkers);
+        };
+    }, []);
+
+    useEffect(() => {
+        const updateCustomEventMarkers = () => {
+            setCustomEventMarkers(getCustomEventPerBuilding());
+        };
+
+        AppStore.on('customEventsChange', updateCustomEventMarkers);
+        AppStore.on('currentScheduleIndexChange', updateCustomEventMarkers);
+        AppStore.on('colorChange', updateCustomEventMarkers);
+
+        return () => {
+            AppStore.removeListener('customEventsChange', updateCustomEventMarkers);
+            AppStore.removeListener('currentScheduleIndexChange', updateCustomEventMarkers);
+            AppStore.removeListener('colorChange', updateCustomEventMarkers);
         };
     }, []);
 

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -152,34 +152,21 @@ export default function CourseMap() {
     const [calendarEvents, setCalendarEvents] = useState(AppStore.getCourseEventsInCalendar());
 
     useEffect(() => {
-        const updateMarkers = () => {
+        const updateAllMarkers = () => {
             setMarkers(getCoursesPerBuilding());
-        };
-
-        AppStore.on('addedCoursesChange', updateMarkers);
-        AppStore.on('currentScheduleIndexChange', updateMarkers);
-        AppStore.on('colorChange', updateMarkers);
-
-        return () => {
-            AppStore.removeListener('addedCoursesChange', updateMarkers);
-            AppStore.removeListener('currentScheduleIndexChange', updateMarkers);
-            AppStore.removeListener('colorChange', updateMarkers);
-        };
-    }, []);
-
-    useEffect(() => {
-        const updateCustomEventMarkers = () => {
             setCustomEventMarkers(getCustomEventPerBuilding());
         };
 
-        AppStore.on('customEventsChange', updateCustomEventMarkers);
-        AppStore.on('currentScheduleIndexChange', updateCustomEventMarkers);
-        AppStore.on('colorChange', updateCustomEventMarkers);
+        AppStore.on('addedCoursesChange', updateAllMarkers);
+        AppStore.on('customEventsChange', updateAllMarkers);
+        AppStore.on('currentScheduleIndexChange', updateAllMarkers);
+        AppStore.on('colorChange', updateAllMarkers);
 
         return () => {
-            AppStore.removeListener('customEventsChange', updateCustomEventMarkers);
-            AppStore.removeListener('currentScheduleIndexChange', updateCustomEventMarkers);
-            AppStore.removeListener('colorChange', updateCustomEventMarkers);
+            AppStore.removeListener('addedCoursesChange', updateAllMarkers);
+            AppStore.removeListener('customEventsChange', updateAllMarkers);
+            AppStore.removeListener('currentScheduleIndexChange', updateAllMarkers);
+            AppStore.removeListener('colorChange', updateAllMarkers);
         };
     }, []);
 


### PR DESCRIPTION
## Summary
1. Add proper listeners for custom events updating in a manner analogous to that of classes in the Map directory

## Test Plan
1. View map
2. Add new custom event with location (try RH, it's one of the acceptable and nearby ones)
3. See if change is reflected
4. See if change reflects when saved and you visit antalmanac.com/map

## Issues

Closes #813 

## Future Followup
1. Not all locations are recognized for custom events on the map even though they are for classes (BS3, for example) and some don't even read on the calendar
2. Routes do not work for custom events (it is difficult to order them correctly with the classes due to how the indexes work)