### PR TITLE
feat: warn when saving empty schedules

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -1,12 +1,10 @@
-import { ScheduleCourse } from '@packages/antalmanac-types';
-import { RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { RepeatingCustomEvent, ScheduleCourse, ShortCourseSchedule } from '@packages/antalmanac-types';
 import { TRPCError } from '@trpc/server';
 import { VariantType } from 'notistack';
 import { WebsocSection } from 'peterportal-api-next-types';
 
 import { SnackbarPosition } from '$components/NotificationSnackbar';
-import analyticsEnum, { logAnalytics } from '$lib/analytics';
-import { courseNumAsDecimal } from '$lib/analytics';
+import analyticsEnum, { logAnalytics, courseNumAsDecimal } from '$lib/analytics';
 import trpc from '$lib/api/trpc';
 import { CourseDetails } from '$lib/course_data.types';
 import { warnMultipleTerms } from '$lib/helpers';
@@ -64,6 +62,24 @@ export const openSnackbar = (
     AppStore.openSnackbar(variant, message, duration, position, style);
 };
 
+function isEmptySchedule(schedules: ShortCourseSchedule[]) {
+    for (const schedule of schedules) {
+        if (schedule.courses.length > 0) {
+            return false;
+        }
+
+        if (schedule.customEvents.length > 0) {
+            return false;
+        }
+
+        if (schedule.scheduleNote !== '') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 export const saveSchedule = async (userID: string, rememberMe: boolean) => {
     logAnalytics({
         category: analyticsEnum.nav.title,
@@ -71,6 +87,7 @@ export const saveSchedule = async (userID: string, rememberMe: boolean) => {
         label: userID,
         value: rememberMe ? 1 : 0,
     });
+
     if (userID != null) {
         userID = userID.replace(/\s+/g, '');
 
@@ -82,6 +99,15 @@ export const saveSchedule = async (userID: string, rememberMe: boolean) => {
             }
 
             const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
+
+            if (
+                isEmptySchedule(scheduleSaveState.schedules) &&
+                !confirm(
+                    "You are attempting to save empty schedule(s). If this is unintentional, this may overwrite your existing schedules that haven't loaded yet!"
+                )
+            ) {
+                return;
+            }
 
             try {
                 await trpc.users.saveUserData.mutate({


### PR DESCRIPTION
## Summary
1. When AA or AnteaterAPI is running slow, users may unintentionally save a completely empty schedule and wipe their own schedules.
2. This PR adds a check for completely empty schedules and warns users, as this is an unexpected action for a user to take (saving empty schedules).

## Test Plan
1. Attempt to save empty schedules, a window confirmation should appear
2. After adding courses, custom events, OR a schedule note, the window confirmation should not appear

## Issues
Closes #990

<!-- [Optional]
## Future Followup
-->
