### PR TITLE
fix: correct the index of Added in TabStore

### DIFF
--- a/apps/antalmanac/src/stores/TabStore.ts
+++ b/apps/antalmanac/src/stores/TabStore.ts
@@ -19,7 +19,7 @@ export const useTabStore = create<TabStore>((set) => {
             }));
             // Disable GPA column on the Added tab because we'd have to query them individually
             // A column needs to be enabled and selected to be displayed
-            if (newTab == 1) {
+            if (newTab == 2) {
                 useColumnStore.getState().setColumnEnabled('gpa', false);
             } else {
                 useColumnStore.getState().setColumnEnabled('gpa', true);


### PR DESCRIPTION
## Summary
1. #921 changed how tabs were ordered (Calendar is now index 0), so Added went from index 1 -> 2
2. This PR corrects TabStore's Added Tab index

## Test Plan
1. On both mobile and desktop views, the Added pane **should not** display GPA column. The Search pane **should**.

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
