### PR TITLE
feat: swap to search on mobile

### DIFF
--- a/apps/antalmanac/src/components/MobileHome.tsx
+++ b/apps/antalmanac/src/components/MobileHome.tsx
@@ -19,7 +19,7 @@ export const mobileContext = createContext<MobileContext>({
 });
 
 const MobileHome = () => {
-    const [selectedTab, setSelectedTab] = useState(0);
+    const [selectedTab, setSelectedTab] = useState(1);
     const params = useParams();
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/MobileHome.tsx
+++ b/apps/antalmanac/src/components/MobileHome.tsx
@@ -19,7 +19,7 @@ export const mobileContext = createContext<MobileContext>({
 });
 
 const MobileHome = () => {
-    const [selectedTab, setSelectedTab] = useState(1);
+    const [selectedTab, setSelectedTab] = useState(localStorage.getItem('userID') ? 0 : 1);
     const params = useParams();
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
1. On mobile, if a user isn't signed in, we'll default to the Classes Tab

![Demo](https://github.com/icssc/AntAlmanac/assets/100006999/2f3dda3b-ad64-4521-abbb-0ac100b161db)

## Test Plan
1. On mobile, check functionality both when signed in and signed out
3. Should swap to classes tab when signed out
4. Shouldn't swap / stay on calendar tab when signed in

## Issues
Closes #858

<!-- [Optional]
## Future Followup
-->
