### PR TITLE
feat: clean up 98 eslint errors and warnings

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -1,18 +1,17 @@
 import './App.css';
 
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { TourProvider } from '@reactour/tour';
 import { SnackbarProvider } from 'notistack';
 import { useEffect } from 'react';
 import ReactGA4 from 'react-ga4';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
-import { TourProvider } from '@reactour/tour';
 import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
-
-import Home from './routes/Home';
 import Feedback from './routes/Feedback';
+import Home from './routes/Home';
 
 const BrowserRouter = createBrowserRouter([
     {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -179,7 +179,10 @@ export default function ScheduleCalendar(props: ScheduleCalendarProps) {
     const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
     const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);
 
-    // If a final is on a Saturday or Sunday, let the calendar start on Saturday
+    /**
+     * If a final is on a Saturday or Sunday, let the calendar start on Saturday
+     */
+    // eslint-disable-next-line import/no-named-as-default-member -- moment doesn't expose named exports: https://github.com/vitejs/vite-plugin-react/issues/202
     moment.updateLocale('es-us', {
         week: {
             dow: hasWeekendCourse && showFinalsSchedule ? 6 : 0,

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -1,9 +1,8 @@
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
-import React, { PureComponent } from 'react';
-
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { ChangeEvent, PureComponent } from 'react';
 
 interface ScheduleSelectorProps {
     customEvent?: RepeatingCustomEvent;
@@ -21,7 +20,7 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
         scheduleIndices: this.props.scheduleIndices,
     };
 
-    handleChange = (dayIndex: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    handleChange = (dayIndex: number) => (event: ChangeEvent<HTMLInputElement>) => {
         const checked = event.target.checked;
 
         this.setState(

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -2,7 +2,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import { ChangeEvent, PureComponent } from 'react';
+import { PureComponent } from 'react';
 
 interface ScheduleSelectorProps {
     customEvent?: RepeatingCustomEvent;
@@ -20,7 +20,7 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
         scheduleIndices: this.props.scheduleIndices,
     };
 
-    handleChange = (dayIndex: number) => (event: ChangeEvent<HTMLInputElement>) => {
+    handleChange = (dayIndex: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
         const checked = event.target.checked;
 
         this.setState(

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/DeleteScheduleDialog.tsx
@@ -10,12 +10,12 @@ import {
     Box,
     Tooltip,
 } from '@material-ui/core';
-import { useState } from 'react';
 import { Clear } from '@material-ui/icons';
+import { useState } from 'react';
 
 import { deleteSchedule } from '$actions/AppStoreActions';
-import { useThemeStore } from '$stores/SettingsStore';
 import AppStore from '$stores/AppStore';
+import { useThemeStore } from '$stores/SettingsStore';
 
 interface DeleteScheduleDialogProps {
     onClose?: () => void;

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Add, Edit } from '@material-ui/icons';
-import { forwardRef, useCallback, useState, useMemo, MouseEvent, ChangeEvent, KeyboardEvent } from 'react';
+import { forwardRef, useCallback, useState, useMemo } from 'react';
 
 import { addSchedule, renameSchedule } from '$actions/AppStoreActions';
 import { useThemeStore } from '$stores/SettingsStore';
@@ -49,7 +49,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
 
     // We need to stop propagation so that the select menu won't close
     const handleOpen = useCallback(
-        (event: MouseEvent<HTMLLIElement>) => {
+        (event: React.MouseEvent) => {
             event.stopPropagation();
             setIsOpen(true);
             onOpen?.();
@@ -69,7 +69,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
         }
     }, [rename, scheduleNames, scheduleRenameIndex]);
 
-    const handleNameChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setScheduleName(event.target.value);
     }, []);
 
@@ -86,7 +86,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
     }, [onClose, rename, scheduleName, scheduleRenameIndex]);
 
     const handleKeyDown = useCallback(
-        (event: KeyboardEvent<HTMLDivElement>) => {
+        (event: React.KeyboardEvent) => {
             event.stopPropagation();
 
             if (event.key === 'Enter') {
@@ -125,7 +125,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
                 fullWidth
                 open={isOpen}
                 onKeyDown={handleKeyDown}
-                onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
+                onClick={(event: React.MouseEvent) => event.stopPropagation()}
                 onClose={() => setIsOpen(false)}
             >
                 <DialogTitle>{rename ? 'Rename Schedule' : 'Add a New Schedule'}</DialogTitle>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -1,4 +1,3 @@
-import { forwardRef, useCallback, useState, useMemo } from 'react';
 import {
     Button,
     Dialog,
@@ -13,6 +12,7 @@ import {
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { Add, Edit } from '@material-ui/icons';
+import { forwardRef, useCallback, useState, useMemo, MouseEvent, ChangeEvent, KeyboardEvent } from 'react';
 
 import { addSchedule, renameSchedule } from '$actions/AppStoreActions';
 import { useThemeStore } from '$stores/SettingsStore';
@@ -49,7 +49,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
 
     // We need to stop propagation so that the select menu won't close
     const handleOpen = useCallback(
-        (event: React.MouseEvent) => {
+        (event: MouseEvent<HTMLLIElement>) => {
             event.stopPropagation();
             setIsOpen(true);
             onOpen?.();
@@ -69,7 +69,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
         }
     }, [rename, scheduleNames, scheduleRenameIndex]);
 
-    const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleNameChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
         setScheduleName(event.target.value);
     }, []);
 
@@ -86,7 +86,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
     }, [onClose, rename, scheduleName, scheduleRenameIndex]);
 
     const handleKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             event.stopPropagation();
 
             if (event.key === 'Enter') {
@@ -125,7 +125,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
                 fullWidth
                 open={isOpen}
                 onKeyDown={handleKeyDown}
-                onClick={(event: React.MouseEvent<Element, MouseEvent>) => event.stopPropagation()}
+                onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
                 onClose={() => setIsOpen(false)}
             >
                 <DialogTitle>{rename ? 'Rename Schedule' : 'Add a New Schedule'}</DialogTitle>

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Popover, Tooltip } from '@material-ui/core';
 import { ColorLens } from '@material-ui/icons';
-import React, { PureComponent } from 'react';
+import { MouseEventHandler, PureComponent } from 'react';
 import { SketchPicker } from 'react-color';
 
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
@@ -26,7 +26,7 @@ class ColorPicker extends PureComponent<ColorPickerProps> {
         color: this.props.color,
     };
 
-    handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
         event.stopPropagation();
 
         this.setState({

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Popover, Tooltip } from '@material-ui/core';
 import { ColorLens } from '@material-ui/icons';
-import { MouseEventHandler, PureComponent } from 'react';
+import { PureComponent } from 'react';
 import { SketchPicker } from 'react-color';
 
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
@@ -26,7 +26,7 @@ class ColorPicker extends PureComponent<ColorPickerProps> {
         color: this.props.color,
     };
 
-    handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
         event.stopPropagation();
 
         this.setState({

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,10 +1,10 @@
-import { AppBar, Toolbar, useMediaQuery } from '@material-ui/core';
+import { AppBar, Toolbar } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 
 import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
-import Logo from './Logo';
+import { Logo } from './Logo';
 import AppDrawer from './SettingsMenu';
 
 const styles = {
@@ -35,8 +35,6 @@ interface CustomAppBarProps {
 }
 
 const Header = ({ classes }: CustomAppBarProps) => {
-    const isMobileScreen = useMediaQuery('(max-width:750px)');
-
     return (
         <AppBar position="static" className={classes.appBar}>
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -20,8 +20,7 @@ import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import TermSelector from '../RightPane/CoursePane/SearchForm/TermSelector';
 import RightPaneStore from '../RightPane/RightPaneStore';
 
-import { addCustomEvent, openSnackbar } from '$actions/AppStoreActions';
-import { addCourse } from '$actions/AppStoreActions';
+import { addCustomEvent, openSnackbar, addCourse } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseInfo } from '$lib/course_data.types';
 import { QueryZotcourseError } from '$lib/customErrors';

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -25,7 +25,7 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseInfo } from '$lib/course_data.types';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
-import WebSOC from '$lib/websoc';
+import { WebSOC } from '$lib/websoc';
 import { ZotcourseResponse, queryZotcourse } from '$lib/zotcourse';
 import AppStore from '$stores/AppStore';
 import { useThemeStore } from '$stores/SettingsStore';

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -93,5 +93,3 @@ export function Logo() {
         />
     );
 }
-
-export default Logo;

--- a/apps/antalmanac/src/components/Map/Marker.tsx
+++ b/apps/antalmanac/src/components/Map/Marker.tsx
@@ -1,8 +1,8 @@
-import { forwardRef, type Ref } from 'react';
-import Leaflet from 'leaflet';
-import { Marker, Popup } from 'react-leaflet';
-import { Box, Button, IconButton, Typography } from '@mui/material';
 import { DirectionsWalk as DirectionsWalkIcon, Info } from '@mui/icons-material';
+import { Box, Button, IconButton, Typography } from '@mui/material';
+import { type Marker, divIcon } from 'leaflet';
+import { forwardRef, type Ref } from 'react';
+import { Marker as ReactLeafletMarker, Popup } from 'react-leaflet';
 
 const GOOGLE_MAPS_URL = 'https://www.google.com/maps/dir/?api=1&travelmode=walking&destination=';
 const IMAGE_CMS_URL = 'https://cms.concept3d.com/map/lib/image-cache/i.php?mapId=463&image=';
@@ -11,7 +11,7 @@ const IMAGE_CMS_URL = 'https://cms.concept3d.com/map/lib/image-cache/i.php?mapId
  * returns a leaflet DivIcon that can replace the marker's default blue icon
  */
 function getMarkerIcon(color = '', stackIndex = 1, label = '') {
-    return Leaflet.divIcon({
+    return divIcon({
         /**
          * Adds offset to __marker__ for stacking markers.
          */
@@ -71,9 +71,9 @@ interface Props {
  * Custom map marker + popup with course info.
  */
 const LocationMarker = forwardRef(
-    ({ lat, lng, color, image, location, acronym, stackIndex, label, children }: Props, ref?: Ref<Leaflet.Marker>) => {
+    ({ lat, lng, color, image, location, acronym, stackIndex, label, children }: Props, ref?: Ref<Marker>) => {
         return (
-            <Marker
+            <ReactLeafletMarker
                 ref={ref}
                 position={[lat, lng]}
                 icon={getMarkerIcon(color, stackIndex, label)}
@@ -142,7 +142,7 @@ const LocationMarker = forwardRef(
                         </Box>
                     </Box>
                 </Popup>
-            </Marker>
+            </ReactLeafletMarker>
         );
     }
 );

--- a/apps/antalmanac/src/components/Map/Routes.tsx
+++ b/apps/antalmanac/src/components/Map/Routes.tsx
@@ -67,7 +67,7 @@ function createRouter(props: ClassRoutesProps, context: LeafletContextInterface)
                 extendToWaypoints: true,
                 missingRouteTolerance: 0,
                 styles: [
-                    { opacity: 0, weight: 30 }, // invisble line extends the range of click/hover events
+                    { opacity: 0, weight: 30 }, // invisible line extends the range of click/hover events
                     { color: props.color, weight: 3 },
                 ],
             });

--- a/apps/antalmanac/src/components/Map/Routes.tsx
+++ b/apps/antalmanac/src/components/Map/Routes.tsx
@@ -1,14 +1,15 @@
-import { useEffect } from 'react';
-import L from 'leaflet';
-import type { LatLngTuple } from 'leaflet';
-import 'leaflet-routing-machine';
 import { createElementHook, createElementObject, useLeafletContext } from '@react-leaflet/core';
 import type { LeafletContextInterface } from '@react-leaflet/core';
+import { latLng, Routing, popup } from 'leaflet';
+import type { LatLngTuple } from 'leaflet';
+import 'leaflet-routing-machine';
+import { useEffect } from 'react';
+
 import { MAPBOX_PROXY_DIRECTIONS_ENDPOINT } from '$lib/api/endpoints';
 
 interface ClassRoutesProps {
     /**
-     * Waypoints needs to be `L.Routing.Waypoint[]` or `LatLng[]` when creating an `L.Routing.plan`.
+     * Waypoints needs to be `Routing.Waypoint[]` or `LatLng[]` when creating an `Routing.plan`.
      * For ease of use from outside, pass in a valid `LatLngTuple[]`, and convert to LatLng inside.
      * @example [[33.6405, -117.8443], [33.6405, -117.8443]]
      */
@@ -36,10 +37,10 @@ function createRouter(props: ClassRoutesProps, context: LeafletContextInterface)
     /**
      * Convert each tuple to an actual `LatLng` object.
      */
-    const waypoints = latLngTuples.map((latLngTuple) => L.latLng(latLngTuple));
+    const waypoints = latLngTuples.map((latLngTuple) => latLng(latLngTuple));
 
-    const routerControl = L.Routing.control({
-        router: L.Routing.mapbox('', {
+    const routerControl = Routing.control({
+        router: Routing.mapbox('', {
             /**
              * Default is mapbox/driving. More options:
              * @see {@link https://docs.mapbox.com/api/navigation/directions/#routing-profiles}
@@ -55,13 +56,13 @@ function createRouter(props: ClassRoutesProps, context: LeafletContextInterface)
          */
         fitSelectedRoutes: false,
 
-        plan: L.Routing.plan(waypoints, {
+        plan: Routing.plan(waypoints, {
             addWaypoints: false,
             createMarker: dontCreateMarker,
         }),
 
         routeLine(route) {
-            const line = L.Routing.line(route, {
+            const line = Routing.line(route, {
                 addWaypoints: false,
                 extendToWaypoints: true,
                 missingRouteTolerance: 0,
@@ -96,26 +97,26 @@ function createRouter(props: ClassRoutesProps, context: LeafletContextInterface)
        <br>
        <span style="color:#888888">${miles}</span>
       `;
-            const popup = L.popup({ content, closeButton: false });
+            const leafletPopup = popup({ content, closeButton: false });
 
             /**
              * @see {@link https://github.com/perliedman/leaflet-routing-machine/issues/117}
              */
             line.eachLayer((lineLayer) => {
                 lineLayer.on('click', (leafletMouseEvent) => {
-                    popup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
+                    leafletPopup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
                 });
                 lineLayer.on('mouseover', (leafletMouseEvent) => {
-                    popup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
+                    leafletPopup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
                 });
                 lineLayer.on('mousemove', (leafletMouseEvent) => {
-                    popup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
+                    leafletPopup.setLatLng(leafletMouseEvent.latlng).addTo(context.map);
                 });
             });
 
             context.map.on('mousemove', (leafletMouseEvent) => {
                 if (!line.getBounds().contains(leafletMouseEvent.latlng)) {
-                    popup.remove();
+                    leafletPopup.remove();
                 }
             });
 

--- a/apps/antalmanac/src/components/Map/UserLocator.tsx
+++ b/apps/antalmanac/src/components/Map/UserLocator.tsx
@@ -1,12 +1,12 @@
-import L from 'leaflet';
-import 'leaflet.locatecontrol';
-import { useEffect } from 'react';
 import { createElementHook, createElementObject, useLeafletContext } from '@react-leaflet/core';
 import type { LeafletContextInterface } from '@react-leaflet/core';
+import { control } from 'leaflet';
+import 'leaflet.locatecontrol';
+import { useEffect } from 'react';
 
-function createUserLocator(_props: any, context: LeafletContextInterface) {
+function createUserLocator(_props: unknown, context: LeafletContextInterface) {
     const userLocator = createElementObject(
-        L.control.locate({
+        control.locate({
             position: 'topleft',
             flyTo: true,
             strings: {

--- a/apps/antalmanac/src/components/NotificationSnackbar.tsx
+++ b/apps/antalmanac/src/components/NotificationSnackbar.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-import { amber, green } from '@material-ui/core/colors';
 import IconButton from '@material-ui/core/IconButton';
+import { amber, green } from '@material-ui/core/colors';
 import { Theme, withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import CloseIcon from '@material-ui/icons/Close';
@@ -52,9 +51,7 @@ class NotificationSnackbar extends PureComponent<NotificationSnackbarProps> {
     openSnackbar = () => {
         this.props.enqueueSnackbar(AppStore.getSnackbarMessage(), {
             variant: AppStore.getSnackbarVariant(),
-            // shitty hack because notistack says it doesn't support `duration`, but this still runs without errors 🤷‍♂️
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
+            // @ts-expect-error notistack type claims it doesn't support `duration`, but this still runs without errors 🤷‍♂️
             duration: AppStore.getSnackbarDuration(),
             position: AppStore.getSnackbarPosition(),
             action: this.snackbarAction,

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -173,5 +173,3 @@ export function CoursePaneButtonRow(props: CoursePaneButtonRowProps) {
         </Box>
     );
 }
-
-export default CoursePaneButtonRow;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -11,7 +11,7 @@ import { openSnackbar } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import Grades from '$lib/grades';
 import WebSOC from '$lib/websoc';
-import useCoursePaneStore from '$stores/CoursePaneStore';
+import { useCoursePaneStore } from '$stores/CoursePaneStore';
 
 function RightPane() {
     const { key, forceUpdate, searchIsDisplayed, displaySearch, displaySections } = useCoursePaneStore();

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -3,14 +3,14 @@ import { useCallback, useEffect } from 'react';
 
 import RightPaneStore from '../RightPaneStore';
 
-import CoursePaneButtonRow from './CoursePaneButtonRow';
+import { CoursePaneButtonRow } from './CoursePaneButtonRow';
 import CourseRenderPane from './CourseRenderPane';
 import SearchForm from './SearchForm/SearchForm';
 
 import { openSnackbar } from '$actions/AppStoreActions';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
-import Grades from '$lib/grades';
-import WebSOC from '$lib/websoc';
+import { Grades } from '$lib/grades';
+import { WebSOC } from '$lib/websoc';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
 
 function RightPane() {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -17,15 +17,16 @@ import noNothing from './static/no_results.png';
 
 import { openSnackbar } from '$actions/AppStoreActions';
 import analyticsEnum from '$lib/analytics';
-import Grades from '$lib/grades';
+import { Grades } from '$lib/grades';
 import { getLocalStorageRecruitmentDismissalTime, setLocalStorageRecruitmentDismissalTime } from '$lib/localStorage';
-import WebSOC from '$lib/websoc';
+import { WebSOC } from '$lib/websoc';
 import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
 function getColors() {
-    const courseColors = AppStore.schedule.getCurrentCourses().reduce(
+    const currentCourses = AppStore.schedule.getCurrentCourses();
+    const courseColors = currentCourses.reduce(
         (accumulator, { section }) => {
             accumulator[section.sectionCode] = section.color;
             return accumulator;
@@ -275,7 +276,7 @@ export default function CourseRenderPane(props: { id?: number }) {
         return () => {
             setHoveredEvents(undefined);
         };
-    }, []);
+    }, [setHoveredEvents]);
 
     return (
         <>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/MobileDeptSelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/MobileDeptSelector.tsx
@@ -7,6 +7,7 @@ import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import { ChangeEvent, PureComponent } from 'react';
 
 import RightPaneStore from '../../../RightPaneStore';
+
 import depts from './depts';
 
 const style = {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -1,12 +1,13 @@
 import TextField from '@material-ui/core/TextField';
 import Autocomplete, { AutocompleteInputChangeReason } from '@material-ui/lab/Autocomplete';
 import { PureComponent } from 'react';
-import search from 'websoc-fuzzy-search';
 import UAParser from 'ua-parser-js';
+import search from 'websoc-fuzzy-search';
 
 type SearchResult = ReturnType<typeof search>;
 
 import RightPaneStore from '../../RightPaneStore';
+
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 
 const emojiMap: Record<string, string> = {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -124,9 +124,8 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
             case 'DEPARTMENT':
                 return `${emojiMap.DEPARTMENT} ${option}: ${object.name}`;
             case 'COURSE':
-                return `${emojiMap.COURSE} ${object.metadata.department} ${(object.metadata as any).number}: ${
-                    object.name
-                }`;
+                // @ts-expect-error type SearchResult.metadata can only be of type CourseMetaData in this case, but the type is not exposed so we can't cast directly
+                return `${emojiMap.COURSE} ${object.metadata.department} ${object.metadata.number}: ${object.name}`;
             case 'INSTRUCTOR':
                 return `${emojiMap.INSTRUCTOR} ${object.name}`;
             default:

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/TermSelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/TermSelector.tsx
@@ -2,6 +2,7 @@ import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
 import { ChangeEvent, useEffect, useState } from 'react';
 
 import RightPaneStore from '../../RightPaneStore';
+
 import { termData } from '$lib/termData';
 
 interface TermSelectorProps {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
@@ -3,11 +3,13 @@ import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { Skeleton } from '@material-ui/lab';
+import { RawResponse, Course, isErrorResponse, PrerequisiteTree } from 'peterportal-api-next-types';
 import { useState } from 'react';
 
-import { RawResponse, Course, isErrorResponse, PrerequisiteTree } from 'peterportal-api-next-types';
 import { MOBILE_BREAKPOINT } from '../../../globals';
+
 import PrereqTree from './PrereqTree';
+
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { PETERPORTAL_REST_ENDPOINT } from '$lib/api/endpoints';
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoBar.tsx
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { Skeleton } from '@material-ui/lab';
-import { RawResponse, Course, isErrorResponse, PrerequisiteTree } from 'peterportal-api-next-types';
+import { type RawResponse, type Course, isErrorResponse, type PrerequisiteTree } from 'peterportal-api-next-types';
 import { useState } from 'react';
 
 import { MOBILE_BREAKPOINT } from '../../../globals';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Paper, Popper, useMediaQuery } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import { ReactElement, useEffect, useState, MouseEvent } from 'react';
+import { useEffect, useState } from 'react';
 
 import { MOBILE_BREAKPOINT } from '../../../globals';
 
@@ -17,9 +17,9 @@ const styles = {
 interface CourseInfoButtonProps {
     classes: ClassNameMap;
     text: string;
-    icon: ReactElement;
+    icon: React.ReactElement;
     redirectLink?: string;
-    popupContent?: ReactElement;
+    popupContent?: React.ReactElement;
     analyticsAction: string;
     analyticsCategory: string;
 }
@@ -49,7 +49,7 @@ function CourseInfoButton({
         }
     }, [popupAnchor, analyticsCategory, analyticsAction]);
 
-    const handleMouseEnter = (event: MouseEvent<HTMLElement>) => {
+    const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
         // If there is popup content, allow the content to be shown when the button is hovered
         // Note that on mobile devices, hovering is not possible, so the popup still needs to be able
         // to appear when the button is clicked
@@ -72,7 +72,7 @@ function CourseInfoButton({
                 startIcon={!isMobileScreen && icon}
                 variant="contained"
                 size="small"
-                onClick={(event: MouseEvent<HTMLElement>) => {
+                onClick={(event: React.MouseEvent<HTMLElement>) => {
                     if (redirectLink) {
                         window.open(redirectLink);
                     }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfoButton.tsx
@@ -1,9 +1,10 @@
 import { Button, Paper, Popper, useMediaQuery } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import React, { useEffect, useState } from 'react';
+import { ReactElement, useEffect, useState, MouseEvent } from 'react';
 
 import { MOBILE_BREAKPOINT } from '../../../globals';
+
 import { logAnalytics } from '$lib/analytics';
 
 const styles = {
@@ -16,9 +17,9 @@ const styles = {
 interface CourseInfoButtonProps {
     classes: ClassNameMap;
     text: string;
-    icon: React.ReactElement;
+    icon: ReactElement;
     redirectLink?: string;
-    popupContent?: React.ReactElement;
+    popupContent?: ReactElement;
     analyticsAction: string;
     analyticsCategory: string;
 }
@@ -48,7 +49,7 @@ function CourseInfoButton({
         }
     }, [popupAnchor, analyticsCategory, analyticsAction]);
 
-    const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
+    const handleMouseEnter = (event: MouseEvent<HTMLElement>) => {
         // If there is popup content, allow the content to be shown when the button is hovered
         // Note that on mobile devices, hovering is not possible, so the popup still needs to be able
         // to appear when the button is clicked
@@ -71,7 +72,7 @@ function CourseInfoButton({
                 startIcon={!isMobileScreen && icon}
                 variant="contained"
                 size="small"
-                onClick={(event: React.MouseEvent<HTMLElement>) => {
+                onClick={(event: MouseEvent<HTMLElement>) => {
                     if (redirectLink) {
                         window.open(redirectLink);
                     }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -5,7 +5,7 @@ import RightPaneStore from '../RightPaneStore';
 import { SectionTableProps } from './SectionTable.types';
 import SectionTableLazyWrapper from './SectionTableLazyWrapper';
 
-import WebSOC from '$lib/websoc';
+import { WebSOC } from '$lib/websoc';
 
 /**
  * If we remove this class, when you search a department+GE combo, only the lectures show up, not the discussions.

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
 
 import RightPaneStore from '../RightPaneStore';
+
 import { SectionTableProps } from './SectionTable.types';
 import SectionTableLazyWrapper from './SectionTableLazyWrapper';
+
 import WebSOC from '$lib/websoc';
 
 /**

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -2,14 +2,14 @@ import { Box, Link, Typography, Skeleton } from '@mui/material';
 import { useState, useEffect, useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-import GradesHelper, { type Grades } from '$lib/grades';
+import { Grades, type GradesProps } from '$lib/grades';
 import { useThemeStore } from '$stores/SettingsStore';
 export interface GradeData {
     grades: {
         name: string;
         all: number;
     }[];
-    courseGrades: Grades;
+    courseGrades: GradesProps;
 }
 
 async function getGradeData(
@@ -17,7 +17,7 @@ async function getGradeData(
     courseNumber: string,
     instructor: string
 ): Promise<GradeData | undefined> {
-    const courseGrades = await GradesHelper.queryGrades(deptCode, courseNumber, instructor, false).catch((e) => {
+    const courseGrades = await Grades.queryGrades(deptCode, courseNumber, instructor, false).catch((e) => {
         console.error(e);
         return undefined;
     });

--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable prefer-const */
+import { Button, Popover } from '@material-ui/core';
 import { Prerequisite, PrerequisiteTree } from 'peterportal-api-next-types';
 import { FC, useState } from 'react';
-import { Button, Popover } from '@material-ui/core';
 
 import { CourseInfo } from './CourseInfoBar';
+
 import { useThemeStore } from '$stores/SettingsStore';
 
 import './PrereqTree.css';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import {
     Box,
     Paper,
@@ -13,15 +12,19 @@ import {
     useMediaQuery,
 } from '@material-ui/core';
 import { Assessment, Help, RateReview, ShowChart as ShowChartIcon } from '@material-ui/icons';
+import { useMemo } from 'react';
+
 import { MOBILE_BREAKPOINT } from '../../../globals';
+
 import CourseInfoBar from './CourseInfoBar';
 import CourseInfoButton from './CourseInfoButton';
 import { EnrollmentHistoryPopup } from './EnrollmentHistoryPopup';
 import GradesPopup from './GradesPopup';
 import { SectionTableProps } from './SectionTable.types';
 import SectionTableBody from './SectionTableBody';
-import useColumnStore, { SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
+
 import analyticsEnum from '$lib/analytics';
+import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
@@ -33,7 +36,7 @@ interface TableHeaderColumnDetails {
     width?: string;
 }
 
-const tableHeaderColumns: Record<SectionTableColumn, TableHeaderColumnDetails> = {
+const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHeaderColumnDetails> = {
     sectionCode: {
         label: 'Code',
         width: '8%',
@@ -112,10 +115,6 @@ function SectionTable(props: SectionTableProps) {
     const courseId = useMemo(() => {
         return courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     }, [courseDetails.deptCode, courseDetails.courseNumber]);
-
-    const encodedDept = useMemo(() => {
-        return encodeURIComponent(courseDetails.deptCode);
-    }, [courseDetails.deptCode]);
 
     /**
      * Limit table width to force side scrolling.

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
@@ -1,5 +1,4 @@
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-
 import { AACourse } from '@packages/antalmanac-types';
 
 /**

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
@@ -1,5 +1,5 @@
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
-import { AACourse } from '@packages/antalmanac-types';
+import type { AACourse } from '@packages/antalmanac-types';
 
 /**
  * This is in its own file so we can import it in SectionTableLazyWrapper without messing up the lazy-load.

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -31,7 +31,7 @@ import Grades from '$lib/grades';
 import { clickToCopy } from '$lib/helpers';
 import locationIds from '$lib/location_ids';
 import AppStore from '$stores/AppStore';
-import useColumnStore, { type SectionTableColumn } from '$stores/ColumnStore';
+import { useColumnStore, type SectionTableColumn } from '$stores/ColumnStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { usePreviewStore, useTimeFormatStore, useThemeStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody.tsx
@@ -27,7 +27,7 @@ import restrictionsMapping from './static/restrictionsMapping.json';
 
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { CourseDetails } from '$lib/course_data.types';
-import Grades from '$lib/grades';
+import { Grades } from '$lib/grades';
 import { clickToCopy } from '$lib/helpers';
 import locationIds from '$lib/location_ids';
 import AppStore from '$stores/AppStore';
@@ -480,6 +480,8 @@ interface SectionTableBodyProps {
     scheduleNames: string[];
 }
 
+// These components have too varied of types, any is fine here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     action: SectionActionCell,
     sectionCode: CourseCodeCell,
@@ -539,7 +541,7 @@ const SectionTableBody = withStyles(styles)((props: SectionTableBodyProps) => {
         } else {
             setHoveredEvents(section, courseDetails, term);
         }
-    }, [alreadyHovered, section, courseDetails, term]);
+    }, [previewMode, alreadyHovered, addedCourse, setHoveredEvents, section, courseDetails, term]);
 
     // Attach event listeners to the store.
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableLazyWrapper.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableLazyWrapper.tsx
@@ -1,9 +1,9 @@
-import React, { Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 
 import { SectionTableProps } from './SectionTable.types';
 
 // This should be in SectionTable.tsx, IMO
-const SectionTable = React.lazy(() => import('./SectionTable'));
+const SectionTable = lazy(() => import('./SectionTable'));
 
 export default function SectionTableLazyWrapper(props: SectionTableProps) {
     return (

--- a/apps/antalmanac/src/components/Tutorial.tsx
+++ b/apps/antalmanac/src/components/Tutorial.tsx
@@ -1,12 +1,11 @@
 import ReplayIcon from '@mui/icons-material/Replay';
 import { Fab, Tooltip } from '@mui/material';
-
 import { useTour } from '@reactour/tour';
-
 import { useEffect, useMemo } from 'react';
+
 import { stepsFactory, tourShouldRun } from '$lib/TutorialHelpers';
-import useCoursePaneStore from '$stores/CoursePaneStore';
 import { removeSampleClasses } from '$lib/tourExampleGeneration';
+import { useCoursePaneStore } from '$stores/CoursePaneStore';
 
 export function Tutorial() {
     const { setCurrentStep, setIsOpen, setSteps, isOpen } = useTour();

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from 'react';
 import {
     Button,
     Dialog,
@@ -8,9 +7,11 @@ import {
     DialogTitle,
     type DialogProps,
 } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+
 import { deleteSchedule } from '$actions/AppStoreActions';
-import { useThemeStore } from '$stores/SettingsStore';
 import AppStore from '$stores/AppStore';
+import { useThemeStore } from '$stores/SettingsStore';
 
 interface ScheduleNameDialogProps extends DialogProps {
     /**

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -42,12 +42,12 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
-    }, [onClose, index]);
+    }, [onClose]);
 
     const handleDelete = useCallback(() => {
         deleteSchedule(index);
         onClose?.({}, 'escapeKeyDown');
-    }, [index]);
+    }, [index, onClose]);
 
     return (
         <Dialog {...dialogProps}>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useState, useEffect, useMemo } from 'react';
 import {
     Box,
     Button,
@@ -9,6 +8,8 @@ import {
     TextField,
     type DialogProps,
 } from '@mui/material';
+import { useCallback, useState, useEffect, useMemo } from 'react';
+
 import { renameSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
 

--- a/apps/antalmanac/src/components/inputs/building-select.tsx
+++ b/apps/antalmanac/src/components/inputs/building-select.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+
 import buildingCatalogue, { Building } from '$lib/buildingCatalogue';
 
 export interface ExtendedBuilding extends Building {

--- a/apps/antalmanac/src/components/inputs/building-select.tsx
+++ b/apps/antalmanac/src/components/inputs/building-select.tsx
@@ -24,9 +24,12 @@ export type BuildingSelectProps = {
 };
 
 export function BuildingSelect(props: BuildingSelectProps) {
-    const handleChange = useCallback(async (_event: React.SyntheticEvent, value: ExtendedBuilding | null) => {
-        await props.onChange?.(value);
-    }, []);
+    const handleChange = useCallback(
+        async (_event: React.SyntheticEvent, value: ExtendedBuilding | null) => {
+            await props.onChange?.(value);
+        },
+        [props]
+    );
 
     const value = useMemo(() => {
         if (props.value == null) {

--- a/apps/antalmanac/src/components/inputs/building-select.tsx
+++ b/apps/antalmanac/src/components/inputs/building-select.tsx
@@ -24,11 +24,13 @@ export type BuildingSelectProps = {
 };
 
 export function BuildingSelect(props: BuildingSelectProps) {
+    const { onChange } = props;
+
     const handleChange = useCallback(
         async (_event: React.SyntheticEvent, value: ExtendedBuilding | null) => {
-            await props.onChange?.(value);
+            await onChange?.(value);
         },
-        [props]
+        [onChange]
     );
 
     const value = useMemo(() => {

--- a/apps/antalmanac/src/index.tsx
+++ b/apps/antalmanac/src/index.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+
 import App from './App';
 
 /**

--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -1,5 +1,6 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import superjson from 'superjson';
+
 import type { AppRouter } from '../../../../backend/src/routers';
 
 function getEndpoint() {

--- a/apps/antalmanac/src/lib/grades.ts
+++ b/apps/antalmanac/src/lib/grades.ts
@@ -1,4 +1,5 @@
 import { GE } from 'peterportal-api-next-types';
+
 import { queryGraphQL } from './helpers';
 
 export interface Grades {

--- a/apps/antalmanac/src/lib/grades.ts
+++ b/apps/antalmanac/src/lib/grades.ts
@@ -2,7 +2,7 @@ import { GE } from 'peterportal-api-next-types';
 
 import { queryGraphQL } from './helpers';
 
-export interface Grades {
+export interface GradesProps {
     averageGPA: number;
     gradeACount: number;
     gradeBCount: number;
@@ -13,7 +13,7 @@ export interface Grades {
     gradeNPCount: number;
 }
 
-export interface CourseInstructorGrades extends Grades {
+export interface CourseInstructorGrades extends GradesProps {
     department: string;
     courseNumber: string;
     instructor: string;
@@ -22,7 +22,7 @@ export interface CourseInstructorGrades extends Grades {
 export interface GradesGraphQLResponse {
     data: {
         aggregateGrades: {
-            gradeDistribution: Grades;
+            gradeDistribution: GradesProps;
         };
     };
 }
@@ -40,7 +40,7 @@ export interface GroupedGradesGraphQLResponse {
  * Note: Be careful with sending too many queries to the GraphQL API. It's not very fast and can be DoS'd easily.
  */
 class _Grades {
-    gradesCache: Record<string, Grades>;
+    gradesCache: Record<string, GradesProps>;
 
     // Grades queries that have been cached
     // We need this because gradesCache destructures the data and doesn't retain whether we looked at one course or a whole department/GE
@@ -133,7 +133,7 @@ class _Grades {
         courseNumber: string,
         instructor = '',
         cacheOnly = true
-    ): Promise<Grades | null> => {
+    ): Promise<GradesProps | null> => {
         instructor = instructor.replace('STAFF', '').trim(); // Ignore STAFF
         const instructorFilter = instructor ? `instructor: "${instructor}"` : '';
 
@@ -167,5 +167,4 @@ class _Grades {
     };
 }
 
-const grades = new _Grades();
-export default grades;
+export const Grades = new _Grades();

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -1,6 +1,7 @@
-import React from 'react';
+import { MouseEvent } from 'react';
 
 import { PETERPORTAL_GRAPHQL_ENDPOINT } from './api/endpoints';
+
 import { openSnackbar } from '$actions/AppStoreActions';
 
 export async function queryGraphQL<PromiseReturnType>(queryString: string): Promise<PromiseReturnType | null> {
@@ -34,7 +35,7 @@ export const warnMultipleTerms = (terms: Set<string>) => {
     );
 };
 
-export async function clickToCopy(event: React.MouseEvent<HTMLElement, MouseEvent>, sectionCode: string) {
+export async function clickToCopy(event: MouseEvent<HTMLElement>, sectionCode: string) {
     event.stopPropagation();
     await navigator.clipboard.writeText(sectionCode);
     openSnackbar('success', 'WebsocSection code copied to clipboard');

--- a/apps/antalmanac/src/lib/websoc.ts
+++ b/apps/antalmanac/src/lib/websoc.ts
@@ -212,5 +212,3 @@ class _WebSOC {
 }
 
 export const WebSOC = new _WebSOC();
-
-export default WebSOC;

--- a/apps/antalmanac/src/lib/websoc.ts
+++ b/apps/antalmanac/src/lib/websoc.ts
@@ -1,4 +1,5 @@
 import type { WebsocAPIResponse, WebsocSectionMeeting } from 'peterportal-api-next-types';
+
 import { PETERPORTAL_WEBSOC_ENDPOINT } from './api/endpoints';
 import type { CourseInfo } from './course_data.types';
 

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
 import { createTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
+import { useEffect } from 'react';
 
 import { useThemeStore } from '$stores/SettingsStore';
 

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo } from 'react';
 import { createTheme, CssBaseline, ThemeProvider, type PaletteOptions } from '@mui/material';
+import { useEffect, useMemo } from 'react';
 
 import { useThemeStore } from '$stores/SettingsStore';
 

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -65,5 +65,3 @@ export const useColumnStore = create<ColumnStore>((set, _) => {
         },
     };
 });
-
-export default useColumnStore;

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -45,5 +45,3 @@ export const useCoursePaneStore = create<CoursePaneStore>((set) => {
         forceUpdate: () => set((state) => ({ key: (state.key += 1) })),
     };
 });
-
-export default useCoursePaneStore;

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -11,7 +11,7 @@ import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } f
 
 import type { CourseInfo } from '$lib/course_data.types';
 import { termData } from '$lib/termData';
-import WebSOC from '$lib/websoc';
+import { WebSOC } from '$lib/websoc';
 import { getColorForNewSection } from '$stores/scheduleHelpers';
 
 /**

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -1,9 +1,9 @@
-import { ScheduleCourse } from '@packages/antalmanac-types';
+import { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-types';
 import { HourMinute } from 'peterportal-api-next-types';
-import { RepeatingCustomEvent } from '@packages/antalmanac-types';
+
 import { CourseEvent, CustomEvent, Location } from '$components/Calendar/CourseCalendarEvent';
-import { notNull, getReferencesOccurring } from '$lib/utils';
 import { getFinalsStartForTerm } from '$lib/termData';
+import { notNull, getReferencesOccurring } from '$lib/utils';
 
 export const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -1,4 +1,4 @@
-import { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-types';
+import type { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-types';
 import { HourMinute } from 'peterportal-api-next-types';
 
 import { CourseEvent, CustomEvent, Location } from '$components/Calendar/CourseCalendarEvent';
@@ -101,7 +101,9 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              *
              * @example [false, false, false, true, false, true, false] -> [3, 5]
              */
-            const dayIndicesOcurring = weekdaysOccurring.map((day, index) => (day ? index : undefined)).filter(notNull);
+            const dayIndicesOccurring = weekdaysOccurring
+                .map((day, index) => (day ? index : undefined))
+                .filter(notNull);
 
             const locationsWithNoDays = bldg ? bldg.map(getLocation) : course.section.meetings[0].bldg.map(getLocation);
 
@@ -111,7 +113,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              */
             const [finalsYear, finalsMonth, finalsDay] = [...(getFinalsStartForTerm(course.term) ?? [2018, 0])];
 
-            return dayIndicesOcurring.map((dayIndex) => ({
+            return dayIndicesOccurring.map((dayIndex) => ({
                 color: course.section.color,
                 term: course.term,
                 title: `${course.deptCode} ${course.courseNumber}`,
@@ -151,14 +153,14 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
 
 export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
     return currentCustomEvents.flatMap((customEvent) => {
-        const dayIndiciesOcurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
+        const dayIndicesOccurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
         /**
          * Only include the day strings that the custom event occurs.
          *
          * @example [1, 3, 5] -> ['M', 'W', 'F']
          */
-        const days = dayIndiciesOcurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
-        return dayIndiciesOcurring.map((dayIndex) => {
+        const days = dayIndicesOccurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
+        return dayIndicesOccurring.map((dayIndex) => {
             const startHour = parseInt(customEvent.start.slice(0, 2), 10);
             const startMin = parseInt(customEvent.start.slice(3, 5), 10);
             const endHour = parseInt(customEvent.end.slice(0, 2), 10);


### PR DESCRIPTION
## Summary
> ✖ 101 problems (66 errors, 35 warnings)
  59 errors and 2 warnings potentially fixable with the `--fix` option.

> ✖ 3 problems (0 errors, 3 warnings)

1. This PR resolves almost 100 eslint problems (the remainder are ones where I didn't feel confident touching on components relating to `Map`) 
2. Broadly, most of these errors and warnings fall into a few buckets:
    - Import Order
    - Default Exports
    - Type errors (`any`)
    - Exhaustive Deps

## Test Plan
1. These changes do span a lot of files, but no business logic has been changed (aside from useEffect/useCallback dependencies). Potential tests would just be clicking around and validating big features haven't regressed
