### PR TITLE
Make area around top bar of mobile devices the same color as app bar (PWA)

### DIFF
--- a/apps/antalmanac/index.html
+++ b/apps/antalmanac/index.html
@@ -20,7 +20,9 @@
             name="viewport"
             content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
         />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#305db7" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style " content="black-translucent" />
         <meta
             name="keywords"
             content="UCI,Anteater,search,classes,Calendar,development,software,add courses,antalmanac,course,course planner"

--- a/apps/antalmanac/public/manifest.json
+++ b/apps/antalmanac/public/manifest.json
@@ -10,6 +10,6 @@
     ],
     "start_url": "./index.html",
     "display": "standalone",
-    "theme_color": "#000000",
-    "background_color": "#ffffff"
+    "theme_color": "#305db7",
+    "background_color": "#000000"
 }


### PR DESCRIPTION
## Summary
This PR builds off of #834 . 
The issue is that you need to explicitly tell iOS that your website is PWA capable and that you want the status bar to match the theme color in your meta tags.

Assuming you guys also want something similar on Android, you'll need to specify what color as a `theme-color` meta tag.

I've applied the previously proposed colors to the manifest files and made the necessary changes to the meta tags. 

### Deployment Note
The PWA currently does not work off of the dev server with port forwarding, so we need to figure that out or find another way to test it.

### Before and After
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/icssc/AntAlmanac/assets/21994085/3d76e52e-b9ca-4651-9fb7-817f217c29cc"/>
    </td>
    <td>
      <img src="https://github.com/icssc/AntAlmanac/assets/21994085/05d5d422-279f-4d75-a29a-f00bfd6441fd"/>
    </td>
  </tr>
<tr>
    <td>
      <img src="https://github.com/icssc/AntAlmanac/assets/21994085/5b637d97-8c47-4d06-b5cb-d86b21f86cbd"/>
    </td>
    <td>
      <img src="https://github.com/icssc/AntAlmanac/assets/21994085/2c72d5e1-7c5e-495a-bf4a-af62a653af5b"/>
    </td>
</tr>
</table>

## Test Plan
Run locally and test visually

## Issues

Closes #840 

<!-- [Optional]
## Future Followup
-->
