### PR TITLE
fix: cleanup calendar warning

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -278,6 +278,7 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
                     step={15}
                     timeslots={2}
                     date={date}
+                    onNavigate={() => undefined}
                     min={getStartTime()}
                     max={new Date(2018, 0, 1, 23)}
                     events={events}


### PR DESCRIPTION
## Summary
1. One line diff adding an `onNavigate` prop, removes console warning ⬇️ 

<img width="433" alt="Screenshot 2024-02-19 at 1 59 48 PM" src="https://github.com/icssc/AntAlmanac/assets/100006999/8da3c293-5c0d-4219-8df2-09a2ab97ff0e">

## Test Plan
1. Check if any unexpected behavior arises from adding the `onNavigate` prop.

<!-- [Optional]
## Future Followup
-->
