### PR TITLE
Improve performance

### DIFF
--- a/apps/antalmanac/index.html
+++ b/apps/antalmanac/index.html
@@ -46,6 +46,7 @@
         />
         <meta property="twitter:image" content="https://antalmanac.com/logo.png" />
 
+        <link rel="preload" href="https://user-images.githubusercontent.com/78244965/277567417-f9816b9d-ddda-4c0f-80f4-eeac92428612.gif" as="image">
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>

--- a/apps/antalmanac/index.html
+++ b/apps/antalmanac/index.html
@@ -47,6 +47,7 @@
         <meta property="twitter:image" content="https://antalmanac.com/logo.png" />
 
         <link rel="preload" href="https://user-images.githubusercontent.com/78244965/277567417-f9816b9d-ddda-4c0f-80f4-eeac92428612.gif" as="image">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="use-credentials">
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>

--- a/apps/antalmanac/index.html
+++ b/apps/antalmanac/index.html
@@ -48,17 +48,21 @@
 
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="/favicon.ico" />
-        <link rel="stylesheet" href="/google_font_roboto_300_400_500_700.css" />
+        <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>
         <link
-            rel="stylesheet"
+            rel="preload"
             href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
             integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
             crossorigin=""
+            as="style"
+            onload="this.rel='stylesheet'"
         />
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+        <link rel="preload" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" as="style" onload="this.rel='stylesheet'"/>
         <link
-            rel="stylesheet"
+            rel="preload"
             href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css"
+            as="style"
+            onload="this.rel='stylesheet'"
         />
 
         <!--

--- a/apps/antalmanac/public/google_font_roboto_300_400_500_700.css
+++ b/apps/antalmanac/public/google_font_roboto_300_400_500_700.css
@@ -125,6 +125,7 @@
         url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC,
         U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {
@@ -189,6 +190,7 @@
         url(https://fonts.gstatic.com/s/roboto/v19/KFOlCnqEu92Fr1MmEU9fBBc4.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC,
         U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {

--- a/apps/antalmanac/public/index.html
+++ b/apps/antalmanac/public/index.html
@@ -46,17 +46,21 @@
 
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-        <link rel="stylesheet" href="%PUBLIC_URL%/google_font_roboto_300_400_500_700.css" />
+        <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>
         <link
-            rel="stylesheet"
+            rel="preload"
             href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
             integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
             crossorigin=""
+            as="style"
+            onload="this.rel='stylesheet'"
         />
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+        <link rel="preload" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" as="style" onload="this.rel='stylesheet'"/>
         <link
-            rel="stylesheet"
+            rel="preload"
             href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css"
+            as="style"
+            onload="this.rel='stylesheet'"
         />
 
         <!--

--- a/apps/antalmanac/public/index.html
+++ b/apps/antalmanac/public/index.html
@@ -44,6 +44,7 @@
         />
         <meta property="twitter:image" content="https://antalmanac.com/logo.png" />
 
+        <link rel="preload" href="https://user-images.githubusercontent.com/78244965/277567417-f9816b9d-ddda-4c0f-80f4-eeac92428612.gif" as="image">
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
         <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>

--- a/apps/antalmanac/public/index.html
+++ b/apps/antalmanac/public/index.html
@@ -45,6 +45,7 @@
         <meta property="twitter:image" content="https://antalmanac.com/logo.png" />
 
         <link rel="preload" href="https://user-images.githubusercontent.com/78244965/277567417-f9816b9d-ddda-4c0f-80f4-eeac92428612.gif" as="image">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="use-credentials">
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
         <link rel="preload" href="/google_font_roboto_300_400_500_700.css" as="style" onload="this.rel='stylesheet'"/>


### PR DESCRIPTION
# Summary
## 1. Eliminate render-blocking resources
### ⭐️Main Change:
Change `rel="stylesheet"` to `rel="preload"`
Add `as="style" onload="this.rel='stylesheet'"`

### Render-Blocking resources:
- `google_font_roboto_300_400_500_700.css`
- `https://unpkg.com/leaflet@1.5.1/dist/leaflet.css`
- `https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css`
- `https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css`
> [Official Doc - render-blocking-resource](https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources)

<br>
<br>

## 2. Preload Largest Contentful Paint (LCP) element's image
### ⭐️Main Change:
Preload the patchNote's gif image to the `index.html`

### LCP element:
- `PatchNotes.tsx`
> [Optimizing LCP element](https://web.dev/articles/optimize-lcp?utm_source=lighthouse&utm_medium=devtools#optimize_when_the_resource_is_discovered)

<br>
<br>

## 3. Pre-connect to required origin
### ⭐️Main Change:
Pre-connect to `https://fonts.gstatic.com` in the `index.html`

### Resources using this website:
- `google_font_roboto_300_400_500_700.css`
> [Official Doc - uses-rel-preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/?utm_source=lighthouse&utm_medium=devtools)

<br>
<br>

## 4. Ensure text remains visible during webfont load
### ⭐️Main Change:
Add `font-display: swap` to some font family
> [Official Doc - Font display](https://developer.chrome.com/docs/lighthouse/performance/font-display)

<br>
<br>

# Issue
Closes #957


