### PR TITLE
fix: remove hovered course on unmount

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -259,7 +259,11 @@ export default function CourseRenderPane(props: { id?: number }) {
         };
     }, [loadCourses, props.id]);
 
-    /* Removes hovered course when component unmounts */
+    /**
+     * Removes hovered course when component unmounts
+     * Handles edge cases where the Section Table is removed, rather than the mouse
+     * ex: Swapping to the Added tab, clicking the LocationCell link
+     */
     useEffect(() => {
         return () => {
             setHoveredCourseEvents(undefined);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -19,12 +19,16 @@ import Grades from '$lib/grades';
 import analyticsEnum from '$lib/analytics';
 import { openSnackbar } from '$actions/AppStoreActions';
 import WebSOC from '$lib/websoc';
+import { useHoveredStore } from '$stores/HoveredStore';
 
 function getColors() {
-    const courseColors = AppStore.schedule.getCurrentCourses().reduce((accumulator, { section }) => {
-        accumulator[section.sectionCode] = section.color;
-        return accumulator;
-    }, {} as { [key: string]: string });
+    const courseColors = AppStore.schedule.getCurrentCourses().reduce(
+        (accumulator, { section }) => {
+            accumulator[section.sectionCode] = section.color;
+            return accumulator;
+        },
+        {} as { [key: string]: string }
+    );
 
     return courseColors;
 }
@@ -174,6 +178,8 @@ export default function CourseRenderPane(props: { id?: number }) {
     const [error, setError] = useState(false);
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
+    const setHoveredCourseEvents = useHoveredStore((store) => store.setHoveredCourseEvents);
+
     const loadCourses = useCallback(async () => {
         setLoading(true);
 
@@ -252,6 +258,13 @@ export default function CourseRenderPane(props: { id?: number }) {
             AppStore.off('scheduleNamesChange', updateScheduleNames);
         };
     }, [loadCourses, props.id]);
+
+    /* Removes hovered course when component unmounts */
+    useEffect(() => {
+        return () => {
+            setHoveredCourseEvents(undefined);
+        };
+    }, [setHoveredCourseEvents]);
 
     return (
         <>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -551,7 +551,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         return () => {
             setHoveredCourseEvents(undefined);
         };
-    });
+    }, [setHoveredCourseEvents]);
 
     // Attach event listeners to the store.
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -546,13 +546,6 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             : setHoveredCourseEvents(section, courseDetails, term);
     }, [addedCourse, courseDetails, hoveredCourseEvents, previewMode, section, setHoveredCourseEvents, term]);
 
-    /* Removes hovered course when component unmounts */
-    useEffect(() => {
-        return () => {
-            setHoveredCourseEvents(undefined);
-        };
-    }, [setHoveredCourseEvents]);
-
     // Attach event listeners to the store.
     useEffect(() => {
         AppStore.on('addedCoursesChange', updateHighlight);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -546,6 +546,13 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
             : setHoveredCourseEvents(section, courseDetails, term);
     }, [addedCourse, courseDetails, hoveredCourseEvents, previewMode, section, setHoveredCourseEvents, term]);
 
+    /* Removes hovered course when component unmounts */
+    useEffect(() => {
+        return () => {
+            setHoveredCourseEvents(undefined);
+        };
+    });
+
     // Attach event listeners to the store.
     useEffect(() => {
         AppStore.on('addedCoursesChange', updateHighlight);


### PR DESCRIPTION
## Summary
1. Set hovered course to `undefined` whenever `SectionTableWrapped` unmounts

![chrome-capture-2024-1-10](https://github.com/icssc/AntAlmanac/assets/100006999/c1f5a683-491b-470f-9ce0-1620e68b9e21)

## Test Plan
1. Attempt to replicate #900, by hovering a course (it should appear in the calendar), then hitting `esc` (or any other action that removes the course results). The hovered course should disappear.

## Issues
Closes #900

<!-- [Optional]
## Future Followup
-->
