### PR TITLE
Mobile Drawer instead of Dropdown

### DIFF
--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,9 +1,6 @@
-import { AppBar, Box, Menu, Toolbar, useMediaQuery } from '@material-ui/core';
-import MenuItem from '@material-ui/core/MenuItem';
+import { AppBar, Toolbar, useMediaQuery } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import MenuIcon from '@material-ui/icons/Menu';
-import { useState, type MouseEventHandler } from 'react';
 
 import Export from './Export';
 import Import from './Import';
@@ -40,24 +37,12 @@ interface CustomAppBarProps {
     classes: ClassNameMap;
 }
 
-const components = [<Import key="studylist" />, <Export key="export" />, <AppDrawer key="settings" />];
-
 const Header = ({ classes }: CustomAppBarProps) => {
     const isMobileScreen = useMediaQuery('(max-width:750px)');
 
-    const [anchorEl, setAnchorEl] = useState<Element | null>(null);
-
-    const handleClick: MouseEventHandler<SVGSVGElement> = (event) => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const handleClose = () => {
-        setAnchorEl(null);
-    };
-
     return (
         <AppBar position="static" className={classes.appBar}>
-            <Toolbar variant="dense">
+            <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
                 <img
                     height={32}
                     src={isMobileScreen ? MobileLogo : Logo}
@@ -65,22 +50,18 @@ const Header = ({ classes }: CustomAppBarProps) => {
                     alt="logo"
                 />
 
-                <div style={{ flexGrow: '1' }} />
+                <div style={{ display: 'flex', flexDirection: 'row' }}>
+                    <LoadSaveScheduleFunctionality />
 
-                <LoadSaveScheduleFunctionality />
+                    {isMobileScreen ? null : (
+                        <>
+                            <Import key="studylist" />
+                            <Export key="export" />
+                        </>
+                    )}
 
-                {isMobileScreen ? (
-                    <Box className={classes.menuIconContainer}>
-                        <MenuIcon onClick={handleClick} className={classes.menuIcon} />
-                        <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
-                            {components.map((element, index) => (
-                                <MenuItem key={index}>{element}</MenuItem>
-                            ))}
-                        </Menu>
-                    </Box>
-                ) : (
-                    components
-                )}
+                    <AppDrawer key="settings" />
+                </div>
             </Toolbar>
         </AppBar>
     );

--- a/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
+++ b/apps/antalmanac/src/components/Header/LoadSaveFunctionality.tsx
@@ -11,13 +11,13 @@ import {
     FormControlLabel,
 } from '@material-ui/core';
 import { CloudDownload, Save } from '@material-ui/icons';
+import { LoadingButton } from '@mui/lab';
 import { ChangeEvent, PureComponent, useEffect, useState } from 'react';
 
-import { LoadingButton } from '@mui/lab';
-import { loadSchedule, saveSchedule } from '$actions/AppStoreActions';
-import { useThemeStore } from '$stores/SettingsStore';
-import AppStore from '$stores/AppStore';
 import actionTypesStore from '$actions/ActionTypesStore';
+import { loadSchedule, saveSchedule } from '$actions/AppStoreActions';
+import AppStore from '$stores/AppStore';
+import { useThemeStore } from '$stores/SettingsStore';
 
 interface LoadSaveButtonBaseProps {
     action: typeof saveSchedule;
@@ -216,7 +216,7 @@ const LoadSaveScheduleFunctionality = () => {
     }, []);
 
     return (
-        <div id="load-save-container">
+        <div id="load-save-container" style={{ display: 'flex', flexDirection: 'row' }}>
             <LoadSaveButtonBase
                 id="save-button"
                 actionName={'Save'}

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -7,12 +7,15 @@ import IconButton from '@mui/material/IconButton';
 import { useCallback, useState } from 'react';
 
 import { AboutButtonGroup } from './AboutButtonGoup';
+import Export from './Export';
+import Import from './Import';
 
 import actionTypesStore from '$actions/ActionTypesStore';
 import { autoSaveSchedule } from '$actions/AppStoreActions';
 import appStore from '$stores/AppStore';
 import useCoursePaneStore from '$stores/CoursePaneStore';
 import { usePreviewStore, useThemeStore, useTimeFormatStore, useAutoSaveStore } from '$stores/SettingsStore';
+
 
 const lightSelectedStyle: CSSProperties = {
     backgroundColor: '#F0F7FF',
@@ -212,6 +215,24 @@ function SettingsMenu() {
     );
 }
 
+function MobileImportExportButtonGroup() {
+    return (
+        <ButtonGroup
+            size="large"
+            style={{
+                display: 'flex',
+                justifyContent: 'space-evenly',
+                alignItems: 'center',
+                width: '100%',
+                borderColor: 'unset',
+            }}
+        >
+            <Import />
+            <Export />
+        </ButtonGroup>
+    );
+}
+
 function AppDrawer() {
     const [drawerOpen, setDrawerOpen] = useState(false);
     const isMobileScreen = useMediaQuery('(max-width:750px)');
@@ -226,7 +247,7 @@ function AppDrawer() {
 
     return (
         <>
-            <IconButton onClick={handleDrawerOpen} color="inherit" size="large">
+            <IconButton onClick={handleDrawerOpen} color="inherit" size="large" style={{ padding: '4px' }}>
                 <MenuRoundedIcon fontSize="inherit" />
             </IconButton>
             <Drawer
@@ -250,6 +271,16 @@ function AppDrawer() {
                             <Close fontSize="inherit" />
                         </IconButton>
                     </Box>
+
+                    {isMobileScreen ? (
+                        <>
+                            <Divider style={{ marginBottom: '16px' }} />
+                            <MobileImportExportButtonGroup />
+                            <Divider style={{ marginTop: '12px', marginBottom: '16px' }}>
+                                <Typography variant="subtitle2">Settings</Typography>
+                            </Divider>
+                        </>
+                    ) : null}
 
                     <SettingsMenu />
 


### PR DESCRIPTION
## Summary
- Replace the dropdown menu on mobile with a drawer. The fact that we had a drawer for desktop but a dropdown for mobile is just stupid because it should be the other way around, if we were to use a dropdown at all.
- Follows up from the two commits that I accidentally pushed to `main` to put the `About`, `Feedback`, and `Donate` buttons into the drawer (7d4ba66a7307719cfaf3b83cee8739be80af5550 and 2c00c3d393f70eb979ae791432beec602d81ea26).
- Also fixes the fact that the drawer open button was in the dropdown menu (although, before, the settings button was in there and would open the drawer, which is also not good). 

## Test Plan
- Verify that all the features are still in the header or drawer. 
- Validate my UI design choices.

## Issues
Closes #839 
