### PR TITLE
ci: fix destroy staging workflow

### DIFF
--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -26,6 +26,7 @@ env:
     VITE_TILES_ENDPOINT: ${{ secrets.VITE_TILES_ENDPOINT}}
     GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+    ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 
     # Turborepo credentials.
     TURBO_API: ${{ vars.TURBO_API }}
@@ -88,6 +89,8 @@ jobs:
 
             - name: Build backend
               run: pnpm --filter "antalmanac-backend" build
+              env:
+                  ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 
             - name: Destroy backend staging CloudFormation stack
               run: pnpm --filter "antalmanac-cdk" backend-staging destroy --force

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -16,8 +16,6 @@ const ALIASES: Record<string, string | undefined> = {
     "IN4MATX": "INF",
 }
 
-// blah
-
 async function main() {
     const apiKey = process.env.ANTEATER_API_KEY;
     if (!apiKey) throw new Error("ANTEATER_API_KEY is required");

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -16,6 +16,8 @@ const ALIASES: Record<string, string | undefined> = {
     "IN4MATX": "INF",
 }
 
+// blah
+
 async function main() {
     const apiKey = process.env.ANTEATER_API_KEY;
     if (!apiKey) throw new Error("ANTEATER_API_KEY is required");


### PR DESCRIPTION
## Summary

Because I suck at devops(tm) I forgot to add the API key to the destroy step which needs to build the backend.

## Test Plan
Not sure if this will deploy the backend? But if so, let the backend build and then add "no deploy" to trigger the destroy workflow
