### PR TITLE
Add dismiss help box functionality

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -1,4 +1,16 @@
-import { Paper, ImageList, ImageListItem, Typography, Link, List, ListItemText, ListItem } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import {
+    Paper,
+    ImageList,
+    ImageListItem,
+    Typography,
+    Link,
+    List,
+    ListItemText,
+    ListItem,
+    Box,
+    IconButton,
+} from '@mui/material';
 
 const images = [
     {
@@ -15,12 +27,21 @@ const images = [
     },
 ];
 
-function HelpBox() {
+interface HelpBoxProps {
+    onDismiss: () => void;
+}
+
+function HelpBox({ onDismiss }: HelpBoxProps) {
     return (
         <Paper variant="outlined" sx={{ padding: 2, marginBottom: '10px', marginRight: '5px' }}>
-            <Typography variant="h5" fontWeight="bold">
-                Need help planning your schedule?
-            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography variant="h5" fontWeight="bold">
+                    Need help planning your schedule?
+                </Typography>
+                <IconButton aria-label="close" size="large" color="inherit" onClick={onDismiss}>
+                    <Close fontSize="inherit" />
+                </IconButton>
+            </Box>
 
             <List component="ol" sx={{ listStyle: 'decimal', pl: 2, pb: 0 }}>
                 <ListItem sx={{ display: 'list-item', p: 0 }}>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -50,6 +50,7 @@ const styles: Styles<Theme, object> = {
 const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) => {
     const { classes, toggleSearch } = props;
     const { manualSearchEnabled, toggleManualSearch } = useCoursePaneStore();
+    const [helpBoxVisibility, setHelpBoxVisibility] = useState(true);
 
     const onFormSubmit = (event: FormEvent) => {
         event.preventDefault();
@@ -57,7 +58,21 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
     };
 
     const currentMonthIndex = new Date().getMonth(); // 0=Jan
-    const activeMonthIndices = [false, false, false, false, false, false, false, false, true, true, false, false];
+    // Active months: February/March for Spring planning, May/June for Fall planning, August for Summer planning,
+    // and November/December for Winter planning
+    const activeMonthIndices = [false, true, true, false, true, true, false, true, false, false, true, true];
+
+    // Display the help box only if more than 30 days has passed since the last dismissal and
+    // the current month is an active month
+    const helpBoxDismissalTime = window.localStorage.getItem('helpBoxDismissalTime');
+    const dismissedRecently =
+        helpBoxDismissalTime !== null && Date.now() - parseInt(helpBoxDismissalTime) < 30 * 24 * 3600 * 1000;
+    const displayHelpBox = helpBoxVisibility && !dismissedRecently && activeMonthIndices[currentMonthIndex];
+
+    const onHelpBoxDismiss = () => {
+        window.localStorage.setItem('helpBoxDismissalTime', Date.now().toString());
+        setHelpBoxVisibility(false);
+    };
 
     return (
         <div className={classes.rightPane}>
@@ -95,7 +110,7 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
                 </div>
             </form>
 
-            {activeMonthIndices[currentMonthIndex] && <HelpBox />}
+            {displayHelpBox && <HelpBox onDismiss={onHelpBoxDismiss} />}
             <PrivacyPolicyBanner />
         </div>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -58,9 +58,9 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
     };
 
     const currentMonthIndex = new Date().getMonth(); // 0=Jan
-    // Active months: February/March for Spring planning, May/June for Fall planning, August for Summer planning,
+    // Active months: February/March for Spring planning, May/June for Fall planning, July/August for Summer planning,
     // and November/December for Winter planning
-    const activeMonthIndices = [false, true, true, false, true, true, false, true, false, false, true, true];
+    const activeMonthIndices = [false, true, true, false, true, true, true, true, false, false, true, true];
 
     // Display the help box only if more than 30 days has passed since the last dismissal and
     // the current month is an active month


### PR DESCRIPTION
## Summary
- The help box now has a close button on the upper-right corner and is dismissible.
- The help box can only be shown on these months: February/March for Spring planning, May/June for Fall planning, July/August for Summer planning, and November/December for Winter planning.
- If 30 days has passed since the last time the user dismissed the help box AND the current month is still an active month, then the help box will be displayed again.
- Any feedback is appreciated for the active months and the 30 day dismissal threshold.

## Test Plan
- Make sure the help box is never shown during inactive months.
- Change the 30 day threshold to something really small, and see if the help box comes back on an active month.

## Issues

Closes #652 

<!-- [Optional]
## Future Followup
-->
