### PR TITLE
fix: handle undefined buildings

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -304,7 +304,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                             to={`/map?location=${building ?? 0}`}
                             onClick={focusMap}
                         >
-                            {buildingCatalogue[+building].name}
+                            {buildingCatalogue[+building]?.name ?? ''}
                         </Link>
                     </div>
                 )}

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -74,7 +74,7 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
             />
             <Box sx={{ margin: '0.75rem', color: '#bbbbbb', fontSize: '1rem' }}>
                 <Link to={`/map?location=${customEvent.building ?? 0}`} onClick={focusMap}>
-                    {customEvent.building ? buildingCatalogue[+customEvent.building].name : ''}
+                    {(customEvent.building && buildingCatalogue[+customEvent.building]?.name) || ''}
                 </Link>
             </Box>
 


### PR DESCRIPTION
## Summary
1. The de-duplication / cleanup in #912 breaks schedules that used the removed locations, or more specifically, their IDs.
2. This PR is a hotfix to handle those undefined values more gracefully as empty strings, but it's not a full fix / undoing of the regression.

## Test Plan
1. Create a custom event with a location
2. Comment out location in `buildingCatalogue.ts`
3. See if clicking the Calendar Event errors out
4. See if opening Added errors out

## Issues
Closes [bug report](https://discord.com/channels/772739905981644850/780316580819107860/1211856788614291476):

> Feedback Type
Issue / Bug
Feedback
It says:
"Unexpected Application Error! Cannot read properties of undefined (reading 'name')
TypeError: Cannot read properties of undefined (reading 'name')

<!-- [Optional]
## Future Followup
-->
