### PR TITLE
968 create error page

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -10,6 +10,7 @@ import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
+import Error from './routes/Error';
 import Feedback from './routes/Feedback';
 import Home from './routes/Home';
 
@@ -17,14 +18,17 @@ const BrowserRouter = createBrowserRouter([
     {
         path: '/',
         element: <Home />,
+        errorElement: <Error />,
     },
     {
         path: '/:tab',
         element: <Home />,
+        errorElement: <Error />,
     },
     {
         path: '/feedback',
         element: <Feedback />,
+        errorElement: <Error />,
     },
 ]);
 

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -10,7 +10,7 @@ import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
-import Error from './routes/Error';
+import { Error } from './routes/Error';
 import Feedback from './routes/Feedback';
 import Home from './routes/Home';
 

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -10,7 +10,7 @@ import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
-import { ErrorPage } from './routes/Error';
+import { ErrorPage } from './routes/ErrorPage';
 import Feedback from './routes/Feedback';
 import Home from './routes/Home';
 

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -10,7 +10,7 @@ import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
-import { Error } from './routes/Error';
+import { ErrorPage } from './routes/Error';
 import Feedback from './routes/Feedback';
 import Home from './routes/Home';
 
@@ -18,17 +18,17 @@ const BrowserRouter = createBrowserRouter([
     {
         path: '/',
         element: <Home />,
-        errorElement: <Error />,
+        errorElement: <ErrorPage />,
     },
     {
         path: '/:tab',
         element: <Home />,
-        errorElement: <Error />,
+        errorElement: <ErrorPage />,
     },
     {
         path: '/feedback',
         element: <Feedback />,
-        errorElement: <Error />,
+        errorElement: <ErrorPage />,
     },
 ]);
 

--- a/apps/antalmanac/src/routes/Error.tsx
+++ b/apps/antalmanac/src/routes/Error.tsx
@@ -1,35 +1,48 @@
 import { Typography, Button, Stack } from '@mui/material';
+import { useRouteError } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 
-export const Error = () => (
-    <Stack
-        spacing={3}
-        sx={{
-            padding: '1rem',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            flexDirection: 'column',
-            height: '100vh',
-            textAlign: 'center',
-        }}
-    >
-        <Typography variant="h3" component="h1">
-            Oops! Something went wrong.
-        </Typography>
-        <Stack spacing={2} sx={{ paddingY: '1rem' }}>
-            <Typography variant="h5" component="p">
-                This error may be caused by your browser having an out of date version of AntAlmanac.
+export const ErrorPage = () => {
+    const error = useRouteError();
+
+    return (
+        <Stack
+            spacing={3}
+            sx={{
+                padding: '1rem',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'column',
+                height: '100vh',
+                gap: 2,
+            }}
+        >
+            <Typography variant="h3" component="h1">
+                Oops! Something went wrong.
             </Typography>
-            <Typography variant="h5" component="p">
-                Try refreshing the page. If the error persists, please submit a{' '}
-                <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link>
-            </Typography>
+            <Stack spacing={2} sx={{ textAlign: 'center' }}>
+                <Typography variant="h5" component="p">
+                    This error may be caused by your browser having an out of date version of AntAlmanac.
+                </Typography>
+                <Typography variant="h5" component="p">
+                    Try refreshing the page. If the error persists, please submit a{' '}
+                    <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error
+                </Typography>
+            </Stack>
+            <Link to="/">
+                <Button variant="contained" size="large">
+                    Back to Home
+                </Button>
+            </Link>
+            <details open>
+                <summary>View Error Message</summary>
+                <p>
+                    {error instanceof Error && (
+                        <pre>{error.stack}</pre> // Display stack trace only in development mode
+                    )}
+                </p>
+            </details>
         </Stack>
-        <Link to="/">
-            <Button variant="contained" size="large">
-                Back to Home
-            </Button>
-        </Link>
-    </Stack>
-);
+    );
+};

--- a/apps/antalmanac/src/routes/Error.tsx
+++ b/apps/antalmanac/src/routes/Error.tsx
@@ -1,14 +1,25 @@
-import { Typography, Button, Stack, Box } from '@mui/material';
+import { Typography, Button, Stack } from '@mui/material';
 import { Link } from 'react-router-dom';
 
-const ErrorPage = () => (
-    <Box sx={{ padding: '1rem' }}>
+export const Error = () => (
+    <Stack
+        spacing={3}
+        sx={{
+            padding: '1rem',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexDirection: 'column',
+            height: '100vh',
+            textAlign: 'center',
+        }}
+    >
         <Typography variant="h3" component="h1">
-            Oops! Something went wrong 🥺 👉👈
+            Oops! Something went wrong.
         </Typography>
         <Stack spacing={2} sx={{ paddingY: '1rem' }}>
             <Typography variant="h5" component="p">
-                This error may be caused by you having an out of date version of AntAlmanac.
+                This error may be caused by your browser having an out of date version of AntAlmanac.
             </Typography>
             <Typography variant="h5" component="p">
                 Try refreshing the page. If the error persists, please submit a{' '}
@@ -17,9 +28,8 @@ const ErrorPage = () => (
         </Stack>
         <Link to="/">
             <Button variant="contained" size="large">
-                Reload
+                Back to Home
             </Button>
         </Link>
-    </Box>
+    </Stack>
 );
-export default ErrorPage;

--- a/apps/antalmanac/src/routes/Error.tsx
+++ b/apps/antalmanac/src/routes/Error.tsx
@@ -1,0 +1,7 @@
+const ErrorPage = () => (
+    <div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+    </div>
+);
+export default ErrorPage;

--- a/apps/antalmanac/src/routes/Error.tsx
+++ b/apps/antalmanac/src/routes/Error.tsx
@@ -1,7 +1,25 @@
+import { Typography, Button, Stack, Box } from '@mui/material';
+import { Link } from 'react-router-dom';
+
 const ErrorPage = () => (
-    <div>
-        <h1>404</h1>
-        <p>The page you are looking for does not exist.</p>
-    </div>
+    <Box sx={{ padding: '1rem' }}>
+        <Typography variant="h3" component="h1">
+            Oops! Something went wrong 🥺 👉👈
+        </Typography>
+        <Stack spacing={2} sx={{ paddingY: '1rem' }}>
+            <Typography variant="h5" component="p">
+                This error may be caused by you having an out of date version of AntAlmanac.
+            </Typography>
+            <Typography variant="h5" component="p">
+                Try refreshing the page. If the error persists, please submit a{' '}
+                <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link>
+            </Typography>
+        </Stack>
+        <Link to="/">
+            <Button variant="contained" size="large">
+                Reload
+            </Button>
+        </Link>
+    </Box>
 );
 export default ErrorPage;

--- a/apps/antalmanac/src/routes/ErrorPage.tsx
+++ b/apps/antalmanac/src/routes/ErrorPage.tsx
@@ -1,6 +1,5 @@
 import { Typography, Button, Stack } from '@mui/material';
-import { useRouteError } from 'react-router-dom';
-import { Link } from 'react-router-dom';
+import { Link, useRouteError } from 'react-router-dom';
 
 export const ErrorPage = () => {
     const error = useRouteError();
@@ -37,11 +36,7 @@ export const ErrorPage = () => {
             </Link>
             <details open>
                 <summary>View Error Message</summary>
-                <p>
-                    {error instanceof Error && (
-                        <pre>{error.stack}</pre> // Display stack trace only in development mode
-                    )}
-                </p>
+                <p>{error instanceof Error && <pre>{error.stack}</pre>}</p>
             </details>
         </Stack>
     );

--- a/apps/antalmanac/src/routes/ErrorPage.tsx
+++ b/apps/antalmanac/src/routes/ErrorPage.tsx
@@ -26,7 +26,7 @@ export const ErrorPage = () => {
                 </Typography>
                 <Typography variant="h5" component="p">
                     Try refreshing the page. If the error persists, please submit a{' '}
-                    <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error
+                    <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
                 </Typography>
             </Stack>
             <Link to="/">


### PR DESCRIPTION
## Summary
Created a custom error page that displays when a user encounters an error or enters a bad route 

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/cdb6d3c4-9a78-4dba-aa17-2d2c1917dbe9">
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/074b22af-b027-4dfb-874a-8be5599d209e">

## Issues
In dark mode the link text color poorly contrasts the gray background 

## Test plan
This error page should appear when the user:
- Enters an invalid route (ex. /test/test)
- A runtime error is caught 
   - To test for runtime errors a `throw Error ('some message')` on any of the pages to simulate an error being thrown
- When an update is made to prod while the user is using the app (in theory)

## Issues
- Closes #968

## Future Follow-Up
- #1047  