### PR TITLE
Added handling for custom events download

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -257,6 +257,7 @@ export function getEventsFromCourses(
     events = AppStore.getEventsWithFinalsInCalendar(),
     term = getDefaultTerm(events).shortName
 ): EventAttributes[] {
+    const customEventIDs = new Set();
     const calendarEvents = events.flatMap((event) => {
         if (event.isCustomEvent) {
             // FIXME: We don't have a way to get the term for custom events,
@@ -270,6 +271,11 @@ export function getEventsFromCourses(
                 { hour: start.getHours(), minute: start.getMinutes() },
                 { hour: end.getHours(), minute: end.getMinutes() }
             );
+            const customEventID = event.customEventID;
+            if (customEventIDs.has(customEventID)) {
+                return [];
+            }
+            customEventIDs.add(customEventID);
             const customEvent: EventAttributes = {
                 productId: 'antalmanac/ics',
                 startOutputType: 'local' as const,


### PR DESCRIPTION
## Summary
I added `const customEventIDs = new Set();`, where it'll be populated with `const customEventID = event.customEventID;`. Each Custom Event object was created with a specific ID, even if it was on multiple days it'll be the same, so then when it maps to download, it shouldn't repeat the custom events.
This is a custom event created for Tuesday and Wednesday.
~~~
SUMMARY:FIX TEST
DTSTAMP:20241027T205447Z
DTSTART;TZID=America/Los_Angeles:20241001T103000
DTEND;TZID=America/Los_Angeles:20241001T153000
RRULE:FREQ=WEEKLY;BYDAY=TU,WE;INTERVAL=1;COUNT=20
END:VEVENT
END:VCALENDAR       
~~~
This is what it appears like on Google Calendar
<img src=https://github.com/user-attachments/assets/a1074bc7-9465-405c-bf25-6e63a3a3aef1 width="500px"/>


Closes #1010 