### PR TITLE
No Unsaved Warning From Tour

### DIFF
--- a/apps/antalmanac/src/lib/tourExampleGeneration.ts
+++ b/apps/antalmanac/src/lib/tourExampleGeneration.ts
@@ -98,7 +98,7 @@ export function addSampleClasses() {
 }
 
 export function removeSampleClasses() {
-    AppStore.deleteCourses(sampleClassesSectionCodes, CURRENT_TERM);
+    AppStore.deleteCourses(sampleClassesSectionCodes, CURRENT_TERM, false);
     sampleClassesSectionCodes = [];
 }
 

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -1,11 +1,10 @@
 import { EventEmitter } from 'events';
-import { VariantType } from 'notistack';
 
 import { ScheduleCourse, ScheduleSaveState, RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { VariantType } from 'notistack';
+
 import { Schedules } from './Schedules';
-import { SnackbarPosition } from '$components/NotificationSnackbar';
-import { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
-import { useTabStore } from '$stores/TabStore';
+
 import actionTypesStore from '$actions/ActionTypesStore';
 import type {
     AddCourseAction,
@@ -19,6 +18,9 @@ import type {
     ChangeCourseColorAction,
     UndoAction,
 } from '$actions/ActionTypesStore';
+import { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
+import { SnackbarPosition } from '$components/NotificationSnackbar';
+import { useTabStore } from '$stores/TabStore';
 
 class AppStore extends EventEmitter {
     schedule: Schedules;
@@ -171,9 +173,9 @@ class AppStore extends EventEmitter {
         }
     }
 
-    deleteCourse(sectionCode: string, term: string) {
+    deleteCourse(sectionCode: string, term: string, triggerUnsavedWarning = true) {
         this.schedule.deleteCourse(sectionCode, term);
-        this.unsavedChanges = true;
+        this.unsavedChanges = triggerUnsavedWarning;
         const action: DeleteCourseAction = {
             type: 'deleteCourse',
             sectionCode: sectionCode,
@@ -183,9 +185,8 @@ class AppStore extends EventEmitter {
         this.emit('addedCoursesChange');
     }
 
-    deleteCourses(sectionCodes: string[], term: string) {
-        sectionCodes.forEach((sectionCode) => this.deleteCourse(sectionCode, term));
-        this.unsavedChanges = true;
+    deleteCourses(sectionCodes: string[], term: string, triggerUnsavedWarning = true) {
+        sectionCodes.forEach((sectionCode) => this.deleteCourse(sectionCode, term, triggerUnsavedWarning));
         this.emit('addedCoursesChange');
     }
 


### PR DESCRIPTION
## Summary
- Fix bug where the unsaved schedule warning would pop up after dismissing tour and typing something in the search bar before closing the page.
- The problem was that the tour removes the sample classes on close, which toggles the warning, even though the user doesn't care about those classes, and they might not have even showed up.

## Test Plan
- Open the page in incognito, type something into the search bar, and close the page. Verify that the warning doesn't pop up.
- Load an existing schedule, remove a class, then close the page. Verify that the warning does still pop up.

## Issues
- Closes #914 
