### PR TITLE
fix: correct error messages when importing courses

### DIFF
--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -27,7 +27,7 @@ import { CourseInfo } from '$lib/course_data.types';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import WebSOC from '$lib/websoc';
-import { ZotCourseResponse, queryZotCourse } from '$lib/zotcourse';
+import { zotcourseResponse, queryZotcourse } from '$lib/zotcourse';
 import AppStore from '$stores/AppStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
@@ -58,7 +58,7 @@ function Import() {
 
         if (isZotcourseImport) {
             try {
-                const zotcourseImport: ZotCourseResponse = await queryZotCourse(zotcourseScheduleName);
+                const zotcourseImport: zotcourseResponse = await queryZotcourse(zotcourseScheduleName);
                 sectionCodes = zotcourseImport.codes;
                 for (const event of zotcourseImport.customEvents) {
                     addCustomEvent(event, [currentSchedule]);

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -19,14 +19,15 @@ import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 import TermSelector from '../RightPane/CoursePane/SearchForm/TermSelector';
 import RightPaneStore from '../RightPane/RightPaneStore';
+
 import { addCustomEvent, openSnackbar } from '$actions/AppStoreActions';
-import analyticsEnum, { logAnalytics } from '$lib/analytics';
-import { warnMultipleTerms } from '$lib/helpers';
-import AppStore from '$stores/AppStore';
-import WebSOC from '$lib/websoc';
-import { CourseInfo } from '$lib/course_data.types';
 import { addCourse } from '$actions/AppStoreActions';
+import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import { CourseInfo } from '$lib/course_data.types';
+import { warnMultipleTerms } from '$lib/helpers';
+import WebSOC from '$lib/websoc';
 import { ZotCourseResponse, queryZotCourse } from '$lib/zotcourse';
+import AppStore from '$stores/AppStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
 function Import() {
@@ -56,8 +57,10 @@ function Import() {
             try {
                 zotcourseImport = await queryZotCourse(zotcourseScheduleName);
             } catch (e) {
-                openSnackbar('error', 'Could not import from Zotcourse.');
-                console.error(e);
+                if (e instanceof Error) {
+                    openSnackbar('error', e.message);
+                    console.error(e);
+                }
                 handleClose();
                 return;
             }
@@ -66,7 +69,7 @@ function Import() {
         const sectionCodes = zotcourseImport ? zotcourseImport.codes : studyListText.match(/\d{5}/g);
 
         if (!sectionCodes) {
-            openSnackbar('error', 'Cannot import an empty/invalid Study List/Zotcourse.');
+            openSnackbar('error', `Cannot import an ${studyListText ? 'invalid' : 'empty'} Study List.`);
             handleClose();
             return;
         }

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -27,7 +27,7 @@ import { CourseInfo } from '$lib/course_data.types';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import WebSOC from '$lib/websoc';
-import { zotcourseResponse, queryZotcourse } from '$lib/zotcourse';
+import { ZotcourseResponse, queryZotcourse } from '$lib/zotcourse';
 import AppStore from '$stores/AppStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
@@ -58,7 +58,7 @@ function Import() {
 
         if (isZotcourseImport) {
             try {
-                const zotcourseImport: zotcourseResponse = await queryZotcourse(zotcourseScheduleName);
+                const zotcourseImport: ZotcourseResponse = await queryZotcourse(zotcourseScheduleName);
                 sectionCodes = zotcourseImport.codes;
                 for (const event of zotcourseImport.customEvents) {
                     addCustomEvent(event, [currentSchedule]);

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -24,6 +24,7 @@ import { addCustomEvent, openSnackbar } from '$actions/AppStoreActions';
 import { addCourse } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseInfo } from '$lib/course_data.types';
+import { QueryZotCourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import WebSOC from '$lib/websoc';
 import { ZotCourseResponse, queryZotCourse } from '$lib/zotcourse';
@@ -57,10 +58,12 @@ function Import() {
             try {
                 zotcourseImport = await queryZotCourse(zotcourseScheduleName);
             } catch (e) {
-                if (e instanceof Error) {
+                if (e instanceof QueryZotCourseError) {
                     openSnackbar('error', e.message);
-                    console.error(e);
+                } else {
+                    openSnackbar('error', 'Could not import from Zotcourse.');
                 }
+                console.error(e);
                 handleClose();
                 return;
             }

--- a/apps/antalmanac/src/lib/customErrors.ts
+++ b/apps/antalmanac/src/lib/customErrors.ts
@@ -1,6 +1,6 @@
 export class QueryZotcourseError extends Error {
     constructor(message: string) {
         super(message);
-        this.name = 'QueryZotCourseError';
+        this.name = 'QueryZotcourseError';
     }
 }

--- a/apps/antalmanac/src/lib/customErrors.ts
+++ b/apps/antalmanac/src/lib/customErrors.ts
@@ -1,4 +1,4 @@
-export class QueryZotCourseError extends Error {
+export class QueryZotcourseError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'QueryZotCourseError';

--- a/apps/antalmanac/src/lib/customErrors.ts
+++ b/apps/antalmanac/src/lib/customErrors.ts
@@ -1,0 +1,6 @@
+export class QueryZotCourseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'QueryZotCourseError';
+    }
+}

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -1,5 +1,7 @@
 import { RepeatingCustomEvent } from '@packages/antalmanac-types';
+
 import trpc from './api/trpc';
+
 import AppStore from '$stores/AppStore';
 
 export interface ZotCourseResponse {
@@ -7,7 +9,9 @@ export interface ZotCourseResponse {
     customEvents: RepeatingCustomEvent[];
 }
 export async function queryZotCourse(schedule_name: string) {
+    if (!schedule_name) throw new Error('Cannot import an empty Zotcourse schedule name');
     const response = await trpc.zotcourse.getUserData.mutate({ scheduleName: schedule_name });
+    if (!response.success) throw new Error('Cannot import an invalid Zotcourse');
     // For custom event, there is no course attribute in each.
     const codes = response.data
         .filter((section: { eventType: number }) => section.eventType === 3)

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -5,7 +5,7 @@ import { QueryZotcourseError } from './customErrors';
 
 import AppStore from '$stores/AppStore';
 
-export interface zotcourseResponse {
+export interface ZotcourseResponse {
     codes: string[];
     customEvents: RepeatingCustomEvent[];
 }

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -1,6 +1,7 @@
 import { RepeatingCustomEvent } from '@packages/antalmanac-types';
 
 import trpc from './api/trpc';
+import { QueryZotCourseError } from './customErrors';
 
 import AppStore from '$stores/AppStore';
 
@@ -9,9 +10,9 @@ export interface ZotCourseResponse {
     customEvents: RepeatingCustomEvent[];
 }
 export async function queryZotCourse(schedule_name: string) {
-    if (!schedule_name) throw new Error('Cannot import an empty Zotcourse schedule name');
+    if (!schedule_name) throw new QueryZotCourseError('Cannot import an empty Zotcourse schedule name');
     const response = await trpc.zotcourse.getUserData.mutate({ scheduleName: schedule_name });
-    if (!response.success) throw new Error('Cannot import an invalid Zotcourse');
+    if (!response.success) throw new QueryZotCourseError('Cannot import an invalid Zotcourse');
     // For custom event, there is no course attribute in each.
     const codes = response.data
         .filter((section: { eventType: number }) => section.eventType === 3)

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -5,11 +5,11 @@ import { QueryZotcourseError } from './customErrors';
 
 import AppStore from '$stores/AppStore';
 
-export interface ZotCourseResponse {
+export interface zotcourseResponse {
     codes: string[];
     customEvents: RepeatingCustomEvent[];
 }
-export async function queryZotCourse(schedule_name: string) {
+export async function queryZotcourse(schedule_name: string) {
     if (!schedule_name) throw new QueryZotcourseError('Cannot import an empty Zotcourse schedule name');
     const response = await trpc.zotcourse.getUserData.mutate({ scheduleName: schedule_name });
     if (!response.success) throw new QueryZotcourseError('Cannot import an invalid Zotcourse');

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -1,7 +1,7 @@
 import { RepeatingCustomEvent } from '@packages/antalmanac-types';
 
 import trpc from './api/trpc';
-import { QueryZotCourseError } from './customErrors';
+import { QueryZotcourseError } from './customErrors';
 
 import AppStore from '$stores/AppStore';
 
@@ -10,9 +10,9 @@ export interface ZotCourseResponse {
     customEvents: RepeatingCustomEvent[];
 }
 export async function queryZotCourse(schedule_name: string) {
-    if (!schedule_name) throw new QueryZotCourseError('Cannot import an empty Zotcourse schedule name');
+    if (!schedule_name) throw new QueryZotcourseError('Cannot import an empty Zotcourse schedule name');
     const response = await trpc.zotcourse.getUserData.mutate({ scheduleName: schedule_name });
-    if (!response.success) throw new QueryZotCourseError('Cannot import an invalid Zotcourse');
+    if (!response.success) throw new QueryZotcourseError('Cannot import an invalid Zotcourse');
     // For custom event, there is no course attribute in each.
     const codes = response.data
         .filter((section: { eventType: number }) => section.eventType === 3)


### PR DESCRIPTION
## Summary
-  Added error handling when making query to Zotcourse.
- Corrected the message that when importing by Study List
![](https://i.imgur.com/cibZ9fA.png)
![](https://i.imgur.com/YT08NoB.png)
![](https://i.imgur.com/kkObHFi.png)

## Test Plan
- Try to import when text field is empty.
- Try to import when text field has invalid input.

## Issues

Closes #872 

## Future Followup
- `import.tsx` could be refactored to make the handling of conditionals clearer when importing via Study List or Zot Course, as there is a conditional explicitly handling Zot Course but not Study List."