### PR TITLE
Made text on buttons in SectionTableBody not wrap

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
@@ -3,11 +3,13 @@ import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { Skeleton } from '@material-ui/lab';
+import { RawResponse, Course, isErrorResponse, PrerequisiteTree } from 'peterportal-api-next-types';
 import { useState } from 'react';
 
-import { RawResponse, Course, isErrorResponse, PrerequisiteTree } from 'peterportal-api-next-types';
 import { MOBILE_BREAKPOINT } from '../../../globals';
+
 import PrereqTree from './PrereqTree';
+
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { PETERPORTAL_REST_ENDPOINT } from '$lib/api/endpoints';
 
@@ -190,8 +192,11 @@ const CourseInfoBar = (props: CourseInfoBarProps) => {
                     const currentTarget = event.currentTarget;
                     void togglePopover(currentTarget);
                 }}
+                style={{ minWidth: 200 }}
             >
-                {`${deptCode} ${courseNumber} | ${courseTitle}`}
+                <span
+                    style={{ whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}
+                >{`${deptCode} ${courseNumber} | ${courseTitle}`}</span>
             </Button>
             <Popover
                 anchorEl={anchorEl}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
@@ -192,7 +192,7 @@ const CourseInfoBar = (props: CourseInfoBarProps) => {
                     const currentTarget = event.currentTarget;
                     void togglePopover(currentTarget);
                 }}
-                style={{ minWidth: 200 }}
+                style={{ maxWidth: 200 }}
             >
                 <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>
                     {`${deptCode} ${courseNumber} | ${courseTitle}`}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
@@ -194,9 +194,9 @@ const CourseInfoBar = (props: CourseInfoBarProps) => {
                 }}
                 style={{ minWidth: 200 }}
             >
-                <span
-                    style={{ whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}
-                >{`${deptCode} ${courseNumber} | ${courseTitle}`}</span>
+                <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>
+                    {`${deptCode} ${courseNumber} | ${courseTitle}`}
+                </span>
             </Button>
             <Popover
                 anchorEl={anchorEl}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
@@ -1,9 +1,10 @@
 import { Button, Paper, Popper, useMediaQuery } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { MOBILE_BREAKPOINT } from '../../../globals';
+
 import { logAnalytics } from '$lib/analytics';
 
 const styles = {
@@ -86,7 +87,7 @@ function CourseInfoButton({
                     }
                 }}
             >
-                {text}
+                <span style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>{text}</span>
             </Button>
 
             {popupContent && (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
@@ -87,7 +87,7 @@ function CourseInfoButton({
                     }
                 }}
             >
-                <span style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>{text}</span>
+                <span style={{ whiteSpace: 'nowrap' }}>{text}</span>
             </Button>
 
             {popupContent && (


### PR DESCRIPTION
## Summary
Made text on buttons in the SectionTableBody not wrap to prevent resizing
## Test Plan
Made sure buttons didn't resize when they shrink under a certain min-width. Text will not wrap and the overflow will be hidden for long course names

![image](https://github.com/user-attachments/assets/91077cbd-2c2d-4d90-9920-2764a14474e2)


## Issues

Closes #729 

<!-- [Optional]
## Future Followup
-->
