### PR TITLE
fix: handle inconsistent ge param

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
@@ -55,10 +55,10 @@ class GESelector extends PureComponent<GESelectorProps, GESelectorState> {
         const stateObj = { url: 'url' };
         const url = new URL(window.location.href);
         const urlParam = new URLSearchParams(url.search);
-        urlParam.delete('GE');
+        urlParam.delete('ge');
         const changedValue = event.target.value as string;
         if (changedValue && changedValue != 'ANY') {
-            urlParam.append('GE', event.target.value as string);
+            urlParam.append('ge', event.target.value as string);
         }
         const param = urlParam.toString();
         const new_url = `${param.trim() ? '?' : ''}${param}`;

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -45,7 +45,7 @@ class RightPaneStore extends EventEmitter {
         const search = new URLSearchParams(window.location.search);
         this.urlCourseCodeValue = search.get('courseCode') || '';
         this.urlTermValue = search.get('term') || '';
-        this.urlGEValue = search.get('GE') || '';
+        this.urlGEValue = search.get('ge') || '';
         this.urlCourseNumValue = search.get('courseNumber') || '';
         this.urlDeptLabel = search.get('deptLabel') || '';
         this.urlDeptValue = search.get('deptValue') || '';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/cells/action.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/cells/action.tsx
@@ -82,7 +82,7 @@ export function ColorAndDelete(props: SectionActionProps) {
  * Copying a specific class's link will only copy its course code.
  * If there is random value let in the url, it will interfere with the generated url.
  */
-const fieldsToReset = ['courseCode', 'courseNumber', 'deptLabel', 'deptValue', 'GE', 'term'];
+const fieldsToReset = ['courseCode', 'courseNumber', 'deptLabel', 'deptValue', 'ge', 'term'];
 
 /**
  * Sections that have not been added to a schedule can be added to a schedule.

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -25,7 +25,7 @@ function paramsAreInURL() {
         'courseCode',
         'courseNumber',
         'deptLabel',
-        'GE',
+        'ge',
         'deptValue',
         'term',
         'sectionCode',
@@ -45,7 +45,7 @@ function paramsAreInURL() {
 function requiredParamsAreInURL() {
     const search = new URLSearchParams(window.location.search);
 
-    const searchParams = ['courseCode', 'courseNumber', 'GE', 'deptValue'];
+    const searchParams = ['courseCode', 'courseNumber', 'ge', 'deptValue'];
 
     return searchParams.some((param) => search.get(param) !== null);
 }


### PR DESCRIPTION
## Summary
1. GE param would be referenced by `ge` or `GE` rather inconsistently in our URL parameter code. This PR resolves inconsistencies by making the GE URL param always `ge`.

## Test Plan
1. Test that searching by GE still works
2. Test that loading a URL with a GE param still works
3. Test that resetting search form clears GE

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
