### PR TITLE
style: add back row styling

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -499,6 +499,7 @@ const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
 
 const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     const { classes, section, courseDetails, term, allowHighlight, scheduleNames } = props;
+    const isDark = useThemeStore((store) => store.isDark);
 
     const activeColumns = useColumnStore((store) => store.activeColumns);
 
@@ -611,15 +612,25 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         return Boolean(conflictingEvent);
     }, [calendarEvents, sectionDetails]);
 
+    /* allowHighlight is always false on CourseRenderPane and always true on AddedCoursePane */
+    const computedAddedCourseStyle = allowHighlight
+        ? isDark
+            ? { background: '#b0b04f' }
+            : { background: '#fcfc97' }
+        : {};
+    const computedScheduleConflictStyle = scheduleConflict
+        ? isDark
+            ? { background: '#121212', opacity: '0.6' }
+            : { background: '#a0a0a0', opacity: '1' }
+        : {};
+
+    const computedRowStyle = addedCourse ? computedAddedCourseStyle : computedScheduleConflictStyle;
+
     return (
         <TableRow
             classes={{ root: classes.row }}
-            className={classNames(
-                classes.tr,
-                // If the course is added, then don't check for/apply scheduleConflict
-                // allowHighlight is ALWAYS false when in Added Course Pane and ALWAYS true when in CourseRenderPane
-                addedCourse ? { addedCourse: addedCourse && allowHighlight } : { scheduleConflict: scheduleConflict }
-            )}
+            className={classNames(classes.tr)}
+            style={computedRowStyle}
             onMouseEnter={handleHover}
             onMouseLeave={handleHover}
         >

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -499,9 +499,10 @@ const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
 
 const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
     const { classes, section, courseDetails, term, allowHighlight, scheduleNames } = props;
-    const isDark = useThemeStore((store) => store.isDark);
 
+    const isDark = useThemeStore((store) => store.isDark);
     const activeColumns = useColumnStore((store) => store.activeColumns);
+    const previewMode = usePreviewStore((store) => store.previewMode);
 
     const [addedCourse, setAddedCourse] = useState(
         AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term}`)
@@ -534,8 +535,6 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         store.hoveredCourseEvents,
         store.setHoveredCourseEvents,
     ]);
-
-    const { previewMode } = usePreviewStore();
 
     const handleHover = useCallback(() => {
         const alreadyHovered =


### PR DESCRIPTION
## Summary
1. Adds back styling for Added Course and Schedule Conflict
2. Refactors it to make it 50% less jank to read

## Test Plan
1. Does the styling appear properly?
3. Is there spillage over to AddedCoursePane? (there shouldn't be added styling there)
4. Is there any styling overlap? (added course and schedule conflict stylings should be mutually exclusive)

## Issues
Closes #886

<!-- [Optional]
## Future Followup
-->
