### PR TITLE
Fixed GPA not showing on Courses Added pane

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -214,12 +214,7 @@ async function getGpaData(deptCode: string, courseNumber: string, instructors: s
 
     // Get the GPA of the first instructor of this section where data exists
     for (const instructor of namedInstructors) {
-        const grades = await Grades.queryGrades(
-            deptCode,
-            courseNumber,
-            instructor,
-            useTabStore.getState().activeTab != 1
-        );
+        const grades = await Grades.queryGrades(deptCode, courseNumber, instructor, false);
         if (grades?.averageGPA) {
             return {
                 gpa: grades.averageGPA.toFixed(2).toString(),


### PR DESCRIPTION
## Summary
As discussed extensively in #983 , the GPA column on the course added pane would show no data unless it was previously loaded into the cache by a search. There were concerns with query deduplication as well, but I believe those should be dispelled by the tests I conducted:

## Test Plan
- If you encapsulate both of the two calls to query the grades with console.log statements, you can observe that even between courses vs. discussions, different discussions of the same course, etc. they all go to the cache once the class itself has been queried once:
![image](https://github.com/icssc/AntAlmanac/assets/105406853/ec116dac-62ac-4143-a4c9-a5b471cf17e5)

To test further,
- Load empty schedule
- Add a couple courses via search pane
- Observe GPA in added courses pane
- Refresh the page and go to added courses pane. GPA should be there
- Add another class and remove one previously added
- Observe added courses pane. Even with refresh, and even if you add the removed course back, added courses pane should always show GPA

## Issues

Closes #983 
