### PR TITLE
feat: encode/decode advanced search in URL

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -103,24 +103,42 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
     };
 
     handleChange = (name: string) => (event: ChangeEvent<{ checked?: boolean; name?: string; value: unknown }>) => {
+        const stateObj = { url: 'url' };
+        const url = new URL(window.location.href);
+        const urlParam = new URLSearchParams(url.search);
+
         if (name === 'online') {
             if (event.target.checked) {
                 this.setState({ building: 'ON', room: 'LINE' });
                 RightPaneStore.updateFormValue('building', 'ON');
                 RightPaneStore.updateFormValue('room', 'LINE');
+
+                urlParam.set('building', 'ON');
+                urlParam.set('room', 'LINE');
             } else {
                 this.setState({ building: '', room: '' });
                 RightPaneStore.updateFormValue('building', '');
                 RightPaneStore.updateFormValue('room', '');
+
+                urlParam.delete('building');
+                urlParam.delete('room');
             }
         } else {
+            const value = event.target.value;
             this.setState({ [name]: event.target.value } as unknown as AdvancedSearchTextFieldsState);
+
+            urlParam.set(name, String(value));
+
             RightPaneStore.updateFormValue(name, event.target.value as string);
         }
+
+        const param = urlParam.toString();
+        const new_url = `${param.trim() ? '?' : ''}${param}`;
+        history.replaceState(stateObj, 'url', '/' + new_url);
     };
 
     /**
-     * UPDATE (6-28-19): Transfered course code and course number search boxes to
+     * UPDATE (6-28-19): Transferred course code and course number search boxes to
      * separate classes.
      */
     render() {
@@ -294,8 +312,22 @@ class AdvancedSearch extends PureComponent<AdvancedSearchProps, AdvancedSearchSt
         super(props);
 
         let advanced = false;
+
         if (typeof Storage !== 'undefined') {
             advanced = getLocalStorageAdvanced() === 'expanded';
+        }
+
+        const formData = RightPaneStore.getFormData();
+        const defaultFormData = RightPaneStore.getDefaultFormData();
+        for (const [key, value] of Object.entries(formData)) {
+            if (key === 'deptLabel' || key === 'deptValue') {
+                continue;
+            }
+
+            if (defaultFormData[key] != value) {
+                advanced = true;
+                break;
+            }
         }
 
         this.state = {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -127,7 +127,11 @@ class UnstyledAdvancedSearchTextFields extends PureComponent<
             const value = event.target.value;
             this.setState({ [name]: event.target.value } as unknown as AdvancedSearchTextFieldsState);
 
-            urlParam.set(name, String(value));
+            if (value !== '') {
+                urlParam.set(name, String(value));
+            } else {
+                urlParam.delete(name);
+            }
 
             RightPaneStore.updateFormValue(name, event.target.value as string);
         }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch.tsx
@@ -339,6 +339,29 @@ class AdvancedSearch extends PureComponent<AdvancedSearchProps, AdvancedSearchSt
         };
     }
 
+    componentDidMount() {
+        RightPaneStore.on('formReset', this.resetParams);
+    }
+
+    resetParams() {
+        const stateObj = { url: 'url' };
+        const url = new URL(window.location.href);
+        const urlParam = new URLSearchParams(url.search);
+
+        const formData = RightPaneStore.getFormData();
+        for (const key of Object.keys(formData)) {
+            if (key === 'deptLabel' || key === 'deptValue') {
+                continue;
+            }
+
+            urlParam.delete(key);
+        }
+
+        const param = urlParam.toString();
+        const new_url = `${param.trim() ? '?' : ''}${param}`;
+        history.replaceState(stateObj, 'url', '/' + new_url);
+    }
+
     handleExpand = () => {
         const nextExpansionState = !this.state.expandAdvanced;
         setLocalStorageAdvanced(nextExpansionState ? 'expanded' : 'notexpanded');

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LegacySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LegacySearch.tsx
@@ -18,7 +18,7 @@ const styles: Styles<Theme, object> = {
         display: 'inline-flex',
         cursor: 'pointer',
         marginTop: 20,
-        marginBotton: 10,
+        marginBottom: 10,
     },
     search: {
         display: 'flex',

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -56,7 +56,7 @@ class RightPaneStore extends EventEmitter {
         const formFields = Object.keys(defaultFormValues);
 
         formFields.forEach((field) => {
-            const paramValue = search.get(field);
+            const paramValue = search.get(field) || search.get(field.toUpperCase());
             if (paramValue !== null) {
                 this.formData[field] = paramValue;
             }

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -48,10 +48,29 @@ class RightPaneStore extends EventEmitter {
         this.urlCourseNumValue = search.get('courseNumber') || '';
         this.urlDeptLabel = search.get('deptLabel') || '';
         this.urlDeptValue = search.get('deptValue') || '';
+
+        this.updateFormDataFromURL(search);
     }
+
+    updateFormDataFromURL = (search: URLSearchParams) => {
+        const formFields = Object.keys(defaultFormValues);
+
+        formFields.forEach((field) => {
+            const paramValue = search.get(field);
+            if (paramValue !== null) {
+                this.formData[field] = paramValue;
+            }
+        });
+
+        this.emit('formDataChange');
+    };
 
     getFormData = () => {
         return this.formData;
+    };
+
+    getDefaultFormData = () => {
+        return defaultFormValues;
     };
 
     getOpenSpotAlertPopoverActive = () => {

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -42,9 +42,17 @@ function paramsAreInURL() {
     return searchParams.some((param) => search.get(param) !== null);
 }
 
+function requiredParamsAreInURL() {
+    const search = new URLSearchParams(window.location.search);
+
+    const searchParams = ['courseCode', 'courseNumber', 'GE', 'deptValue'];
+
+    return searchParams.some((param) => search.get(param) !== null);
+}
+
 export const useCoursePaneStore = create<CoursePaneStore>((set) => {
     return {
-        searchIsDisplayed: true,
+        searchIsDisplayed: requiredParamsAreInURL() ? false : true,
         displaySearch: () => {
             set({ searchIsDisplayed: true });
         },

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -21,7 +21,23 @@ function paramsAreInURL() {
     const search = new URLSearchParams(window.location.search);
 
     // TODO: This should be standardized
-    const searchParams = ['courseCode', 'courseNumber', 'deptLabel', 'GE', 'deptValue', 'term'];
+    const searchParams = [
+        'courseCode',
+        'courseNumber',
+        'deptLabel',
+        'GE',
+        'deptValue',
+        'term',
+        'sectionCode',
+        'instructor',
+        'units',
+        'endTime',
+        'startTime',
+        'coursesFull',
+        'building',
+        'room',
+        'division',
+    ];
 
     return searchParams.some((param) => search.get(param) !== null);
 }


### PR DESCRIPTION
## Summary
1. Encode advanced search into the URL
2. Decode params and apply accordingly
    - Open advanced search if params exist
  
![chrome-capture-2024-9-24](https://github.com/user-attachments/assets/6b713696-4dfe-4572-99c5-3defbd8f3f62)

## Test Plan
1. Test that params are correctly applied, and when used for search, are correct

## Issues
- Closes #558 

## Future Followup
- Have a `/search` route which executes the search immediately.