### PR TITLE
Auto-update the Logo Based on Season/Holiday

### DIFF
--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -7,8 +7,14 @@ import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
 import AppDrawer from './SettingsMenu';
 
-import Logo from '$assets/logo.svg';
-import MobileLogo from '$assets/mobile-logo.svg';
+import ChristmasLogo from '$assets/christmas-logo.png';
+import MobileChristmasLogo from '$assets/christmas-mobile-logo.png';
+import DefaultLogo from '$assets/logo.svg';
+import MobileDefaultLogo from '$assets/mobile-logo.svg';
+//import ThanksgivingLogo from '$assets/thanksgiving-logo.png';
+//import MobileThanksgivingLogo from '$assets/thanksgiving-mobile-logo.png';
+//import HalloweenLogo from '$assets/halloween-logo.png';
+//import MobileHalloweenLogo from '$assets/halloween-mobile-logo.png';
 
 const styles = {
     appBar: {
@@ -37,6 +43,40 @@ interface CustomAppBarProps {
     classes: ClassNameMap;
 }
 
+/*
+interface LogoBounds {
+    startDay: number; // inclusive
+    startMonth: number;
+    endDay: number; // exclusive
+    endMonth: number;
+}
+*/
+
+const withinBounds = (): boolean => {
+    //(bounds: LogoBounds): boolean => {
+    //const { startDay, startMonth, endDay, endMonth } = bounds;
+    //const currentDate = new Date();
+    //const currentMonth = currentDate.getMonth();
+    //const currentDay = currentDate.getDate();
+
+    // compare dates
+    return true; // not implemented obviously
+};
+
+//const Christmas: LogoBounds = { startDay: 1, startMonth: 11, endDay: 1, endMonth: 1 };
+// ...
+
+const getLogo = (isMobileScreen: boolean): string => {
+    if (withinBounds()) {
+        //Christmas)) {
+        return isMobileScreen ? MobileChristmasLogo : ChristmasLogo;
+    }
+    // ...
+    else {
+        return isMobileScreen ? MobileDefaultLogo : DefaultLogo;
+    }
+};
+
 const Header = ({ classes }: CustomAppBarProps) => {
     const isMobileScreen = useMediaQuery('(max-width:750px)');
 
@@ -45,7 +85,7 @@ const Header = ({ classes }: CustomAppBarProps) => {
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
                 <img
                     height={32}
-                    src={isMobileScreen ? MobileLogo : Logo}
+                    src={getLogo(isMobileScreen)}
                     title={'Thanks Aejin for designing this seasonal logo!'}
                     alt="logo"
                 />

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -41,7 +41,7 @@ const Header = ({ classes }: CustomAppBarProps) => {
     return (
         <AppBar position="static" className={classes.appBar}>
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
-                <Logo isMobileScreen={isMobileScreen} />
+                <Logo />
 
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <LoadSaveScheduleFunctionality />

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -5,16 +5,8 @@ import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import Export from './Export';
 import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
+import Logo from './Logo';
 import AppDrawer from './SettingsMenu';
-
-import ChristmasLogo from '$assets/christmas-logo.png';
-import MobileChristmasLogo from '$assets/christmas-mobile-logo.png';
-import DefaultLogo from '$assets/logo.svg';
-import MobileDefaultLogo from '$assets/mobile-logo.svg';
-//import ThanksgivingLogo from '$assets/thanksgiving-logo.png';
-//import MobileThanksgivingLogo from '$assets/thanksgiving-mobile-logo.png';
-//import HalloweenLogo from '$assets/halloween-logo.png';
-//import MobileHalloweenLogo from '$assets/halloween-mobile-logo.png';
 
 const styles = {
     appBar: {
@@ -43,52 +35,13 @@ interface CustomAppBarProps {
     classes: ClassNameMap;
 }
 
-/*
-interface LogoBounds {
-    startDay: number; // inclusive
-    startMonth: number;
-    endDay: number; // exclusive
-    endMonth: number;
-}
-*/
-
-const withinBounds = (): boolean => {
-    //(bounds: LogoBounds): boolean => {
-    //const { startDay, startMonth, endDay, endMonth } = bounds;
-    //const currentDate = new Date();
-    //const currentMonth = currentDate.getMonth();
-    //const currentDay = currentDate.getDate();
-
-    // compare dates
-    return true; // not implemented obviously
-};
-
-//const Christmas: LogoBounds = { startDay: 1, startMonth: 11, endDay: 1, endMonth: 1 };
-// ...
-
-const getLogo = (isMobileScreen: boolean): string => {
-    if (withinBounds()) {
-        //Christmas)) {
-        return isMobileScreen ? MobileChristmasLogo : ChristmasLogo;
-    }
-    // ...
-    else {
-        return isMobileScreen ? MobileDefaultLogo : DefaultLogo;
-    }
-};
-
 const Header = ({ classes }: CustomAppBarProps) => {
     const isMobileScreen = useMediaQuery('(max-width:750px)');
 
     return (
         <AppBar position="static" className={classes.appBar}>
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
-                <img
-                    height={32}
-                    src={getLogo(isMobileScreen)}
-                    title={'Thanks Aejin for designing this seasonal logo!'}
-                    alt="logo"
-                />
+                <Logo isMobileScreen={isMobileScreen} />
 
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <LoadSaveScheduleFunctionality />

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -1,3 +1,6 @@
+import { useMediaQuery } from '@mui/material';
+import { useMemo } from 'react';
+
 import ChristmasLogo from '$assets/christmas-logo.png';
 import MobileChristmasLogo from '$assets/christmas-mobile-logo.png';
 import HalloweenLogo from '$assets/halloween-logo.png';
@@ -6,6 +9,27 @@ import DefaultLogo from '$assets/logo.svg';
 import MobileDefaultLogo from '$assets/mobile-logo.svg';
 import ThanksgivingLogo from '$assets/thanksgiving-logo.png';
 import MobileThanksgivingLogo from '$assets/thanksgiving-mobile-logo.png';
+
+type Logo = {
+    name: string;
+    mobileLogo: string;
+    desktopLogo: string;
+    startDay: number; // inclusive
+    startMonthIndex: number;
+    endDay: number; // exclusive
+    endMonthIndex: number;
+    attribution?: string;
+};
+
+const defaultLogo: Logo = {
+    name: 'Default',
+    mobileLogo: MobileDefaultLogo,
+    desktopLogo: DefaultLogo,
+    startDay: 0,
+    startMonthIndex: 0,
+    endDay: 31,
+    endMonthIndex: 12,
+};
 
 const logos: Logo[] = [
     {
@@ -16,6 +40,7 @@ const logos: Logo[] = [
         startMonthIndex: 11,
         endDay: 1,
         endMonthIndex: 1,
+        attribution: 'Thanks Aejin for designing this seasonal logo!',
     },
     {
         name: 'Thanksgiving',
@@ -25,6 +50,7 @@ const logos: Logo[] = [
         startMonthIndex: 10,
         endDay: 1,
         endMonthIndex: 11,
+        attribution: 'Thanks Aejin for designing this seasonal logo!',
     },
     {
         name: 'Halloween',
@@ -34,54 +60,38 @@ const logos: Logo[] = [
         startMonthIndex: 9,
         endDay: 1,
         endMonthIndex: 10,
+        attribution: 'Thanks Aejin for designing this seasonal logo!',
     },
+    defaultLogo,
 ];
 
-interface Logo {
-    name: string;
-    mobileLogo: string;
-    desktopLogo: string;
-    startDay: number; // inclusive
-    startMonthIndex: number;
-    endDay: number; // exclusive
-    endMonthIndex: number;
-}
-
-interface Logos {
-    logos: Logo[];
-}
-
-interface LogoImage extends Pick<Logo, 'mobileLogo' | 'desktopLogo'> {
-    imageCredit?: string;
-}
-
-const inBounds = (props: Logo): boolean => {
+function logoIsForCurrentSeason(logo: Logo) {
     const currentDate = new Date();
     const currentYear = currentDate.getFullYear();
 
     const endYear = currentYear;
-    const startYear = props.startMonthIndex > props.endMonthIndex ? endYear - 1 : endYear;
-    const endDate = new Date(endYear, props.endMonthIndex, props.endDay);
-    const startDate = new Date(startYear, props.startMonthIndex, props.startDay);
+    const startYear = logo.startMonthIndex > logo.endMonthIndex ? endYear - 1 : endYear;
+    const endDate = new Date(endYear, logo.endMonthIndex, logo.endDay);
+    const startDate = new Date(startYear, logo.startMonthIndex, logo.startDay);
 
     return currentDate >= startDate && currentDate < endDate;
-};
-
-const getLogo = (props: Logos): LogoImage => {
-    for (const logo of props.logos) {
-        if (inBounds(logo)) {
-            return {
-                mobileLogo: logo.mobileLogo,
-                desktopLogo: logo.desktopLogo,
-                imageCredit: 'Thanks Aejin for designing this seasonal logo!',
-            };
-        }
-    }
-    return { mobileLogo: MobileDefaultLogo, desktopLogo: DefaultLogo };
-};
-
-export default function Logo({ isMobileScreen }: { isMobileScreen: boolean }) {
-    const { mobileLogo, desktopLogo, imageCredit } = getLogo({ logos });
-
-    return <img height={32} src={isMobileScreen ? mobileLogo : desktopLogo} title={imageCredit ?? ''} alt="logo" />;
 }
+
+export function Logo() {
+    const isMobileScreen = useMediaQuery('(max-width:750px)');
+
+    const currentLogo = useMemo(() => {
+        return logos.find((logo) => logoIsForCurrentSeason(logo)) ?? defaultLogo;
+    }, []);
+
+    return (
+        <img
+            height={32}
+            src={isMobileScreen ? currentLogo?.mobileLogo : currentLogo?.desktopLogo}
+            title={currentLogo?.attribution}
+            alt="logo"
+        />
+    );
+}
+
+export default Logo;

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -47,51 +47,41 @@ interface Logo {
     endMonthIndex: number;
 }
 
-interface LogoProps {
-    isMobileScreen: boolean;
+interface Logos {
     logos: Logo[];
 }
 
+interface LogoImage extends Pick<Logo, 'mobileLogo' | 'desktopLogo'> {
+    imageCredit?: string;
+}
+
 const inBounds = (props: Logo): boolean => {
-    // get current date
     const currentDate = new Date();
-
-    // for testing...
-    // const currentDate = new Date(2024, 8, 30); // within default logo range
-    // const currentDate = new Date(2024, 9, 31); // last day of halloween logo (last day of october)
-    // const currentDate = new Date(2024, 10, 1); // first day of thanksgiving logo (first day of november, etc.)
-    // const currentDate = new Date(2024, 10, 30); // last day of thanksgiving logo
-    // const currentDate = new Date(2024, 0, 15); // should be christmas logo
-    // const currentDate = new Date(2024, 1, 1); // first day back in default range - dalton as of 5/20/24
-
-    // get bounds
     const currentYear = currentDate.getFullYear();
+
     const endYear = currentYear;
     const startYear = props.startMonthIndex > props.endMonthIndex ? endYear - 1 : endYear;
     const endDate = new Date(endYear, props.endMonthIndex, props.endDay);
     const startDate = new Date(startYear, props.startMonthIndex, props.startDay);
 
-    // check if current date is in bounds of special event/holiday/season
     return currentDate >= startDate && currentDate < endDate;
 };
 
-const getLogo = (props: LogoProps): string => {
+const getLogo = (props: Logos): LogoImage => {
     for (const logo of props.logos) {
         if (inBounds(logo)) {
-            // console.log('using the ' + logo.name + ' logo!');
-            return props.isMobileScreen ? logo.mobileLogo : logo.desktopLogo;
+            return {
+                mobileLogo: logo.mobileLogo,
+                desktopLogo: logo.desktopLogo,
+                imageCredit: 'Thanks Aejin for designing this seasonal logo!',
+            };
         }
     }
-    return props.isMobileScreen ? MobileDefaultLogo : DefaultLogo;
+    return { mobileLogo: MobileDefaultLogo, desktopLogo: DefaultLogo };
 };
 
 export default function Logo({ isMobileScreen }: { isMobileScreen: boolean }) {
-    return (
-        <img
-            height={32}
-            src={getLogo({ isMobileScreen: isMobileScreen, logos: logos })}
-            title={'Thanks Aejin for designing this seasonal logo!'}
-            alt="logo"
-        />
-    );
+    const { mobileLogo, desktopLogo, imageCredit } = getLogo({ logos });
+
+    return <img height={32} src={isMobileScreen ? mobileLogo : desktopLogo} title={imageCredit ?? ''} alt="logo" />;
 }

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -1,0 +1,97 @@
+import ChristmasLogo from '$assets/christmas-logo.png';
+import MobileChristmasLogo from '$assets/christmas-mobile-logo.png';
+import HalloweenLogo from '$assets/halloween-logo.png';
+import MobileHalloweenLogo from '$assets/halloween-mobile-logo.png';
+import DefaultLogo from '$assets/logo.svg';
+import MobileDefaultLogo from '$assets/mobile-logo.svg';
+import ThanksgivingLogo from '$assets/thanksgiving-logo.png';
+import MobileThanksgivingLogo from '$assets/thanksgiving-mobile-logo.png';
+
+const logos: Logo[] = [
+    {
+        name: 'Christmas',
+        mobileLogo: MobileChristmasLogo,
+        desktopLogo: ChristmasLogo,
+        startDay: 1,
+        startMonthIndex: 11,
+        endDay: 1,
+        endMonthIndex: 1,
+    },
+    {
+        name: 'Thanksgiving',
+        mobileLogo: MobileThanksgivingLogo,
+        desktopLogo: ThanksgivingLogo,
+        startDay: 1,
+        startMonthIndex: 10,
+        endDay: 1,
+        endMonthIndex: 11,
+    },
+    {
+        name: 'Halloween',
+        mobileLogo: MobileHalloweenLogo,
+        desktopLogo: HalloweenLogo,
+        startDay: 1,
+        startMonthIndex: 9,
+        endDay: 1,
+        endMonthIndex: 10,
+    },
+];
+
+interface Logo {
+    name: string;
+    mobileLogo: string;
+    desktopLogo: string;
+    startDay: number; // inclusive
+    startMonthIndex: number;
+    endDay: number; // exclusive
+    endMonthIndex: number;
+}
+
+interface LogoProps {
+    isMobileScreen: boolean;
+    logos: Logo[];
+}
+
+const inBounds = (props: Logo): boolean => {
+    // get current date
+    const currentDate = new Date();
+
+    // for testing...
+    // const currentDate = new Date(2024, 8, 30); // within default logo range
+    // const currentDate = new Date(2024, 9, 31); // last day of halloween logo (last day of october)
+    // const currentDate = new Date(2024, 10, 1); // first day of thanksgiving logo (first day of november, etc.)
+    // const currentDate = new Date(2024, 10, 30); // last day of thanksgiving logo
+    // const currentDate = new Date(2024, 0, 15); // should be christmas logo
+    // const currentDate = new Date(2024, 1, 1); // first day back in default range - dalton as of 5/20/24
+
+    // get bounds
+    const currentYear = currentDate.getFullYear();
+    const endYear = currentYear;
+    const startYear = props.startMonthIndex > props.endMonthIndex ? endYear - 1 : endYear;
+    const endDate = new Date(endYear, props.endMonthIndex, props.endDay);
+    const startDate = new Date(startYear, props.startMonthIndex, props.startDay);
+
+    // check if current date is in bounds of special event/holiday/season
+    return currentDate >= startDate && currentDate < endDate;
+};
+
+const getLogo = (props: LogoProps): string => {
+    for (const logo of props.logos) {
+        if (inBounds(logo)) {
+            // console.log('using the ' + logo.name + ' logo!');
+            return props.isMobileScreen ? logo.mobileLogo : logo.desktopLogo;
+        }
+    }
+    return props.isMobileScreen ? MobileDefaultLogo : DefaultLogo;
+};
+
+export default function Logo({ isMobileScreen }: { isMobileScreen: boolean }) {
+    return (
+        <img
+            height={32}
+            src={getLogo({ isMobileScreen: isMobileScreen, logos: logos })}
+            title={'Thanks Aejin for designing this seasonal logo!'}
+            alt="logo"
+        />
+    );
+}


### PR DESCRIPTION
## Summary
Wrote out a Logo component that consolidates the logic previously used for the logo (such as should it be mobile version) and returns the appropriate logo based on the current date. To add a new seasonal logo, simply create a new Logo object in the Logos array.

Not code related, but the windows I used for the logos can be widened/updated if appropriate. Not sure how long the winter one should extend to, for example. Would love thoughts on that.

## Test Plan
- View the logo as-is. Since we are not in a particular event range it should be default
- Confirm that it still switches to mobile when window is resized
- Edit the "current date" object to be any other possible date. The logo should reflect the season of that date

## Issues

Closes #973 to follow up #974 and similar

## Future Followup

Do we have more designs? The default logo as-is will display for 8 contiguous months.
