### PR TITLE
Fix lag when going back from search results

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
-import { Alert, Box, IconButton } from '@mui/material';
+import { Alert, Box, GlobalStyles, IconButton } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import { AACourse, AASection } from '@packages/antalmanac-types';
 import { WebsocDepartment, WebsocSchool, WebsocAPIResponse, GE } from 'peterportal-api-next-types';
@@ -281,6 +281,7 @@ export default function CourseRenderPane(props: { id?: number }) {
                     <RecruitmentBanner />
                     <Box>
                         <Box sx={{ height: '50px', marginBottom: '5px' }} />
+                        <GlobalStyles styles={{ '*::-webkit-scrollbar': { height: '8px' } }} />
                         {courseData.map((_: WebsocSchool | WebsocDepartment | AACourse, index: number) => {
                             let heightEstimate = 200;
                             if ((courseData[index] as AACourse).sections !== undefined)

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -13,7 +13,6 @@ import {
     useMediaQuery,
 } from '@material-ui/core';
 import { Assessment, Help, RateReview, ShowChart as ShowChartIcon } from '@material-ui/icons';
-import { GlobalStyles } from '@mui/material';
 import { MOBILE_BREAKPOINT } from '../../../globals';
 import CourseInfoBar from './CourseInfoBar';
 import CourseInfoButton from './CourseInfoButton';
@@ -129,7 +128,6 @@ function SectionTable(props: SectionTableProps) {
 
     return (
         <>
-            <GlobalStyles styles={{ '*::-webkit-scrollbar': { height: '8px' } }} />
             <Box style={{ display: 'flex', gap: 4, marginTop: 4, marginBottom: 8 }}>
                 <CourseInfoBar
                     deptCode={courseDetails.deptCode}


### PR DESCRIPTION
## Summary
* This has been annoying me for the past few months so I ran a bisect last night and located the culprit PR (#738)
* Moved the GlobalStyles from the SectionTable to the CourseRenderPane so there should only be one of them in existence now and not a hundred
  * kind of wild that was the issue

before:

https://github.com/icssc/AntAlmanac/assets/8922227/39635b71-d439-4521-a289-9321da250743

after:

https://github.com/icssc/AntAlmanac/assets/8922227/645194cc-e5c1-470e-b380-21a77d024269

## Test Plan
Try on both staging and prod:
1. Load a bunch of search results e.g. i've been searching COMPSCI and scrolling down until I reach the research classes
2. Click back
3. Compare how long it takes

## Issues

Closes #790 

<!-- [Optional]
## Future Followup
-->
