### PR TITLE
Display "No Courses Added Yet" when list of added classes is empty

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -303,11 +303,14 @@ function SkeletonSchedule() {
     }, []);
 
     const sectionsByTerm: [string, string[]][] = useMemo(() => {
-        const result = skeletonSchedule.courses.reduce((accumulated, course) => {
-            accumulated[course.term] ??= [];
-            accumulated[course.term].push(course.sectionCode);
-            return accumulated;
-        }, {} as Record<string, string[]>);
+        const result = skeletonSchedule.courses.reduce(
+            (accumulated, course) => {
+                accumulated[course.term] ??= [];
+                accumulated[course.term].push(course.sectionCode);
+                return accumulated;
+            },
+            {} as Record<string, string[]>
+        );
 
         return Object.entries(result);
     }, [skeletonSchedule.courses]);
@@ -412,6 +415,7 @@ function AddedSectionsGrid() {
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                {courses.length < 1 ? <Typography variant="h7">No Courses Added Yet!</Typography> : <></>}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -406,6 +406,13 @@ function AddedSectionsGrid() {
         return scheduleNames[scheduleIndex];
     }, [scheduleNames, scheduleIndex]);
 
+    // "No Courses Added Yet!" notification
+    const noCoursesNotif = (
+        <Box style={{ backgroundColor: 'grey', padding: '16px' }}>
+            <Typography align="center">No Courses Added Yet!</Typography>
+        </Box>
+    );
+
     return (
         <Box display="flex" flexDirection="column" gap={1}>
             <Box display="flex" width={1} position="absolute" zIndex="2">
@@ -415,7 +422,7 @@ function AddedSectionsGrid() {
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                {courses.length < 1 ? <Typography>No Courses Added Yet!</Typography> : <></>}
+                {courses.length < 1 ? noCoursesNotif : <></>}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -422,7 +422,7 @@ function AddedSectionsGrid() {
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                {courses.length < 1 ? noCoursesNotif : <></>}
+                {courses.length < 1 ? noCoursesNotif : null}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -415,7 +415,7 @@ function AddedSectionsGrid() {
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                {courses.length < 1 ? <Typography variant="h7">No Courses Added Yet!</Typography> : <></>}
+                {courses.length < 1 ? <Typography>No Courses Added Yet!</Typography> : <></>}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -422,7 +422,7 @@ function AddedSectionsGrid() {
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                {courses.length < 1 ? noCoursesNotif : null}
+                {courses.length < 1 ? NoCoursesBox : null}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -407,7 +407,7 @@ function AddedSectionsGrid() {
     }, [scheduleNames, scheduleIndex]);
 
     // "No Courses Added Yet!" notification
-    const noCoursesNotif = (
+    const NoCoursesBox = (
         <Box style={{ backgroundColor: 'grey', padding: '16px' }}>
             <Typography align="center">No Courses Added Yet!</Typography>
         </Box>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -408,8 +408,8 @@ function AddedSectionsGrid() {
 
     // "No Courses Added Yet!" notification
     const NoCoursesBox = (
-        <Box style={{ backgroundColor: 'grey', padding: '16px' }}>
-            <Typography align="center">No Courses Added Yet!</Typography>
+        <Box style={{ paddingTop: '12px', paddingBottom: '12px' }}>
+            <Typography align="left">No Courses Added Yet!</Typography>
         </Box>
     );
 


### PR DESCRIPTION
## Summary

Adds a "No Courses Added Yet!" notification in the right pane for Added courses when the list of added classes is empty.

![Screenshot from 2024-02-26 12-06-45](https://github.com/icssc/AntAlmanac/assets/24789977/a9bc98ca-4fff-4935-a111-945a28bef395)

## Test Plan

Start from an empty schedule, add classes, then remove classes until the schedule is empty again. "No Courses Added!" should appear under the schedule name if and only if the list of added classes is empty.

## Issues

Closes #922 

<!-- [Optional]
## Future Followup
-->
