### PR TITLE
fix: tutorial followup

### DIFF
--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -30,7 +30,7 @@ export function tourShouldRun(): boolean {
     return !(
         localStorage.getItem(tourHasRunKey) == 'true' ||
         window.matchMedia('(max-width: 768px)').matches ||
-        localStorage.getItem('userId') != null
+        localStorage.getItem('userID') != null
     );
 }
 

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -81,6 +81,9 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
                     You can always review the tour by clicking the button in the bottom right corner.
                 </>
             ),
+            actionAfter: () => {
+                markTourHasRun();
+            },
         },
         searchBar: {
             selector: '#searchBar',


### PR DESCRIPTION
## Summary
Noticed two small bugs in the tutorial:

1. `localStorage.getItem()` was using `userId` instead of `userID`
2. tourHasRun isn't set to true if `esc` or close button is used on the first page

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
