### PR TITLE
Extending the Hover Feature for Finals

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -80,14 +80,15 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const { isMilitaryTime } = useTimeFormatStore();
-    const { hoveredCourseEvents } = useHoveredStore();
+    const { hoveredCalendarizedCourses, hoveredCalendarizedFinal } = useHoveredStore();
 
     const getEventsForCalendar = (): CalendarEvent[] => {
-        return showFinalsSchedule
-            ? finalsEventsInCalendar
-            : hoveredCourseEvents
-              ? [...eventsInCalendar, ...hoveredCourseEvents]
-              : eventsInCalendar;
+        if (showFinalsSchedule)
+            return hoveredCalendarizedFinal
+                ? [...finalsEventsInCalendar, hoveredCalendarizedFinal]
+                : finalsEventsInCalendar;
+        else
+            return hoveredCalendarizedCourses ? [...eventsInCalendar, ...hoveredCalendarizedCourses] : eventsInCalendar;
     };
 
     const handleClosePopover = () => {
@@ -165,8 +166,11 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
 
     const onlyCourseEvents = eventsInCalendar.filter((e) => !e.isCustomEvent) as CourseEvent[];
 
-    const finalsDate =
-        onlyCourseEvents.length > 0 ? getFinalsStartDateForTerm(onlyCourseEvents[0].term) : getDefaultFinalsStartDate();
+    const finalsDate = hoveredCalendarizedFinal
+        ? getFinalsStartDateForTerm(hoveredCalendarizedFinal.term)
+        : onlyCourseEvents.length > 0
+          ? getFinalsStartDateForTerm(onlyCourseEvents[0].term)
+          : getDefaultFinalsStartDate();
 
     const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
     const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -80,7 +80,10 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
     const { isMilitaryTime } = useTimeFormatStore();
-    const { hoveredCalendarizedCourses, hoveredCalendarizedFinal } = useHoveredStore();
+    const [hoveredCalendarizedCourses, hoveredCalendarizedFinal] = useHoveredStore((store) => [
+        store.hoveredCalendarizedCourses,
+        store.hoveredCalendarizedFinal,
+    ]);
 
     const getEventsForCalendar = (): CalendarEvent[] => {
         if (showFinalsSchedule)

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -268,7 +268,7 @@ export default function CourseRenderPane(props: { id?: number }) {
         return () => {
             setHoveredEvents(undefined);
         };
-    }, [setHoveredEvents]);
+    }, []);
 
     return (
         <>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -178,7 +178,7 @@ export default function CourseRenderPane(props: { id?: number }) {
     const [error, setError] = useState(false);
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
 
-    const setHoveredCourseEvents = useHoveredStore((store) => store.setHoveredCourseEvents);
+    const setHoveredEvents = useHoveredStore((store) => store.setHoveredEvents);
 
     const loadCourses = useCallback(async () => {
         setLoading(true);
@@ -266,9 +266,9 @@ export default function CourseRenderPane(props: { id?: number }) {
      */
     useEffect(() => {
         return () => {
-            setHoveredCourseEvents(undefined);
+            setHoveredEvents(undefined);
         };
-    }, [setHoveredCourseEvents]);
+    }, [setHoveredEvents]);
 
     return (
         <>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -533,15 +533,17 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
 
     const [hoveredEvents, setHoveredEvents] = useHoveredStore((store) => [store.hoveredEvents, store.setHoveredEvents]);
 
-    const handleHover = useCallback(() => {
-        const alreadyHovered =
-            hoveredEvents &&
-            hoveredEvents.some((scheduleCourse) => scheduleCourse.section.sectionCode == section.sectionCode);
+    const alreadyHovered = useMemo(() => {
+        return hoveredEvents?.some((scheduleCourse) => scheduleCourse.section.sectionCode == section.sectionCode);
+    }, [hoveredEvents, section.sectionCode]);
 
-        !previewMode || alreadyHovered || addedCourse
-            ? setHoveredEvents(undefined)
-            : setHoveredEvents(section, courseDetails, term);
-    }, [addedCourse, courseDetails, hoveredEvents, previewMode, section, setHoveredEvents, term]);
+    const handleHover = useCallback(() => {
+        if (!previewMode || alreadyHovered || addedCourse) {
+            setHoveredEvents(undefined);
+        } else {
+            setHoveredEvents(section, courseDetails, term);
+        }
+    }, [alreadyHovered, section, courseDetails, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -531,20 +531,17 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         setCalendarEvents(AppStore.getCourseEventsInCalendar());
     }, [setCalendarEvents]);
 
-    const [hoveredCourseEvents, setHoveredCourseEvents] = useHoveredStore((store) => [
-        store.hoveredCourseEvents,
-        store.setHoveredCourseEvents,
-    ]);
+    const [hoveredEvents, setHoveredEvents] = useHoveredStore((store) => [store.hoveredEvents, store.setHoveredEvents]);
 
     const handleHover = useCallback(() => {
         const alreadyHovered =
-            hoveredCourseEvents &&
-            hoveredCourseEvents.some((courseEvent) => courseEvent.sectionCode == section.sectionCode);
+            hoveredEvents &&
+            hoveredEvents.some((scheduleCourse) => scheduleCourse.section.sectionCode == section.sectionCode);
 
         !previewMode || alreadyHovered || addedCourse
-            ? setHoveredCourseEvents(undefined)
-            : setHoveredCourseEvents(section, courseDetails, term);
-    }, [addedCourse, courseDetails, hoveredCourseEvents, previewMode, section, setHoveredCourseEvents, term]);
+            ? setHoveredEvents(undefined)
+            : setHoveredEvents(section, courseDetails, term);
+    }, [addedCourse, courseDetails, hoveredEvents, previewMode, section, setHoveredEvents, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -112,13 +112,13 @@ function getFinalsStartForTerm(term: string) {
  */
 function getDefaultFinalsStartDate() {
     // FIXME: Un-offset once Spring starts, or figure out a proper fix
-    const [year, month, day] = getDefaultFinalsStart() || [];
+    const [year, month, day] = getDefaultFinalsStart() ?? [];
     return year && month && day ? new Date(year, month, day + 1) : undefined;
 }
 
 function getFinalsStartDateForTerm(term: string) {
     const date = getFinalsStartForTerm(term);
-    const [year, month, day] = date || [];
+    const [year, month, day] = date ?? [];
     return year && month && day ? new Date(year, month, day + 1) : undefined;
 }
 

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -112,7 +112,7 @@ function getFinalsStartForTerm(term: string) {
  */
 function getDefaultFinalsStartDate() {
     // FIXME: Un-offset once Spring starts, or figure out a proper fix
-    const [year, month, day] = termData[defaultTerm + 1].finalsStartDate || [];
+    const [year, month, day] = getDefaultFinalsStart() || [];
     return year && month && day ? new Date(year, month, day + 1) : undefined;
 }
 

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -4,6 +4,7 @@ import { calendarizeCourseEvents, calendarizeFinals } from './calendarizeHelpers
 import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CourseDetails } from '$lib/course_data.types';
 
+const HOVERED_SECTION_COLOR = '#80808080';
 export interface HoveredStore {
     hoveredEvents: ScheduleCourse[] | undefined;
     setHoveredEvents: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
@@ -11,53 +12,53 @@ export interface HoveredStore {
     hoveredCalendarizedFinal: CourseEvent | undefined;
 }
 
+const DEFAULT_HOVERED_STORE = {
+    hoveredEvents: undefined,
+    hoveredCalendarizedCourses: undefined,
+    hoveredCalendarizedFinal: undefined,
+};
+
 export const useHoveredStore = create<HoveredStore>((set) => {
     return {
-        hoveredEvents: undefined,
-        hoveredCalendarizedCourses: undefined,
-        hoveredCalendarizedFinal: undefined,
+        ...DEFAULT_HOVERED_STORE,
         setHoveredEvents: (section, courseDetails, term) => {
-            set({
-                hoveredEvents:
-                    section && courseDetails && term
-                        ? [
-                              {
-                                  ...courseDetails,
-                                  section: {
-                                      ...section,
-                                      color: '#80808080',
-                                  },
-                                  term,
-                              },
-                          ]
-                        : undefined,
-                hoveredCalendarizedCourses:
-                    section && courseDetails && term
-                        ? calendarizeCourseEvents([
-                              {
-                                  ...courseDetails,
-                                  section: {
-                                      ...section,
-                                      color: '#80808080',
-                                  },
-                                  term,
-                              },
-                          ])
-                        : undefined,
-                hoveredCalendarizedFinal:
-                    section && courseDetails && term
-                        ? calendarizeFinals([
-                              {
-                                  ...courseDetails,
-                                  section: {
-                                      ...section,
-                                      color: '#80808080',
-                                  },
-                                  term,
-                              },
-                          ])[0]
-                        : undefined,
-            });
+            if (section == null || courseDetails == null || term == null) {
+                set({ ...DEFAULT_HOVERED_STORE });
+                return;
+            } else {
+                set({
+                    hoveredEvents: [
+                        {
+                            ...courseDetails,
+                            section: {
+                                ...section,
+                                color: HOVERED_SECTION_COLOR,
+                            },
+                            term,
+                        },
+                    ],
+                    hoveredCalendarizedCourses: calendarizeCourseEvents([
+                        {
+                            ...courseDetails,
+                            section: {
+                                ...section,
+                                color: HOVERED_SECTION_COLOR,
+                            },
+                            term,
+                        },
+                    ]),
+                    hoveredCalendarizedFinal: calendarizeFinals([
+                        {
+                            ...courseDetails,
+                            section: {
+                                ...section,
+                                color: HOVERED_SECTION_COLOR,
+                            },
+                            term,
+                        },
+                    ])[0],
+                });
+            }
         },
     };
 });

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -25,40 +25,39 @@ export const useHoveredStore = create<HoveredStore>((set) => {
             if (section == null || courseDetails == null || term == null) {
                 set({ ...DEFAULT_HOVERED_STORE });
                 return;
-            } else {
-                set({
-                    hoveredEvents: [
-                        {
-                            ...courseDetails,
-                            section: {
-                                ...section,
-                                color: HOVERED_SECTION_COLOR,
-                            },
-                            term,
-                        },
-                    ],
-                    hoveredCalendarizedCourses: calendarizeCourseEvents([
-                        {
-                            ...courseDetails,
-                            section: {
-                                ...section,
-                                color: HOVERED_SECTION_COLOR,
-                            },
-                            term,
-                        },
-                    ]),
-                    hoveredCalendarizedFinal: calendarizeFinals([
-                        {
-                            ...courseDetails,
-                            section: {
-                                ...section,
-                                color: HOVERED_SECTION_COLOR,
-                            },
-                            term,
-                        },
-                    ])[0],
-                });
             }
+            set({
+                hoveredEvents: [
+                    {
+                        ...courseDetails,
+                        section: {
+                            ...section,
+                            color: HOVERED_SECTION_COLOR,
+                        },
+                        term,
+                    },
+                ],
+                hoveredCalendarizedCourses: calendarizeCourseEvents([
+                    {
+                        ...courseDetails,
+                        section: {
+                            ...section,
+                            color: HOVERED_SECTION_COLOR,
+                        },
+                        term,
+                    },
+                ]),
+                hoveredCalendarizedFinal: calendarizeFinals([
+                    {
+                        ...courseDetails,
+                        section: {
+                            ...section,
+                            color: HOVERED_SECTION_COLOR,
+                        },
+                        term,
+                    },
+                ])[0],
+            });
         },
     };
 });

--- a/apps/antalmanac/src/stores/HoveredStore.ts
+++ b/apps/antalmanac/src/stores/HoveredStore.ts
@@ -1,20 +1,37 @@
 import { create } from 'zustand';
-import { AASection } from '@packages/antalmanac-types';
-import { calendarizeCourseEvents } from './calendarizeHelpers';
+import { AASection, ScheduleCourse } from '@packages/antalmanac-types';
+import { calendarizeCourseEvents, calendarizeFinals } from './calendarizeHelpers';
 import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CourseDetails } from '$lib/course_data.types';
 
 export interface HoveredStore {
-    hoveredCourseEvents: CourseEvent[] | undefined;
-    setHoveredCourseEvents: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
+    hoveredEvents: ScheduleCourse[] | undefined;
+    setHoveredEvents: (section?: AASection, courseDetails?: CourseDetails, term?: string) => void;
+    hoveredCalendarizedCourses: CourseEvent[] | undefined;
+    hoveredCalendarizedFinal: CourseEvent | undefined;
 }
 
 export const useHoveredStore = create<HoveredStore>((set) => {
     return {
-        hoveredCourseEvents: undefined,
-        setHoveredCourseEvents: (section, courseDetails, term) => {
+        hoveredEvents: undefined,
+        hoveredCalendarizedCourses: undefined,
+        hoveredCalendarizedFinal: undefined,
+        setHoveredEvents: (section, courseDetails, term) => {
             set({
-                hoveredCourseEvents:
+                hoveredEvents:
+                    section && courseDetails && term
+                        ? [
+                              {
+                                  ...courseDetails,
+                                  section: {
+                                      ...section,
+                                      color: '#80808080',
+                                  },
+                                  term,
+                              },
+                          ]
+                        : undefined,
+                hoveredCalendarizedCourses:
                     section && courseDetails && term
                         ? calendarizeCourseEvents([
                               {
@@ -26,6 +43,19 @@ export const useHoveredStore = create<HoveredStore>((set) => {
                                   term,
                               },
                           ])
+                        : undefined,
+                hoveredCalendarizedFinal:
+                    section && courseDetails && term
+                        ? calendarizeFinals([
+                              {
+                                  ...courseDetails,
+                                  section: {
+                                      ...section,
+                                      color: '#80808080',
+                                  },
+                                  term,
+                              },
+                          ])[0]
                         : undefined,
             });
         },


### PR DESCRIPTION
## Summary

Since we've been diversifying the information available about finals, I decided to generalize the functionality of the hover feature.
- Modified HoveredStore.ts to have separate data fields for calendarized finals, calendarized courses, and raw ScheduleCourse data
- Correspondingly updated the variable names in courseRenderPane and sectionTableBody to decentralize it from "courses" to events in general
- Cleaned up the logic in CalendarRoot for incorporating the hovered courses, and added finals to the logic
- Changed the date view to override any selected finals week to the week of the hovered final

I also made an extremely small one line refactor in TermData for consistency's sake since it is related to this PR and was discussed.

## Test Plan
- Attempt hover on courses as well as finals for an arbitrary course on an empty schedule
- Attempt hover on both after adding a course
- Attempt hover on both after adding a course from a different, non-default quarter
- Attempt hover on both after adding a course from a different but default quarter

## Future Followup
Is there a reason hover to preview is still an experimental toggle feature?
