### PR TITLE
Make finals dates follow term of first class in schedule

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -7,8 +7,8 @@ import { SyntheticEvent, useEffect, useState } from 'react';
 import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calendar';
 
 import CalendarToolbar from './CalendarToolbar';
-import CourseCalendarEvent, { CalendarEvent } from './CourseCalendarEvent';
-import { getDefaultFinalsStartDate } from '$lib/termData';
+import CourseCalendarEvent, { CalendarEvent, CourseEvent } from './CourseCalendarEvent';
+import { getDefaultFinalsStartDate, getFinalsStartDateForTerm } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import locationIds from '$lib/location_ids';
 import { useTimeFormatStore } from '$stores/SettingsStore';
@@ -82,7 +82,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const { isMilitaryTime } = useTimeFormatStore();
     const { hoveredCourseEvents } = useHoveredStore();
 
-    const getEventsForCalendar = () => {
+    const getEventsForCalendar = (): CourseEvent[] => {
         return showFinalsSchedule
             ? finalsEventsInCalendar
             : hoveredCourseEvents
@@ -163,9 +163,12 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
     const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
 
-    const defaultFinals = getDefaultFinalsStartDate();
-    const finalsDateFormat = defaultFinals ? 'ddd MM/DD' : 'ddd';
-    const date = showFinalsSchedule && defaultFinals ? defaultFinals : new Date(2018, 0, 1);
+    const finalsDate = events.length > 0 ? getFinalsStartDateForTerm(events[0].term) : getDefaultFinalsStartDate();
+
+    console.log(events);
+
+    const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
+    const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);
 
     // If a final is on a Saturday or Sunday, let the calendar start on Saturday
     moment.updateLocale('es-us', {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -166,7 +166,6 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const finalsDate =
         eventsInCalendar.length > 0 ? getFinalsStartDateForTerm(eventsInCalendar[0].term) : getDefaultFinalsStartDate();
 
-    console.log(events);
 
     const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
     const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -82,7 +82,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const { isMilitaryTime } = useTimeFormatStore();
     const { hoveredCourseEvents } = useHoveredStore();
 
-    const getEventsForCalendar = (): CourseEvent[] => {
+    const getEventsForCalendar = (): CalendarEvent[] => {
         return showFinalsSchedule
             ? finalsEventsInCalendar
             : hoveredCourseEvents
@@ -163,9 +163,10 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
     const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
 
-    const finalsDate =
-        eventsInCalendar.length > 0 ? getFinalsStartDateForTerm(eventsInCalendar[0].term) : getDefaultFinalsStartDate();
+    const onlyCourseEvents = eventsInCalendar.filter((e) => !e.isCustomEvent) as CourseEvent[];
 
+    const finalsDate =
+        onlyCourseEvents.length > 0 ? getFinalsStartDateForTerm(onlyCourseEvents[0].term) : getDefaultFinalsStartDate();
 
     const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
     const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -163,7 +163,8 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
     const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
 
-    const finalsDate = events.length > 0 ? getFinalsStartDateForTerm(events[0].term) : getDefaultFinalsStartDate();
+    const finalsDate =
+        eventsInCalendar.length > 0 ? getFinalsStartDateForTerm(eventsInCalendar[0].term) : getDefaultFinalsStartDate();
 
     console.log(events);
 

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -97,6 +97,11 @@ function getDefaultFinalsStart() {
     return termData[defaultTerm + 1].finalsStartDate;
 }
 
+function getFinalsStartForTerm(term: string) {
+    const termThatMatches = termData.find((t) => t.shortName === term) as Term;
+    return termThatMatches.finalsStartDate;
+}
+
 /**
  * Returns the default finals start as Date object
  * Days offset by 1 to accomodate toggling with Saturday finals
@@ -107,4 +112,18 @@ function getDefaultFinalsStartDate() {
     return year && month && day ? new Date(year, month, day + 1) : undefined;
 }
 
-export { defaultTerm, getDefaultTerm, termData, getDefaultFinalsStart, getDefaultFinalsStartDate };
+function getFinalsStartDateForTerm(term: string) {
+    const date = getFinalsStartForTerm(term);
+    const [year, month, day] = date || [];
+    return year && month && day ? new Date(year, month, day + 1) : undefined;
+}
+
+export {
+    defaultTerm,
+    getDefaultTerm,
+    termData,
+    getDefaultFinalsStart,
+    getDefaultFinalsStartDate,
+    getFinalsStartForTerm,
+    getFinalsStartDateForTerm,
+};

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -29,7 +29,7 @@ class Term {
 const termData = [
     new Term('2024 Spring', '2024 Spring Quarter', [2024, 3, 1], [2024, 5, 8]),
     new Term('2024 Winter', '2024 Winter Quarter', [2024, 0, 8], [2024, 2, 16]),
-    new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28]),
+    new Term('2023 Fall', '2023 Fall Quarter', [2023, 8, 28], [2023, 11, 9]),
     new Term('2023 Summer2', '2023 Summer Session 2', [2023, 7, 7]),
     new Term('2023 Summer10wk', '2023 10-wk Summer', [2023, 5, 26]),
     new Term('2023 Summer1', '2023 Summer Session 1', [2023, 5, 26]),

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -98,7 +98,11 @@ function getDefaultFinalsStart() {
 }
 
 function getFinalsStartForTerm(term: string) {
-    const termThatMatches = termData.find((t) => t.shortName === term) as Term;
+    const termThatMatches = termData.find((t) => t.shortName === term);
+    if (termThatMatches === undefined) {
+        console.warn(`No matching term for ${term}`);
+        return getDefaultFinalsStart();
+    }
     return termThatMatches.finalsStartDate;
 }
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -107,7 +107,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
 
             /**
              * Fallback to January 2018 if no finals start date is available.
-             * defaultFinalsDay is handled later by day since it varies by day.
+             * finalsDay is handled later by day since it varies by day.
              */
             const [finalsYear, finalsMonth, finalsDay] = [...(getFinalsStartForTerm(course.term) ?? [2018, 0])];
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -3,7 +3,7 @@ import { HourMinute } from 'peterportal-api-next-types';
 import { RepeatingCustomEvent } from '@packages/antalmanac-types';
 import { CourseEvent, CustomEvent, Location } from '$components/Calendar/CourseCalendarEvent';
 import { notNull, getReferencesOccurring } from '$lib/utils';
-import { getDefaultFinalsStart } from '$lib/termData';
+import { getFinalsStartForTerm } from '$lib/termData';
 
 export const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 
@@ -109,9 +109,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              * Fallback to January 2018 if no finals start date is available.
              * defaultFinalsDay is handled later by day since it varies by day.
              */
-            const [defaultFinalsYear, defaultFinalsMonth, defaultFinalsDay] = [
-                ...(getDefaultFinalsStart() ?? [2018, 0]),
-            ];
+            const [finalsYear, finalsMonth, finalsDay] = [...(getFinalsStartForTerm(course.term) ?? [2018, 0])];
 
             return dayIndicesOcurring.map((dayIndex) => ({
                 color: course.section.color,
@@ -129,16 +127,16 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
                 sectionCode: course.section.sectionCode,
                 sectionType: 'Fin',
                 start: new Date(
-                    defaultFinalsYear,
-                    defaultFinalsMonth,
-                    defaultFinalsDay ? defaultFinalsDay + dayIndex : dayIndex - 1,
+                    finalsYear,
+                    finalsMonth,
+                    finalsDay ? finalsDay + dayIndex : dayIndex - 1,
                     startHour,
                     startMin
                 ),
                 end: new Date(
-                    defaultFinalsYear,
-                    defaultFinalsMonth,
-                    defaultFinalsDay ? defaultFinalsDay + dayIndex : dayIndex - 1,
+                    finalsYear,
+                    finalsMonth,
+                    finalsDay ? finalsDay + dayIndex : dayIndex - 1,
                     endHour,
                     endMin
                 ),

--- a/apps/antalmanac/tests/calendarize-helpers.test.ts
+++ b/apps/antalmanac/tests/calendarize-helpers.test.ts
@@ -61,7 +61,7 @@ describe('calendarize-helpers', () => {
                 status: 'OPEN',
                 sectionComment: 'placeholderSectionComment',
             },
-            term: 'placeholderTerm',
+            term: '2024 Winter',
         },
     ];
 
@@ -70,7 +70,7 @@ describe('calendarize-helpers', () => {
         {
             locations: [],
             color: 'placeholderColor',
-            term: 'placeholderTerm',
+            term: '2024 Winter',
             title: 'placeholderDeptCode placeholderCourseNumber',
             courseTitle: 'placeholderCourseTitle',
             instructors: [],
@@ -99,7 +99,7 @@ describe('calendarize-helpers', () => {
         {
             locations: [],
             color: 'placeholderColor',
-            term: 'placeholderTerm',
+            term: '2024 Winter',
             title: 'placeholderDeptCode placeholderCourseNumber',
             courseTitle: 'placeholderCourseTitle',
             instructors: [],
@@ -128,7 +128,7 @@ describe('calendarize-helpers', () => {
         {
             locations: [],
             color: 'placeholderColor',
-            term: 'placeholderTerm',
+            term: '2024 Winter',
             title: 'placeholderDeptCode placeholderCourseNumber',
             courseTitle: 'placeholderCourseTitle',
             instructors: [],
@@ -160,13 +160,13 @@ describe('calendarize-helpers', () => {
         {
             locations: [],
             color: 'placeholderColor',
-            term: 'placeholderTerm',
+            term: '2024 Winter',
             title: 'placeholderDeptCode placeholderCourseNumber',
             courseTitle: 'placeholderCourseTitle',
             instructors: [],
             sectionCode: 'placeholderSectionCode',
             sectionType: 'Fin',
-            start: new Date(2024, 2, 17, 1, 2), // Predicated on default term being Spring 2024
+            start: new Date(2024, 2, 17, 1, 2), // Winter 2024 dates
             end: new Date(2024, 2, 17, 3, 4), // ...
             finalExam: {
                 examStatus: 'SCHEDULED_FINAL',


### PR DESCRIPTION
## Summary
Instead of always using the default term for finals, use the term of the first course in the currently selected schedule.

## Test Plan
Load finals from fall quarter. Right now spring quarter finals aren't out so it won't work.

## Issues
Closes #908