### PR TITLE
Change Christmas to Normal Logo

### DIFF
--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -7,8 +7,8 @@ import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
 import AppDrawer from './SettingsMenu';
 
-import Logo from '$assets/christmas-logo.png';
-import MobileLogo from '$assets/christmas-mobile-logo.png';
+import Logo from '$assets/logo.svg';
+import MobileLogo from '$assets/mobile-logo.svg';
 
 const styles = {
     appBar: {


### PR DESCRIPTION
## Summary
Just changed the path from christmas-logo.png to logo.svg. Simply reverted the seasonal logos to regular. Two line change

## Test Plan
Observe the mobile and desktop logos and confirm they are default.

## Issues

Closes #969 

## Future Followup
Do this dynamically (#973)
