### PR TITLE
Fixed "Error loading grades information" with advanced search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -212,7 +212,7 @@ export default function CourseRenderPane(props: { id?: number }) {
         const gradesQueryParams = {
             department: formData.deptValue,
             ge: formData.ge as GE,
-            instructorName: formData.instructor,
+            instructor: formData.instructor,
         };
 
         try {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -212,6 +212,7 @@ export default function CourseRenderPane(props: { id?: number }) {
         const gradesQueryParams = {
             department: formData.deptValue,
             ge: formData.ge as GE,
+            instructorName: formData.instructor,
         };
 
         try {

--- a/apps/antalmanac/src/lib/grades.ts
+++ b/apps/antalmanac/src/lib/grades.ts
@@ -47,17 +47,17 @@ class _Grades {
     populateGradesCache = async ({
         department,
         ge,
-        instructorName,
+        instructor,
     }: {
         department?: string;
         ge?: GE;
-        instructorName?: string;
+        instructor?: string;
     }): Promise<void> => {
         department = department != 'ALL' ? department : undefined;
         ge = ge != 'ANY' ? ge : undefined;
-        instructorName = instructorName != '' ? instructorName : undefined;
+        instructor = instructor != '' ? instructor : undefined;
 
-        if (!department && !ge && !instructorName)
+        if (!department && !ge && !instructor)
             throw new Error('populateGradesCache: Must provide either department, ge, or instructor');
 
         const queryKey = `${department ?? ''}${ge ?? ''}`;

--- a/apps/antalmanac/src/lib/grades.ts
+++ b/apps/antalmanac/src/lib/grades.ts
@@ -44,11 +44,21 @@ class _Grades {
      * @param courseNumber The course number of the course.
      * @param ge The GE filter
      */
-    populateGradesCache = async ({ department, ge }: { department?: string; ge?: GE }): Promise<void> => {
+    populateGradesCache = async ({
+        department,
+        ge,
+        instructorName,
+    }: {
+        department?: string;
+        ge?: GE;
+        instructorName?: string;
+    }): Promise<void> => {
         department = department != 'ALL' ? department : undefined;
         ge = ge != 'ANY' ? ge : undefined;
+        instructorName = instructorName != '' ? instructorName : undefined;
 
-        if (!department && !ge) throw new Error('populateGradesCache: Must provide either department or ge');
+        if (!department && !ge && !instructorName)
+            throw new Error('populateGradesCache: Must provide either department, ge, or instructor');
 
         const queryKey = `${department ?? ''}${ge ?? ''}`;
 


### PR DESCRIPTION
## Summary
Stopped the error "Error loading grades information" from displaying when inserting an instructor's name and having a successful search.
![image](https://github.com/user-attachments/assets/8cd6ed68-7c56-4cb4-a6d4-7e80bfe740f7)
(The error no longer shows up in the bottom left after a successful advanced search using a professor's name.)

The error was being caused because when trying to populate the grades cache through `populateGradesCache`, the instructor would not be passed in as a parameter.
![image](https://github.com/user-attachments/assets/dedfa13f-a1dc-4002-b71b-0e3632149b0c)
(This is the updated code with instructor being passed as a parameter.)

As a result, even if an instructor was successfully passed into advanced search but a GE and department were _not_ supplied, `populateGradesCache` would throw an error asking to provide a department or GE. 
![image](https://github.com/user-attachments/assets/4bfc8665-8aa1-447c-a8c3-2ea90759181e)
(It would throw the error at the bottom which used to _only_ check for an empty GE or department).

To fix this, as shown above, I fixed the conditions under which the error was thrown, checking if instructor was also empty before throwing.

## Test Plan
Check if any combination of an inputted or not inputted GE, department, and instructor causes an issue.

## Issues

Closes #1020 

<!-- [Optional]
## Future Followup
-->
