### PR TITLE
style: remove hardcoded gutter width

### DIFF
--- a/apps/antalmanac/src/components/Calendar/calendar.css
+++ b/apps/antalmanac/src/components/Calendar/calendar.css
@@ -40,14 +40,6 @@
     font-size: 0.9rem;
 }
 
-.rbc-time-header-gutter {
-    width: 42px;
-}
-
-.rbc-time-gutter {
-    width: 42px;
-}
-
 @media (min-resolution: 96dpi) {
     .rbc-timeslot-group {
         min-height: 28px;


### PR DESCRIPTION
## Summary
1. Fixes time gutter overflow by removing the hardcoded pixel width

## Test Plan
1. Test calendar on a variety of screens; not much should change, but it should be responsive / size up to fit text now.

## Issues
Closes #852

<!-- [Optional]
## Future Followup
-->
