### PR TITLE
Duplicate calendar

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -59,7 +59,7 @@ export interface ClearScheduleAction {
 
 export interface CopyScheduleAction {
     type: 'copySchedule';
-    to: number;
+    newScheduleName: string;
 }
 
 export interface ChangeCourseColorAction {
@@ -159,7 +159,7 @@ class ActionTypesStore extends EventEmitter {
                     AppStore.schedule.clearCurrentSchedule();
                     break;
                 case 'copySchedule':
-                    AppStore.schedule.copySchedule(action.to);
+                    AppStore.schedule.copySchedule(action.newScheduleName);
                     break;
                 default:
                     break;

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -11,8 +11,8 @@ import { removeLocalStorageUserId, setLocalStorageUserId } from '$lib/localStora
 import AppStore from '$stores/AppStore';
 
 export interface CopyScheduleOptions {
-    onSuccess: (index: number) => unknown;
-    onError: (index: number) => unknown;
+    onSuccess: (scheduleName: string) => unknown;
+    onError: (scheduleName: string) => unknown;
 }
 
 export const addCourse = (
@@ -250,17 +250,17 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (to: number, options?: CopyScheduleOptions) => {
+export const copySchedule = (newScheduleName: string, options?: CopyScheduleOptions) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,
     });
 
     try {
-        AppStore.copySchedule(to);
-        options?.onSuccess(to);
+        AppStore.copySchedule(newScheduleName);
+        options?.onSuccess(newScheduleName);
     } catch (error) {
-        options?.onError(to);
+        options?.onError(newScheduleName);
     }
 };
 

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
 import type { DialogProps } from '@mui/material';
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 import { addSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
@@ -12,7 +12,9 @@ import { useThemeStore } from '$stores/SettingsStore';
 function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
     const isDark = useThemeStore((store) => store.isDark);
 
-    const [name, setName] = useState(AppStore.getDefaultScheduleName());
+    const [name, setName] = useState(
+        AppStore.getNextScheduleName(AppStore.getDefaultScheduleName(), AppStore.getScheduleNames().length)
+    );
 
     const handleCancel = () => {
         onClose?.({}, 'escapeKeyDown');
@@ -24,7 +26,6 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
 
     const submitName = () => {
         addSchedule(name);
-        setName(AppStore.schedule.getDefaultScheduleName());
         onClose?.({}, 'escapeKeyDown');
     };
 
@@ -45,6 +46,17 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
             }
         }
     };
+
+    const handleScheduleNamesChange = useCallback(() => {
+        setName(AppStore.getNextScheduleName(AppStore.getDefaultScheduleName(), AppStore.getScheduleNames().length));
+    }, []);
+
+    useEffect(() => {
+        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
+        return () => {
+            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
+        };
+    }, [handleScheduleNamesChange]);
 
     return (
         <Dialog onKeyDown={handleKeyDown} {...props}>

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -72,7 +72,7 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
                 <Button onClick={handleCancel} color={isDark ? 'secondary' : 'primary'}>
                     Cancel
                 </Button>
-                <Button onClick={submitName} variant="contained" color="primary" disabled={name.trim() === ''}>
+                <Button onClick={submitName} variant="contained" color="primary" disabled={name?.trim() === ''}>
                     Add Schedule
                 </Button>
             </DialogActions>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -51,7 +51,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
             <DialogTitle>Copy Schedule</DialogTitle>
             <DialogContent>
                 <Box padding={1}>
-                    <TextField fullWidth label="Name *" onChange={handleNameChange} value={name} />
+                    <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
                 </Box>
             </DialogContent>
             <DialogActions>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -5,12 +5,10 @@ import {
     DialogActions,
     DialogContent,
     DialogTitle,
-    MenuItem,
-    Select,
+    TextField,
     type DialogProps,
 } from '@mui/material';
-import { SelectChangeEvent } from '@mui/material';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 import { copySchedule, addSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
@@ -22,11 +20,11 @@ interface CopyScheduleDialogProps extends DialogProps {
 function CopyScheduleDialog(props: CopyScheduleDialogProps) {
     const { index } = props;
     const { onClose } = props; // destructured separately for memoization.
-    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
-    const [selectedSchedule, setSelectedSchedule] = useState<number>(0);
+    const scheduleNames = AppStore.getScheduleNames();
+    const [name, setName] = useState<string>(`Copy of ${scheduleNames[index]}`);
 
-    const handleScheduleChange = useCallback((event: SelectChangeEvent<number>) => {
-        setSelectedSchedule(event.target.value as number);
+    const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setName(event.target.value);
     }, []);
 
     const handleCancel = useCallback(() => {
@@ -34,49 +32,18 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
     }, [onClose]);
 
     const handleCopy = useCallback(() => {
-        if (selectedSchedule !== scheduleNames.length) {
-            if (selectedSchedule === scheduleNames.length + 1) {
-                addSchedule(AppStore.getNextScheduleName('Copy of ' + scheduleNames[index]));
-                AppStore.changeCurrentSchedule(index);
-            }
-            copySchedule(selectedSchedule);
-        } else {
-            scheduleNames.forEach((_, scheduleIndex) => {
-                if (scheduleIndex !== index) {
-                    copySchedule(scheduleIndex);
-                }
-            });
-        }
+        addSchedule(AppStore.getNextScheduleName(name));
+        AppStore.changeCurrentSchedule(index);
+        copySchedule(AppStore.getScheduleNames().length - 1);
         onClose?.({}, 'escapeKeyDown');
-    }, [index, onClose, selectedSchedule, scheduleNames]);
-
-    const handleScheduleNamesChange = useCallback(() => {
-        setScheduleNames([...AppStore.getScheduleNames()]);
-    }, []);
-
-    useEffect(() => {
-        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
-
-        return () => {
-            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
-        };
-    }, [handleScheduleNamesChange]);
+    }, [index, onClose]);
 
     return (
         <Dialog onClose={onClose} {...props}>
-            <DialogTitle>Copy To Schedule</DialogTitle>
-
+            <DialogTitle>Copy Schedule</DialogTitle>
             <DialogContent>
                 <Box padding={1}>
-                    <Select fullWidth value={selectedSchedule} onChange={handleScheduleChange}>
-                        {scheduleNames.map((name, idx) => (
-                            <MenuItem key={idx} value={idx} disabled={index === idx}>
-                                {name}
-                            </MenuItem>
-                        ))}
-                        <MenuItem value={scheduleNames.length + 1}>Copy to New Schedule</MenuItem>
-                        <MenuItem value={scheduleNames.length}>Copy to All Schedules</MenuItem>
-                    </Select>
+                    <TextField fullWidth label="Name" onChange={handleNameChange} value={name} />
                 </Box>
             </DialogContent>
 
@@ -85,7 +52,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
                     Cancel
                 </Button>
                 <Button onClick={handleCopy} variant="contained" color="primary">
-                    Copy Schedule
+                    Make a Copy
                 </Button>
             </DialogActions>
         </Dialog>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -12,7 +12,7 @@ import {
 import { SelectChangeEvent } from '@mui/material';
 import { useState, useEffect, useCallback } from 'react';
 
-import { copySchedule } from '$actions/AppStoreActions';
+import { copySchedule, addSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
 
 interface CopyScheduleDialogProps extends DialogProps {
@@ -35,6 +35,10 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
 
     const handleCopy = useCallback(() => {
         if (selectedSchedule !== scheduleNames.length) {
+            if (selectedSchedule === scheduleNames.length + 1) {
+                addSchedule('Copy of ' + scheduleNames[index]);
+                AppStore.changeCurrentSchedule(index);
+            }
             copySchedule(selectedSchedule);
         } else {
             scheduleNames.forEach((_, scheduleIndex) => {
@@ -70,6 +74,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
                                 {name}
                             </MenuItem>
                         ))}
+                        <MenuItem value={scheduleNames.length + 1}>Copy to New Schedule</MenuItem>
                         <MenuItem value={scheduleNames.length}>Copy to All Schedules</MenuItem>
                     </Select>
                 </Box>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -58,7 +58,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
                 <Button onClick={handleCancel} color="inherit">
                     Cancel
                 </Button>
-                <Button onClick={handleCopy} variant="contained" color="primary" disabled={name.trim() === ''}>
+                <Button onClick={handleCopy} variant="contained" color="primary" disabled={name?.trim() === ''}>
                     Make a Copy
                 </Button>
             </DialogActions>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -58,7 +58,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
                 <Button onClick={handleCancel} color="inherit">
                     Cancel
                 </Button>
-                <Button onClick={handleCopy} variant="contained" color="primary">
+                <Button onClick={handleCopy} variant="contained" color="primary" disabled={name.trim() === ''}>
                     Make a Copy
                 </Button>
             </DialogActions>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -36,7 +36,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
     const handleCopy = useCallback(() => {
         if (selectedSchedule !== scheduleNames.length) {
             if (selectedSchedule === scheduleNames.length + 1) {
-                addSchedule('Copy of ' + scheduleNames[index]);
+                addSchedule(AppStore.getNextScheduleName('Copy of ' + scheduleNames[index]));
                 AppStore.changeCurrentSchedule(index);
             }
             copySchedule(selectedSchedule);

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -7,7 +7,7 @@ import {
     DialogTitle,
     type DialogProps,
 } from '@mui/material';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { deleteSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
@@ -35,10 +35,7 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
      * This is destructured separately for memoization.
      */
     const { onClose } = props;
-
-    const scheduleName = useMemo(() => {
-        return AppStore.schedule.getScheduleName(index);
-    }, [index]);
+    const [name, setName] = useState<string>(AppStore.getScheduleNames()[index]);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
@@ -49,12 +46,24 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
         onClose?.({}, 'escapeKeyDown');
     }, [index, onClose]);
 
+    const handleScheduleNamesChange = useCallback(() => {
+        setName(AppStore.getScheduleNames()[index]);
+    }, [index]);
+
+    useEffect(() => {
+        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
+
+        return () => {
+            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
+        };
+    }, [handleScheduleNamesChange]);
+
     return (
         <Dialog {...dialogProps}>
             <DialogTitle>Delete Schedule</DialogTitle>
 
             <DialogContent>
-                <DialogContentText>Are you sure you want to delete &#34;{scheduleName}&#34;?</DialogContentText>
+                <DialogContentText>Are you sure you want to delete &#34;{name}&#34;?</DialogContentText>
             </DialogContent>
 
             <DialogActions>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -92,7 +92,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
                 <Button onClick={handleCancel} color={'inherit'}>
                     Cancel
                 </Button>
-                <Button onClick={submitName} variant="contained" color="primary" disabled={name.trim() === ''}>
+                <Button onClick={submitName} variant="contained" color="primary" disabled={name?.trim() === ''}>
                     Rename Schedule
                 </Button>
             </DialogActions>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -8,7 +8,7 @@ import {
     TextField,
     type DialogProps,
 } from '@mui/material';
-import { useCallback, useState, useEffect, useMemo } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 
 import { renameSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
@@ -35,10 +35,6 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
      */
     const { onClose } = props;
     const [name, setName] = useState(AppStore.getScheduleNames()[index]);
-
-    const disabled = useMemo(() => {
-        return name?.trim() === '';
-    }, [name]);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
@@ -96,7 +92,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
                 <Button onClick={handleCancel} color={'inherit'}>
                     Cancel
                 </Button>
-                <Button onClick={submitName} variant="contained" color="primary" disabled={disabled}>
+                <Button onClick={submitName} variant="contained" color="primary" disabled={name.trim() === ''}>
                     Rename Schedule
                 </Button>
             </DialogActions>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -34,10 +34,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
      * This is destructured separately for memoization.
      */
     const { onClose } = props;
-
-    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
-
-    const [name, setName] = useState(scheduleNames[index]);
+    const [name, setName] = useState(AppStore.getScheduleNames()[index]);
 
     const disabled = useMemo(() => {
         return name?.trim() === '';
@@ -45,8 +42,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');
-        setName(scheduleNames[index]);
-    }, [onClose, scheduleNames, index]);
+    }, [onClose, index]);
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setName(event.target.value);
@@ -75,8 +71,8 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
     );
 
     const handleScheduleNamesChange = useCallback(() => {
-        setScheduleNames(AppStore.getScheduleNames());
-    }, []);
+        setName(AppStore.getScheduleNames()[index]);
+    }, [index]);
 
     useEffect(() => {
         AppStore.on('scheduleNamesChange', handleScheduleNamesChange);

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -71,8 +71,8 @@ class AppStore extends EventEmitter {
         }
     }
 
-    getNextScheduleName(newScheduleName: string) {
-        return this.schedule.getNextScheduleName(newScheduleName);
+    getNextScheduleName(newScheduleName: string, scheduleIndex: number) {
+        return this.schedule.getNextScheduleName(newScheduleName, scheduleIndex);
     }
 
     getDefaultScheduleName() {

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -71,6 +71,10 @@ class AppStore extends EventEmitter {
         }
     }
 
+    getNextScheduleName(newScheduleName: string) {
+        return this.schedule.getNextScheduleName(newScheduleName);
+    }
+
     getDefaultScheduleName() {
         return this.schedule.getDefaultScheduleName();
     }

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -295,14 +295,17 @@ class AppStore extends EventEmitter {
         window.localStorage.removeItem('unsavedActions');
     }
 
-    copySchedule(to: number) {
-        this.schedule.copySchedule(to);
+    copySchedule(newScheduleName: string) {
+        this.schedule.copySchedule(newScheduleName);
         this.unsavedChanges = true;
         const action: CopyScheduleAction = {
             type: 'copySchedule',
-            to: to,
+            newScheduleName: newScheduleName,
         };
         actionTypesStore.autoSaveSchedule(action);
+        this.emit('scheduleNamesChange');
+        this.emit('currentScheduleIndexChange');
+        this.emit('scheduleNotesChange');
         this.emit('addedCoursesChange');
         this.emit('customEventsChange');
     }

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -146,10 +146,11 @@ export class Schedules {
     }
 
     /**
+     * @deprecated This method is no longer used by any features
      * Append all courses from current schedule to the schedule with the target index.
      * @param to Index of the schedule to append courses to. If equal to number of schedules, will append courses to all schedules.
      */
-    copySchedule(to: number) {
+    copyToSchedule(to: number) {
         this.addUndoState();
         for (const course of this.getCurrentCourses()) {
             if (to === this.getNumberOfSchedules()) {
@@ -165,6 +166,24 @@ export class Schedules {
             } else {
                 this.addCustomEvent(customEvent, [to]);
             }
+        }
+    }
+
+    /**
+     * Copy the current schedule to a newly created schedule with the specified name.
+     * @param newScheduleName The name of the new schedule. If a schedule with the same name already exists, a number will be appended to the name.
+     */
+    copySchedule(newScheduleName: string) {
+        this.addNewSchedule(this.getNextScheduleName(newScheduleName));
+        this.currentScheduleIndex = this.previousStates[this.previousStates.length - 1].scheduleIndex; // return to previous schedule index for copying
+        const to = this.getNumberOfSchedules() - 1;
+
+        for (const course of this.getCurrentCourses()) {
+            this.addCourse(course, to, false);
+        }
+
+        for (const customEvent of this.getCurrentCustomEvents()) {
+            this.addCustomEvent(customEvent, [to]);
         }
     }
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -50,22 +50,19 @@ export class Schedules {
         this.skeletonSchedules = [];
     }
 
-    getNextScheduleName(newScheduleName: string) {
-        const scheduleNames = this.getScheduleNames();
+    getNextScheduleName(newScheduleName: string, scheduleIndex: number) {
+        const scheduleNames = this.getScheduleNames().filter((_, index) => index !== scheduleIndex);
         let nextScheduleName = newScheduleName;
         let counter = 1;
 
         while (scheduleNames.includes(nextScheduleName)) {
             nextScheduleName = `${newScheduleName}(${counter++})`;
         }
-
         return nextScheduleName;
     }
 
     getDefaultScheduleName() {
-        const termName = termData[0].shortName.replaceAll(' ', '-');
-        const countSameScheduleNames = this.getScheduleNames().filter((name) => name.includes(termName)).length;
-        return `${termName + (countSameScheduleNames == 0 ? '' : '(' + countSameScheduleNames + ')')}`;
+        return termData[0].shortName.replaceAll(' ', '-');
     }
 
     getCurrentScheduleIndex() {
@@ -104,12 +101,13 @@ export class Schedules {
 
     /**
      * Create an empty schedule.
+     * @param newScheduleName The name of the new schedule. If a schedule with the same name already exists, a number will be appended to the name.
      */
     addNewSchedule(newScheduleName: string) {
         this.addUndoState();
         const scheduleNoteId = Math.random();
         this.schedules.push({
-            scheduleName: newScheduleName,
+            scheduleName: this.getNextScheduleName(newScheduleName, this.getNumberOfSchedules()),
             courses: [],
             customEvents: [],
             scheduleNoteId: scheduleNoteId,
@@ -121,10 +119,11 @@ export class Schedules {
 
     /**
      * Rename schedule with the specified index.
+     * @param newScheduleName The name of the new schedule. If a schedule with the same name already exists, a number will be appended to the name.
      */
     renameSchedule(newScheduleName: string, scheduleIndex: number) {
         this.addUndoState();
-        this.schedules[scheduleIndex].scheduleName = newScheduleName;
+        this.schedules[scheduleIndex].scheduleName = this.getNextScheduleName(newScheduleName, scheduleIndex);
     }
 
     /**
@@ -171,10 +170,9 @@ export class Schedules {
 
     /**
      * Copy the current schedule to a newly created schedule with the specified name.
-     * @param newScheduleName The name of the new schedule. If a schedule with the same name already exists, a number will be appended to the name.
      */
     copySchedule(newScheduleName: string) {
-        this.addNewSchedule(this.getNextScheduleName(newScheduleName));
+        this.addNewSchedule(newScheduleName);
         this.currentScheduleIndex = this.previousStates[this.previousStates.length - 1].scheduleIndex; // return to previous schedule index for copying
         const to = this.getNumberOfSchedules() - 1;
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -51,7 +51,8 @@ export class Schedules {
     }
 
     getNextScheduleName(newScheduleName: string, scheduleIndex: number) {
-        const scheduleNames = this.getScheduleNames().filter((_, index) => index !== scheduleIndex);
+        const scheduleNames = this.getScheduleNames();
+        scheduleNames.splice(scheduleIndex, 1);
         let nextScheduleName = newScheduleName;
         let counter = 1;
 
@@ -142,30 +143,6 @@ export class Schedules {
         this.addUndoState();
         this.schedules.splice(scheduleIndex, 1);
         this.currentScheduleIndex = Math.min(scheduleIndex, this.getNumberOfSchedules() - 1);
-    }
-
-    /**
-     * @deprecated This method is no longer used by any features
-     * Append all courses from current schedule to the schedule with the target index.
-     * @param to Index of the schedule to append courses to. If equal to number of schedules, will append courses to all schedules.
-     */
-    copyToSchedule(to: number) {
-        this.addUndoState();
-        for (const course of this.getCurrentCourses()) {
-            if (to === this.getNumberOfSchedules()) {
-                this.addCourseToAllSchedules(course);
-            } else {
-                this.addCourse(course, to, false);
-            }
-        }
-
-        for (const customEvent of this.getCurrentCustomEvents()) {
-            if (to === this.getNumberOfSchedules()) {
-                this.addCustomEvent(customEvent, [...Array(to).keys()]);
-            } else {
-                this.addCustomEvent(customEvent, [to]);
-            }
-        }
     }
 
     /**

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -51,8 +51,15 @@ export class Schedules {
     }
 
     getNextScheduleName(newScheduleName: string) {
-        const countSameScheduleNames = this.getScheduleNames().filter((name) => name.includes(newScheduleName)).length;
-        return `${newScheduleName + (countSameScheduleNames == 0 ? '' : '(' + countSameScheduleNames + ')')}`;
+        const scheduleNames = this.getScheduleNames();
+        let nextScheduleName = newScheduleName;
+        let counter = 1;
+
+        while (scheduleNames.includes(nextScheduleName)) {
+            nextScheduleName = `${newScheduleName}(${counter++})`;
+        }
+
+        return nextScheduleName;
     }
 
     getDefaultScheduleName() {

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -50,6 +50,11 @@ export class Schedules {
         this.skeletonSchedules = [];
     }
 
+    getNextScheduleName(newScheduleName: string) {
+        const countSameScheduleNames = this.getScheduleNames().filter((name) => name.includes(newScheduleName)).length;
+        return `${newScheduleName + (countSameScheduleNames == 0 ? '' : '(' + countSameScheduleNames + ')')}`;
+    }
+
     getDefaultScheduleName() {
         const termName = termData[0].shortName.replaceAll(' ', '-');
         const countSameScheduleNames = this.getScheduleNames().filter((name) => name.includes(termName)).length;


### PR DESCRIPTION
## Summary
- Copy to New Schedule functionality 
- Enforce unique schedule names when duplicating, creating, or renaming a schedule
- Fix bug where schedule names aren't updated and thus displayed properly for deletion modals

## Test Plan
- Undo New Schedule Creation: Verify undo functionality removes a newly created schedule.
- Combined Undo for Schedule Creation and Event Copying: Confirm one undo removes both a new schedule and copied events.
- Duplicate Schedule Name on Creation: Validate a duplicate schedule name results in a suffix like (1).
- Duplicate Schedule Name on Renaming: Check renaming to an existing name adds a suffix or prevents duplication.
- Renaming and Duplicating Schedules: Verify renaming a schedule and duplicating it results in proper suffixes.
- Adding Custom Events: Verify custom events are added with all details intact.
- Start with existing schedule 2025-Winter. Create new schedule with same name. Expect 2025-Winter(1). Try renaming schedule to 2025-Winter. Expect 2025-Winter(1)
- Deleting schedule modal shows correct name of schedule to delete; Create 3 schedules; delete the second schedule; open up the delete modal for the third schedule. It should display the name of the third schedule and not the second schedule

## Issues
Closes #1034, #1032