### PR TITLE
feat(download.ts): add location attribute to custom events

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -7,6 +7,7 @@ import { notNull } from './utils';
 import { openSnackbar } from '$actions/AppStoreActions';
 import { CustomEvent, FinalExam } from '$components/Calendar/CourseCalendarEvent';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import buildingCatalogue from '$lib/buildingCatalogue';
 import { getDefaultTerm, termData } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 
@@ -261,7 +262,7 @@ export function getEventsFromCourses(
         if (event.isCustomEvent) {
             // FIXME: We don't have a way to get the term for custom events,
             // so we just use the default term.
-            const { title, start, end } = event as CustomEvent;
+            const { title, start, end, building } = event as CustomEvent;
             const days = getByDays(event.days.join(''));
             const rrule = getRRule(days, getQuarter(term));
             const eventStartDate = getClassStartDate(term, days);
@@ -275,8 +276,7 @@ export function getEventsFromCourses(
                 startOutputType: 'local' as const,
                 endOutputType: 'local' as const,
                 title: title,
-                // TODO: Add location to custom events, waiting for https://github.com/icssc/AntAlmanac/issues/249
-                // location: `${location.building} ${location.room}`,
+                location: buildingCatalogue[Number(building)].name,
                 start: firstClassStart,
                 end: firstClassEnd,
                 recurrenceRule: rrule,


### PR DESCRIPTION
## Summary

I noticed a TODO asking to implement a location for custom events once #249 was finished. I noticed that the issue was completed so I went ahead and implemented it.

Though... it looks a bit funky because `CustomEvent.building` saves an ID instead of the actual building name. This happens in `CustomEventDialog.tsx` because it needs a key for the list that's needed in `BuildingSelect`. Though I noticed that `BuildingSelect` gets the name of the building using the format I used here.

## Test Plan

I tested this by creating a custom event and downloading a `.ics`. I then imported it to Google Calendar and saw that the location of the event was successfully added.

![Google Calendar event displaying a successfully added location to an event.](https://github.com/user-attachments/assets/0b567635-a158-425c-ac23-027da72cafe2)


## Issues

N/A, but addresses this line in the code:

https://github.com/icssc/AntAlmanac/blob/559b615c2d92ea5c5fa3965c6360abaefe23c830/apps/antalmanac/src/lib/download.ts#L278-L279

## Future Follow-Up
- #1010 