### PR TITLE
Always display GPA Column

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -3,7 +3,7 @@ import { Box, Chip, IconButton, Paper, SxProps, TextField, Tooltip, Typography }
 import { AACourse } from '@packages/antalmanac-types';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { ColumnToggleButton } from '../CoursePane/CoursePaneButtonRow';
+import { ColumnToggleDropdown } from '../CoursePane/CoursePaneButtonRow';
 import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
 
 import CustomEventDetailView from './CustomEventDetailView';
@@ -378,7 +378,7 @@ function AddedSectionsGrid() {
             <Box display="flex" width={1} position="absolute" zIndex="2">
                 <CopyScheduleButton index={scheduleIndex} />
                 <ClearScheduleButton />
-                <ColumnToggleButton />
+                <ColumnToggleDropdown />
             </Box>
             <Box style={{ marginTop: 50 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -32,6 +32,7 @@ const buttonSx: SxProps = {
 };
 
 const columnLabels: Record<SectionTableColumn, string> = {
+    action: 'Action',
     sectionCode: 'Code',
     sectionDetails: 'Type',
     instructors: 'Instructors',
@@ -92,6 +93,9 @@ export function ColumnToggleDropdown() {
         [selectedColumns]
     );
 
+    console.log('selectedColumns', selectedColumns);
+    console.log('selectedColumnNames', selectedColumnNames);
+
     return (
         <>
             <Tooltip title="Show/Hide Columns">
@@ -111,12 +115,16 @@ export function ColumnToggleDropdown() {
                         renderValue={renderEmptySelectValue}
                         MenuProps={{ anchorEl }}
                     >
-                        {COLUMN_LABEL_ENTRIES.map(([column, label], index) => (
-                            <MenuItem key={column} value={column}>
-                                <Checkbox checked={selectedColumns[index]} color="default" />
-                                <ListItemText primary={label} />
-                            </MenuItem>
-                        ))}
+                        {COLUMN_LABEL_ENTRIES
+                            // Disallow toggling the action column (the one to add courses)
+                            .filter(([column]) => column !== 'action')
+                            // Add 1 to the index to offset the action column being filtered out
+                            .map(([column, label], index) => (
+                                <MenuItem key={column} value={column}>
+                                    <Checkbox checked={selectedColumns[index + 1]} color="default" />
+                                    <ListItemText primary={label} />
+                                </MenuItem>
+                            ))}
                     </Select>
                 </FormControl>
             </Popover>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { ArrowBack, Visibility, Refresh } from '@mui/icons-material';
 import {
     Box,
     Checkbox,
@@ -12,7 +12,8 @@ import {
     type SxProps,
     Popover,
 } from '@mui/material';
-import { ArrowBack, Visibility, Refresh } from '@mui/icons-material';
+import { useCallback, useMemo, useState } from 'react';
+
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 
 /**
@@ -61,7 +62,7 @@ const COLUMN_LABEL_ENTRIES = Object.entries(columnLabels);
  *
  * e.g. show/hide the section code, instructors, etc.
  */
-export function ColumnToggleButton() {
+export function ColumnToggleDropdown() {
     const [selectedColumns, setSelectedColumns] = useColumnStore((store) => [
         store.selectedColumns,
         store.setSelectedColumns,
@@ -163,7 +164,7 @@ export function CoursePaneButtonRow(props: CoursePaneButtonRowProps) {
                 </IconButton>
             </Tooltip>
 
-            <ColumnToggleButton />
+            <ColumnToggleDropdown />
         </Box>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -93,9 +93,6 @@ export function ColumnToggleDropdown() {
         [selectedColumns]
     );
 
-    console.log('selectedColumns', selectedColumns);
-    console.log('selectedColumnNames', selectedColumnNames);
-
     return (
         <>
             <Tooltip title="Show/Hide Columns">

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -485,7 +485,6 @@ interface SectionTableBodyProps {
     scheduleNames: string[];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     action: SectionActionCell,
     sectionCode: CourseCodeCell,

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -23,9 +23,6 @@ export const SECTION_TABLE_COLUMNS = [
 export type SectionTableColumn = (typeof SECTION_TABLE_COLUMNS)[number];
 
 interface ColumnStore {
-    // Columns that are enabled. Sometimes columns can be hidden depending on the tab, or perhaps screen size in the future.
-    enabledColumns: boolean[];
-
     // Columns that are selected in the dropdown
     selectedColumns: boolean[];
 
@@ -39,53 +36,27 @@ interface ColumnStore {
      * @param columns The columns that are selected in the dropdown.
      */
     setSelectedColumns: (columns: SectionTableColumn[]) => void;
-
-    /**
-     * Used by TabStore to enable/disable columns depending on the tab.
-     *
-     * @param column The target column.
-     * @param state Whether the column should be enabled or not.
-     */
-    setColumnEnabled: (column: SectionTableColumn, state: boolean) => void;
 }
 
-// Don't enable GPA column if the user is on the Added tab
-const enabledColumnsInitial = SECTION_TABLE_COLUMNS.map(
-    (col) => !(window.location.pathname.split('/').slice(1)[0] === 'added' && col === 'gpa')
-);
+// Currently, the mapping/filtering does nothing, but this could be used to enable/disable columns.
 const selectedColumnsInitial = SECTION_TABLE_COLUMNS.map(() => true);
-const activeColumnsInitial = SECTION_TABLE_COLUMNS.filter(
-    (_, index) => enabledColumnsInitial[index] && selectedColumnsInitial[index]
-);
+const activeColumnsInitial = SECTION_TABLE_COLUMNS.filter((_, index) => selectedColumnsInitial[index]);
 
 /**
  * Store of columns that are currently being displayed in the search results.
  */
-export const useColumnStore = create<ColumnStore>((set, get) => {
+export const useColumnStore = create<ColumnStore>((set, _) => {
     return {
-        enabledColumns: enabledColumnsInitial,
         selectedColumns: selectedColumnsInitial,
         activeColumns: activeColumnsInitial,
         setSelectedColumns: (columns: SectionTableColumn[]) => {
             set(() => {
                 const selectedColumns = SECTION_TABLE_COLUMNS.map((column) => columns.includes(column));
-                const activeColumns = SECTION_TABLE_COLUMNS.filter(
-                    (_, index) => get().enabledColumns[index] && selectedColumns[index]
-                );
-                return { selectedColumns: selectedColumns, activeColumns: activeColumns };
+                return { selectedColumns };
             });
             logAnalytics({
                 category: analyticsEnum.classSearch.title,
                 action: analyticsEnum.classSearch.actions.TOGGLE_COLUMNS,
-            });
-        },
-        setColumnEnabled: (column: SectionTableColumn, state: boolean) => {
-            set((prevState) => {
-                prevState.enabledColumns[SECTION_TABLE_COLUMNS.indexOf(column)] = state;
-                const activeColumns = SECTION_TABLE_COLUMNS.filter(
-                    (_, index) => prevState.enabledColumns[index] && prevState.selectedColumns[index]
-                );
-                return { enabledColumns: prevState.enabledColumns, activeColumns: activeColumns };
             });
         },
     };

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -51,8 +51,12 @@ export const useColumnStore = create<ColumnStore>((set, _) => {
         activeColumns: activeColumnsInitial,
         setSelectedColumns: (columns: SectionTableColumn[]) => {
             set(() => {
-                const selectedColumns = SECTION_TABLE_COLUMNS.map((column) => columns.includes(column));
-                return { selectedColumns };
+                const selectedColumns: boolean[] = SECTION_TABLE_COLUMNS.map((column) => columns.includes(column));
+                const activeColumns: SectionTableColumn[] = SECTION_TABLE_COLUMNS.filter(
+                    (_, index) => selectedColumns[index]
+                );
+                console.log('activeColumns', activeColumns);
+                return { selectedColumns, activeColumns };
             });
             logAnalytics({
                 category: analyticsEnum.classSearch.title,

--- a/apps/antalmanac/src/stores/TabStore.ts
+++ b/apps/antalmanac/src/stores/TabStore.ts
@@ -1,7 +1,5 @@
 import { create } from 'zustand';
 
-import { useColumnStore } from './ColumnStore';
-
 interface TabStore {
     activeTab: number;
     setActiveTab: (newTab: number) => void;
@@ -17,13 +15,6 @@ export const useTabStore = create<TabStore>((set) => {
             set(() => ({
                 activeTab: newTab,
             }));
-            // Disable GPA column on the Added tab because we'd have to query them individually
-            // A column needs to be enabled and selected to be displayed
-            if (newTab == 2) {
-                useColumnStore.getState().setColumnEnabled('gpa', false);
-            } else {
-                useColumnStore.getState().setColumnEnabled('gpa', true);
-            }
         },
     };
 });


### PR DESCRIPTION
## Summary
- The GPA column will now be shown on both the search and added panes.
- Remove vestigial logic in the stores which enabled the disabling of the columns in the added pane.
- Fix a bug that broke the column toggle buttons. This was broken before, but no one noticed.

## Test Plan
- Check that the GPA column shows up in both panes.
- Check that the column toggles work as expected.

## Issues
- Closes #939 

## Future Followup
- Would be nice for the column filtering to persist between page loads.
