### PR TITLE
refactor: make one instance of copy, clear buttons

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarToolbar.tsx
@@ -1,22 +1,21 @@
 import {
     Add as AddIcon,
     ArrowDropDown as ArrowDropDownIcon,
-    Delete as DeleteIcon,
     Edit as EditIcon,
     Undo as UndoIcon,
     Clear as ClearIcon,
-    ContentCopy as ContentCopyIcon,
 } from '@mui/icons-material';
 import { Box, Button, IconButton, Paper, Popover, Tooltip, Typography, useTheme } from '@mui/material';
 import { useState, useMemo, useCallback, useEffect } from 'react';
 
 import CustomEventDialog from './Toolbar/CustomEventDialog/CustomEventDialog';
 
-import { changeCurrentSchedule, clearSchedules, undoDelete } from '$actions/AppStoreActions';
+import { changeCurrentSchedule, undoDelete } from '$actions/AppStoreActions';
+import { ClearScheduleButton } from '$components/buttons/Clear';
+import { CopyScheduleButton } from '$components/buttons/Copy';
 import DownloadButton from '$components/buttons/Download';
 import ScreenshotButton from '$components/buttons/Screenshot';
 import AddScheduleDialog from '$components/dialogs/AddSchedule';
-import CopyScheduleDialog from '$components/dialogs/CopySchedule';
 import DeleteScheduleDialog from '$components/dialogs/DeleteSchedule';
 import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
@@ -45,37 +44,6 @@ function handleUndo() {
         action: analyticsEnum.calendar.actions.UNDO,
     });
     undoDelete(null);
-}
-
-function handleClearSchedule() {
-    if (window.confirm('Are you sure you want to clear this schedule?')) {
-        clearSchedules();
-        logAnalytics({
-            category: analyticsEnum.calendar.title,
-            action: analyticsEnum.calendar.actions.CLEAR_SCHEDULE,
-        });
-    }
-}
-
-function CopyScheduleButton(props: { index: number }) {
-    const [open, setOpen] = useState(false);
-
-    const handleOpen = useCallback(() => {
-        setOpen(true);
-    }, []);
-
-    const handleClose = useCallback(() => {
-        setOpen(false);
-    }, []);
-
-    return (
-        <Box>
-            <IconButton onClick={handleOpen} size="small">
-                <ContentCopyIcon />
-            </IconButton>
-            <CopyScheduleDialog fullWidth open={open} index={props.index} onClose={handleClose} />
-        </Box>
-    );
 }
 
 function EditScheduleButton(props: { index: number }) {
@@ -358,11 +326,7 @@ function CalendarPaneToolbar(props: CalendarPaneToolbarProps) {
                     </IconButton>
                 </Tooltip>
 
-                <Tooltip title="Clear schedule">
-                    <IconButton onClick={handleClearSchedule} size="medium" disabled={skeletonMode}>
-                        <DeleteIcon fontSize="small" />
-                    </IconButton>
-                </Tooltip>
+                <ClearScheduleButton size="medium" fontSize="small" skeletonMode={skeletonMode} />
 
                 <CustomEventDialog key="custom" scheduleNames={AppStore.getScheduleNames()} />
             </Box>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,5 +1,4 @@
-import { ContentCopy, DeleteOutline } from '@mui/icons-material';
-import { Box, Chip, IconButton, Paper, SxProps, TextField, Tooltip, Typography } from '@mui/material';
+import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -8,8 +7,9 @@ import SectionTableLazyWrapper from '../SectionTable/SectionTableLazyWrapper';
 
 import CustomEventDetailView from './CustomEventDetailView';
 
-import { clearSchedules, updateScheduleNote } from '$actions/AppStoreActions';
-import CopyScheduleDialog from '$components/dialogs/CopySchedule';
+import { updateScheduleNote } from '$actions/AppStoreActions';
+import { ClearScheduleButton } from '$components/buttons/Clear';
+import { CopyScheduleButton } from '$components/buttons/Copy';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { clickToCopy } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
@@ -31,10 +31,6 @@ const buttonSx: SxProps = {
 
 interface CourseWithTerm extends AACourse {
     term: string;
-}
-
-interface CopyScheduleButtonProps {
-    index: number;
 }
 
 const NOTE_MAX_LEN = 5000;
@@ -81,49 +77,6 @@ function getCourses() {
     });
 
     return formattedCourses;
-}
-
-function handleClear() {
-    if (window.confirm('Are you sure you want to clear this schedule?')) {
-        clearSchedules();
-        logAnalytics({
-            category: analyticsEnum.addedClasses.title,
-            action: analyticsEnum.addedClasses.actions.CLEAR_SCHEDULE,
-        });
-    }
-}
-
-function ClearScheduleButton() {
-    return (
-        <Tooltip title="Clear Schedule">
-            <IconButton sx={buttonSx} onClick={handleClear}>
-                <DeleteOutline />
-            </IconButton>
-        </Tooltip>
-    );
-}
-
-function CopyScheduleButton({ index }: CopyScheduleButtonProps) {
-    const [open, setOpen] = useState(false);
-
-    const handleOpen = useCallback(() => {
-        setOpen(true);
-    }, []);
-
-    const handleClose = useCallback(() => {
-        setOpen(false);
-    }, []);
-
-    return (
-        <>
-            <Tooltip title="Copy Schedule">
-                <IconButton sx={buttonSx} onClick={handleOpen} size="small">
-                    <ContentCopy />
-                </IconButton>
-            </Tooltip>
-            <CopyScheduleDialog fullWidth open={open} index={index} onClose={handleClose} />
-        </>
-    );
 }
 
 function CustomEventsBox() {
@@ -376,8 +329,8 @@ function AddedSectionsGrid() {
     return (
         <Box display="flex" flexDirection="column" gap={1} marginX={0.5}>
             <Box display="flex" width={1} position="absolute" zIndex="2">
-                <CopyScheduleButton index={scheduleIndex} />
-                <ClearScheduleButton />
+                <CopyScheduleButton index={scheduleIndex} buttonSx={buttonSx} />
+                <ClearScheduleButton buttonSx={buttonSx} />
                 <ColumnToggleDropdown />
             </Box>
             <Box style={{ marginTop: 50 }}>

--- a/apps/antalmanac/src/components/buttons/Clear.tsx
+++ b/apps/antalmanac/src/components/buttons/Clear.tsx
@@ -1,0 +1,32 @@
+import { DeleteOutline } from '@mui/icons-material';
+import { IconButton, SxProps, Tooltip } from '@mui/material';
+
+import { clearSchedules } from '$actions/AppStoreActions';
+import analyticsEnum, { logAnalytics } from '$lib/analytics';
+
+function handleClearSchedule() {
+    if (window.confirm('Are you sure you want to clear this schedule?')) {
+        clearSchedules();
+        logAnalytics({
+            category: analyticsEnum.calendar.title,
+            action: analyticsEnum.calendar.actions.CLEAR_SCHEDULE,
+        });
+    }
+}
+
+interface ClearScheduleButtonProps {
+    skeletonMode?: boolean;
+    buttonSx?: SxProps;
+    size?: 'small' | 'medium' | 'large' | undefined;
+    fontSize?: 'small' | 'medium' | 'large' | 'inherit' | undefined;
+}
+
+export function ClearScheduleButton({ skeletonMode, buttonSx, size, fontSize }: ClearScheduleButtonProps) {
+    return (
+        <Tooltip title="Clear schedule">
+            <IconButton sx={buttonSx} onClick={handleClearSchedule} size={size} disabled={skeletonMode}>
+                <DeleteOutline fontSize={fontSize} />
+            </IconButton>
+        </Tooltip>
+    );
+}

--- a/apps/antalmanac/src/components/buttons/Copy.tsx
+++ b/apps/antalmanac/src/components/buttons/Copy.tsx
@@ -1,0 +1,33 @@
+import { ContentCopy } from '@mui/icons-material';
+import { IconButton, SxProps, Tooltip } from '@mui/material';
+import { useCallback, useState } from 'react';
+
+import CopyScheduleDialog from '$components/dialogs/CopySchedule';
+
+interface CopyScheduleButtonProps {
+    index: number;
+    buttonSx?: SxProps;
+}
+
+export function CopyScheduleButton({ index, buttonSx }: CopyScheduleButtonProps) {
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = useCallback(() => {
+        setOpen(true);
+    }, []);
+
+    const handleClose = useCallback(() => {
+        setOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Tooltip title="Copy Schedule">
+                <IconButton sx={buttonSx} onClick={handleOpen} size="small">
+                    <ContentCopy />
+                </IconButton>
+            </Tooltip>
+            <CopyScheduleDialog fullWidth open={open} index={index} onClose={handleClose} />
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
1. There were two instances of copy and clear (CalendarToolbar and AddedCoursePane) which were virtually identical.
2. This PR refactors it such that there's now only one instance

## Test Plan
1. Confirm that copy and clear still work

## Issues
Closes #966

<!-- [Optional]
## Future Followup
-->
