### PR TITLE
fix: enable scroll-y

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -212,7 +212,7 @@ export default function ScheduleCalendar(_props?: ScheduleCalendarProps) {
     }, []);
 
     return (
-        <Box id="calendar-root" borderRadius={1} flexGrow={1} height={0} display="flex" flexDirection="column">
+        <Box id="calendar-root" borderRadius={1} flexGrow={1} height={'0px'} display="flex" flexDirection="column">
             <CalendarToolbar
                 currentScheduleIndex={currentScheduleIndex}
                 toggleDisplayFinalsSchedule={toggleDisplayFinalsSchedule}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -54,7 +54,7 @@ function RightPane() {
     }, [handleKeydown]);
 
     return (
-        <Box height={0} flexGrow={1} marginX={0.5}>
+        <Box height={'0px'} flexGrow={1} marginX={0.5}>
             <CoursePaneButtonRow
                 showSearch={!searchIsDisplayed}
                 onDismissSearchResults={displaySearch}


### PR DESCRIPTION
## Summary
1. Changes in #1001 broke vertical scrolling on Dekstop
2. This PR fixes those problems 

## Test Plan
1. AA's desktop panels (left, right) should scroll appropriately on smaller view heights

![chrome-capture-2024-10-3](https://github.com/user-attachments/assets/d0f0f41c-5b06-4d7c-afbc-6ef6ee04c324)
