### PR TITLE
fix: date formatting logic in enrollmentHistory for Safari

### DIFF
--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -106,8 +106,9 @@ export class DepartmentEnrollmentHistory {
             const enrollmentDays: EnrollmentHistoryDay[] = [];
 
             for (const [i, date] of enrollmentHistory.dates.entries()) {
-                const d = new Date(date);
-                const formattedDate = `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+                const dateParts = date.split('-');
+                const d = new Date(Number(dateParts[0]), Number(dateParts[1]), Number(dateParts[2]));
+                const formattedDate = `${d.getMonth()}/${d.getDate() - 1}/${d.getFullYear()}`;
 
                 enrollmentDays.push({
                     date: formattedDate,

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -105,10 +105,10 @@ export class DepartmentEnrollmentHistory {
         for (const enrollmentHistory of res) {
             const enrollmentDays: EnrollmentHistoryDay[] = [];
 
-            for (const [i, date] of enrollmentHistory.dates.entries()) {
-                const dateParts = date.split('-');
-                const d = new Date(Number(dateParts[0]), Number(dateParts[1]), Number(dateParts[2]));
-                const formattedDate = `${d.getMonth()}/${d.getDate() - 1}/${d.getFullYear()}`;
+            for (const [i, dateString] of enrollmentHistory.dates.entries()) {
+                const [day = '', month = '', year = ''] = dateString.split('-');
+                const date = new Date(Number(day), Number(month), Number(year));
+                const formattedDate = `${date.getMonth()}/${date.getDate() - 1}/${date.getFullYear()}`;
 
                 enrollmentDays.push({
                     date: formattedDate,


### PR DESCRIPTION
## Summary
Safari handles parsing dates differently than other browsers. Here is one way of fixing it by handling the date as a string before making it a Date object

I think you can also maybe using something like `date-fns` to handle the cross platform behavior for parsing dates (although I personally think that might be too overkill for just this one use case)

## Test Plan
Verified that the result is the same as what's on prod. Tested on Mac and iOS
![image](https://github.com/icssc/AntAlmanac/assets/21994085/8bd57a21-bca4-4e40-bcfa-464c420d28af)

## Issues

Closes #947 

<!-- [Optional]
## Future Followup
-->

