### PR TITLE
Fix past enrollment date

### DIFF
--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -107,7 +107,7 @@ export class DepartmentEnrollmentHistory {
 
             for (const [i, date] of enrollmentHistory.dates.entries()) {
                 const d = new Date(date);
-                const formattedDate = `${d.getMonth() + 1}/${d.getDate() + 1}/${d.getFullYear()}`;
+                const formattedDate = `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
 
                 enrollmentDays.push({
                     date: formattedDate,


### PR DESCRIPTION
## Summary
- We don't need to add 1 to the return value of `getDate()` since it is 1-indexed. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate

## Test Plan
- Go to a course (e.g. CS 142A) in Spring 2024 and verify that the last date of February is 2/29/2024 and the first date of March is 3/1/2024.
- Go to a course (e.g. CS 122D) in Spring 2023 and verify that the last date of February is 2/28/2023 and the first date of March is 3/1/2023.

## Issues

Closes #943 

<!-- [Optional]
## Future Followup
-->
