### PR TITLE
fix: close popover when event is deleted

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -213,6 +213,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                         <IconButton
                             size="small"
                             onClick={() => {
+                                props.closePopover();
                                 deleteCourse(sectionCode, term);
                                 logAnalytics({
                                     category: analyticsEnum.calendar.title,


### PR DESCRIPTION
## Summary
1. Deleting a course event in the calendar now correctly closes its popover as well
2. One line diff 😼 

Live Behavior:
![chrome-capture-2024-1-20](https://github.com/icssc/AntAlmanac/assets/100006999/32799a27-c758-4a39-a718-b723f92a1d30)

PR Behavior:
![chrome-capture-2024-1-20 (1)](https://github.com/icssc/AntAlmanac/assets/100006999/2382f913-d180-4c25-b314-b810e024a0f3)

## Test Plan
1. Add an event
2. Click it, opening its popover
4. Delete the event
5. Popover should dissapear

## Issues
Closes my personal gripe

<!-- [Optional]
## Future Followup
-->
