### PR TITLE
fix: default colors deplete too rapidly

### DIFF
--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -167,23 +167,20 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
         (course) => course.section.sectionType === newSection.section.sectionType
     );
 
-    const usedColors = new Set(sectionsInSchedule.map((course) => course.section.color));
+    const usedColors = sectionsInSchedule.map((course) => course.section.color);
+    const lastDefaultColor = usedColors.findLast((materialColor) =>
+        (defaultColors as string[]).includes(materialColor)
+    ) as unknown as (typeof defaultColors)[number];
 
     // If the same sectionType exists, return that color
     if (existingSectionsType.length > 0) return existingSectionsType[0].section.color;
 
     // If the same courseTitle exists, but not the same sectionType, return a close color
-    if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, usedColors);
+    if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, new Set(usedColors));
 
-    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return the next color after the last one in use, looping after reaching the end.
+    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return the next color up after the last default color in use, looping after reaching the end.
     return (
-        defaultColors.find((materialColor) => !usedColors.has(materialColor)) ||
-        defaultColors[
-            (defaultColors.indexOf(
-                sectionsInSchedule[sectionsInSchedule.length - 1].section.color as (typeof defaultColors)[number]
-            ) +
-                1) %
-                7
-        ]
+        defaultColors.find((materialColor) => !usedColors.includes(materialColor)) ||
+        defaultColors[(defaultColors.indexOf(lastDefaultColor) + 1) % 7]
     );
 }

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -181,6 +181,6 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return the next color up after the last default color in use, looping after reaching the end.
     return (
         defaultColors.find((materialColor) => !usedColors.includes(materialColor)) ||
-        defaultColors[(defaultColors.indexOf(lastDefaultColor) + 1) % 7]
+        defaultColors[(defaultColors.indexOf(lastDefaultColor) + 1) % defaultColors.length]
     );
 }

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -175,9 +175,15 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     // If the same courseTitle exists, but not the same sectionType, return a close color
     if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, usedColors);
 
-    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return a random one that's been used already.
+    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return the next color after the last one in use, looping after reaching the end.
     return (
         defaultColors.find((materialColor) => !usedColors.has(materialColor)) ||
-        defaultColors[Math.floor(Math.random() * defaultColors.length)]
+        defaultColors[
+            (defaultColors.indexOf(
+                sectionsInSchedule[sectionsInSchedule.length - 1].section.color as (typeof defaultColors)[number]
+            ) +
+                1) %
+                7
+        ]
     );
 }


### PR DESCRIPTION
## Summary
Adjusted color selection to work by linear assignment from the 8th course onward. This is done by determining the color of the most recent class added and choosing the color directly after it in the defaultColors list (looping back around to the first color when needed).
## Test Plan
- Ensure that the assignment works properly when classes are deleted out of order.
- Ensure assignment works when users select custom colors for courses (this in particular poses an issue).
## Issues

Closes #647 

## Future Followup
There can still be some imbalance in colors if many classes are added and some deleted--if keeping all the colors even is a priority we could auto-update the colors of previously added classes, but that may be unnecessary or overkill. Can also add to the original 7-color palette if desired.