### PR TITLE
fix(download.ts): set events as PRIVATE by default

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -279,6 +279,7 @@ export function getEventsFromCourses(
                 // location: `${location.building} ${location.room}`,
                 start: firstClassStart,
                 end: firstClassEnd,
+                classification: 'PRIVATE',
                 recurrenceRule: rrule,
             };
             return customEvent;
@@ -302,6 +303,7 @@ export function getEventsFromCourses(
                             description: `Final Exam for ${courseTitle}`,
                             start: finalStart,
                             end: finalEnd,
+                            classification: 'PRIVATE',
                         };
                     } else {
                         const classStartDate = getClassStartDate(term, days);
@@ -324,6 +326,7 @@ export function getEventsFromCourses(
                             location: `${location.building} ${location.room}`,
                             start: firstClassStart,
                             end: firstClassEnd,
+                            classification: 'PRIVATE',
                             recurrenceRule: rrule,
                         };
                     }


### PR DESCRIPTION
## Summary

I opened #963 a few months ago when I noticed that Google Calendar events imported from AntAlmanac were public for anybody with my UCI email to see. This concerned me because this meant people would know exactly where I'd be and when.

This fixes the issue by setting the `classification` attribute to `PRIVATE` on the events in the `calendarEvents` array, making the event private.

## Test Plan

I tested this by downloading the `.ics` file using a development environment of AntAlmanac with my changes and importing it to my Google Calendar, and successfully saw that it was a private event by default.

![Photo of a private event imported from AntAlmanac.](https://github.com/user-attachments/assets/c1aa5580-3e97-47ef-9871-32131aec7f0e)

... no I'm not taking ICS 6B. I can *never* go through that again...

## Issues

Closes #963
