### PR TITLE
Fix: Default Colors deplete too Rapidly

### DIFF
--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -175,9 +175,19 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     // If the same courseTitle exists, but not the same sectionType, return a close color
     if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, usedColors);
 
-    // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return a random one that's been used already.
-    return (
-        defaultColors.find((materialColor) => !usedColors.has(materialColor)) ||
-        defaultColors[Math.floor(Math.random() * defaultColors.length)]
-    );
+    // If there are no existing sections with the same course title, generate a new color.
+    // If we run out of unique colors, reuse the earliest assigned default color, treating it as an unused color.
+
+    let unusedColor: defaultColors.find((materialColor) => !usedColors.has(materialColor));
+    if (!unusedColor) return unusedColor;
+
+    for (const usedColor of usedColors) {
+        if (usedColor in defaultColors) {
+            usedColors.delete(usedColor);
+            break;
+        }
+    }
+
+    return defaultColors.find((materialColor) => !usedColors.has(materialColor));
+        
 }


### PR DESCRIPTION
## Summary
This fix adjusts color selection by treating the earliest used default color as unused and reusing it if every default color is in use.
## Test Plan
* Ensure that the assignment works properly when classes are deleted out of order.
* Ensure assignment works when users select changing the colors of courses, particularly to a default color.
## Issues

Closes #647

