### PR TITLE
chore: add console.error in error spots to help developer

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -139,6 +139,7 @@ export const loadSchedule = async (userId: string, rememberMe: boolean) => {
                     );
                 }
             } catch (e) {
+                console.error(e);
                 openSnackbar(
                     'error',
                     `Failed to load schedules. If this continues to happen, please submit a feedback form.`

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -530,6 +530,7 @@ export class Schedules {
                 });
             }
         } catch (e) {
+            console.error(e);
             this.revertState();
             throw new Error('Unable to load schedule');
         }


### PR DESCRIPTION
## Summary
The error messages in the snackbar are very vague. Add console.error to help debug things if it breaks client side.