### PR TITLE
fix: reduce theme swap time

### DIFF
--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -5,6 +5,7 @@ import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { Close, DarkMode, Help, LightMode, Settings, SettingsBrightness } from '@mui/icons-material';
 
 import { usePreviewStore, useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
+import useCoursePaneStore from '$stores/CoursePaneStore';
 
 const lightSelectedStyle: CSSProperties = {
     backgroundColor: '#F0F7FF',
@@ -28,8 +29,10 @@ function ThemeMenu() {
         store.isDark,
         store.setAppTheme,
     ]);
+    const { forceUpdate } = useCoursePaneStore();
 
     const handleThemeChange = (event: React.MouseEvent<HTMLButtonElement>) => {
+        forceUpdate();
         setTheme(event.currentTarget.value as 'light' | 'dark' | 'system');
     };
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import RightPaneStore from '../RightPaneStore';
 import CoursePaneButtonRow from './CoursePaneButtonRow';
@@ -11,8 +11,7 @@ import Grades from '$lib/grades';
 import useCoursePaneStore from '$stores/CoursePaneStore';
 
 function RightPane() {
-    const [key, forceUpdate] = useReducer((currentCount) => currentCount + 1, 0);
-    const { searchIsDisplayed, displaySearch, displaySections } = useCoursePaneStore();
+    const { key, forceUpdate, searchIsDisplayed, displaySearch, displaySections } = useCoursePaneStore();
 
     const handleSearch = useCallback(() => {
         if (RightPaneStore.formDataIsValid()) {
@@ -24,7 +23,7 @@ function RightPane() {
                 `Please provide one of the following: Department, GE, Course Code/Range, or Instructor`
             );
         }
-    }, [displaySections]);
+    }, [displaySections, forceUpdate]);
 
     const refreshSearch = useCallback(() => {
         logAnalytics({
@@ -34,7 +33,7 @@ function RightPane() {
         WebSOC.clearCache();
         Grades.clearCache();
         forceUpdate();
-    }, []);
+    }, [forceUpdate]);
 
     const handleKeydown = useCallback(
         (event: KeyboardEvent) => {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -24,7 +24,7 @@ function RightPane() {
                 `Please provide one of the following: Department, GE, Course Code/Range, or Instructor`
             );
         }
-    }, []);
+    }, [displaySections]);
 
     const refreshSearch = useCallback(() => {
         logAnalytics({
@@ -49,7 +49,7 @@ function RightPane() {
         return () => {
             document.removeEventListener('keydown', handleKeydown, false);
         };
-    }, []);
+    }, [handleKeydown]);
 
     return (
         <div style={{ height: '100%' }}>

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -12,6 +12,9 @@ interface CoursePaneStore {
     enableManualSearch: () => void;
     disableManualSearch: () => void;
     toggleManualSearch: () => void;
+
+    key: number;
+    forceUpdate: () => void;
 }
 
 function paramsAreInURL() {
@@ -37,6 +40,9 @@ export const useCoursePaneStore = create<CoursePaneStore>((set) => {
         enableManualSearch: () => set({ manualSearchEnabled: true }),
         disableManualSearch: () => set({ manualSearchEnabled: false }),
         toggleManualSearch: () => set((state) => ({ manualSearchEnabled: !state.manualSearchEnabled })),
+
+        key: 0,
+        forceUpdate: () => set((state) => ({ key: (state.key += 1) })),
     };
 });
 


### PR DESCRIPTION
## Summary
1. Refactored `forceUpdate`, the mechanism which reloaded the search results, into `CoursePaneStore`
2. Immediately prior to theme swaps, we hook onto `forceUpdate`, derendering the components while maintaining the current search. 

Massive, massive "performance" boost. No more crashing sites. Much credit to @js0mmer for the idea.

![chrome-capture-2024-1-12](https://github.com/icssc/AntAlmanac/assets/100006999/07262801-dd81-49c0-a182-06eb6c21f07c)

## Test Plan
1. Scroll to the bottom of COMPSCI and test out theme swaps!

## Issues
Closes #694

<!-- [Optional]
## Future Followup
-->
