### PR TITLE
style: correct tab colors on light mode

### DIFF
--- a/apps/antalmanac/src/components/SharedRoot.tsx
+++ b/apps/antalmanac/src/components/SharedRoot.tsx
@@ -124,6 +124,7 @@ function ScheduleManagementMobileTabs(props: ScheduleManagementTabsProps) {
  */
 function ScheduleManagementDesktopTabs(props: ScheduleManagementTabsProps) {
     const { value, setActiveTab } = props;
+    const isDark = useThemeStore((store) => store.isDark);
 
     const onChange = (_event: React.SyntheticEvent, value: number) => {
         setActiveTab(value + 1);
@@ -145,7 +146,7 @@ function ScheduleManagementDesktopTabs(props: ScheduleManagementTabsProps) {
                             height: '44px',
                             padding: 3,
                             minWidth: '33%',
-                            '&.Mui-selected': { color: 'white' },
+                            ...(isDark ? { '&.Mui-selected': { color: 'white' } } : {}),
                         }}
                         label={
                             <div style={{ display: 'inline-flex', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary
1. On light mode, white tab text color was unreadable. This PR fixes that.

Before:
<img width="974" alt="Screenshot 2024-11-05 at 11 14 53 AM" src="https://github.com/user-attachments/assets/ad61420b-82fc-4f43-b47c-7bba9d0df178">

After:
<img width="978" alt="Screenshot 2024-11-05 at 11 15 01 AM" src="https://github.com/user-attachments/assets/7bd64561-c718-4ba0-8b2c-c4de62736fe8">

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
