### PR TITLE
Swap past enrollment arrows and order

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -45,7 +45,7 @@ function PopupHeader({
                 width: graphWidth,
             }}
         >
-            <Tooltip title="Newer Graph">
+            <Tooltip title="Older Graph">
                 {/* In order for a tooltip to work properly with disabled buttons, we need to wrap the button in a span */}
                 <span>
                     <IconButton onClick={handleBack} disabled={graphIndex === 0}>
@@ -56,7 +56,7 @@ function PopupHeader({
             <Typography sx={{ fontWeight: 500, fontSize: isMobileScreen ? '0.8rem' : '1rem', textAlign: 'center' }}>
                 {popupTitle}
             </Typography>
-            <Tooltip title="Older Graph">
+            <Tooltip title="Newer Graph">
                 <span>
                     <IconButton onClick={handleForward} disabled={graphIndex === enrollmentHistory.length - 1}>
                         <ArrowForward />
@@ -114,7 +114,9 @@ export function EnrollmentHistoryPopup({ department, courseNumber }: EnrollmentH
         deptEnrollmentHistory.find(courseNumber).then((data) => {
             if (data) {
                 setEnrollmentHistory(data);
-                setGraphIndex(0);
+                // The graph index is the last past enrollment graph since we want to show
+                // the most recent quarter's graph
+                setGraphIndex(data.length - 1);
             }
             setLoading(false);
         });

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -135,7 +135,7 @@ export class DepartmentEnrollmentHistory {
 
     /**
      * Sorts the given array of enrollment histories so that
-     * the most recent quarters are in the beginning of the array.
+     * the oldest quarters are in the beginning of the array
      *
      * @param enrollmentHistory Array where each element represents the enrollment
      * history of a course section during one quarter
@@ -145,10 +145,10 @@ export class DepartmentEnrollmentHistory {
             const aTerm = `${a.year} ${a.quarter}`;
             const bTerm = `${b.year} ${b.quarter}`;
             // If the term for a appears earlier than the term for b in the list of
-            // term short names, then a must be the enrollment history for a later quarter
+            // term short names, then a must be the enrollment history for a more recent quarter
             return (
-                DepartmentEnrollmentHistory.termShortNames.indexOf(aTerm) -
-                DepartmentEnrollmentHistory.termShortNames.indexOf(bTerm)
+                DepartmentEnrollmentHistory.termShortNames.indexOf(bTerm) -
+                DepartmentEnrollmentHistory.termShortNames.indexOf(aTerm)
             );
         });
     }


### PR DESCRIPTION
## Summary
- Swapped the arrows in the past enrollment popup such that the left arrow navigates to an older graph and the right arrow navigates to a newer graph.
- Instead of sorting the graphs from most recent quarter to oldest quarter, we will sort them from oldest quarter to most recent quarter.
- When the user first opens the popup, the most recent quarter's past enrollment graph should still be displayed.

## Test Plan
- Open the past enrollment popup and see if the arrows work properly and are disabled at the right times.

## Issues

Closes #931 

<!-- [Optional]
## Future Followup
-->
