### PR TITLE
feat: update error page

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -329,8 +329,6 @@ function AddedSectionsGrid() {
         </Box>
     );
 
-    throw Error('foo');
-
     return (
         <Box display="flex" flexDirection="column" gap={1} marginX={0.5}>
             <Box display="flex" width={1} position="absolute" zIndex="2">

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -329,6 +329,8 @@ function AddedSectionsGrid() {
         </Box>
     );
 
+    throw Error('foo');
+
     return (
         <Box display="flex" flexDirection="column" gap={1} marginX={0.5}>
             <Box display="flex" width={1} position="absolute" zIndex="2">

--- a/apps/antalmanac/src/routes/ErrorPage.tsx
+++ b/apps/antalmanac/src/routes/ErrorPage.tsx
@@ -7,7 +7,7 @@ export const ErrorPage = () => {
     const location = useLocation();
 
     return (
-        <Box sx={{ height: '100dvh', overflowY: 'scroll' }}>
+        <Box sx={{ height: '100dvh', overflowY: 'auto' }}>
             <Stack
                 sx={{
                     display: 'flex',
@@ -16,45 +16,45 @@ export const ErrorPage = () => {
                     maxWidth: 800,
                     minHeight: '100dvh',
                     margin: 'auto',
+                    padding: 2,
+                    gap: 2,
                 }}
             >
-                <Stack sx={{ maxHeight: '100dvh', gap: 2, height: 'fit-content', padding: 2 }}>
-                    <Typography variant="h3" component="h1">
-                        Oops! Something went wrong.
+                <Typography variant="h3" component="h1">
+                    Oops! Something went wrong.
+                </Typography>
+                <Stack spacing={2}>
+                    <Typography variant="h5" component="p">
+                        This error may be caused by your browser having an out of date version of AntAlmanac.
                     </Typography>
-                    <Stack spacing={2}>
-                        <Typography variant="h5" component="p">
-                            This error may be caused by your browser having an out of date version of AntAlmanac.
-                        </Typography>
-                        <Typography variant="h5" component="p">
-                            Try refreshing the page. If the error persists, please submit a{' '}
-                            <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
-                        </Typography>
-                    </Stack>
-                    <Link to="/">
-                        <Button variant="contained" size="large">
-                            Back to Home
-                        </Button>
-                    </Link>
-                    <Accordion defaultExpanded disableGutters sx={{ maxWidth: '100%' }}>
-                        <AccordionSummary expandIcon={<ExpandMore />}>
-                            <Typography component="p">View Error Message</Typography>
-                        </AccordionSummary>
-                        <AccordionDetails
-                            sx={{
-                                display: 'flex',
-                                gap: 1,
-                                textAlign: 'left',
-                                flexWrap: 'wrap',
-                            }}
-                        >
-                            <Typography sx={{ fontWeight: '600' }}>Route: {location.pathname}</Typography>
-                            <Typography sx={{ wordBreak: 'break-word' }}>
-                                {error instanceof Error ? error.stack : 'No error stack provided.'}
-                            </Typography>
-                        </AccordionDetails>
-                    </Accordion>
+                    <Typography variant="h5" component="p">
+                        Try refreshing the page. If the error persists, please submit a{' '}
+                        <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
+                    </Typography>
                 </Stack>
+                <Link to="/">
+                    <Button variant="contained" size="large">
+                        Back to Home
+                    </Button>
+                </Link>
+                <Accordion defaultExpanded disableGutters sx={{ maxWidth: '100%' }}>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                        <Typography component="p">View Error Message</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails
+                        sx={{
+                            display: 'flex',
+                            gap: 1,
+                            textAlign: 'left',
+                            flexWrap: 'wrap',
+                        }}
+                    >
+                        <Typography sx={{ fontWeight: '600' }}>Route: {location.pathname}</Typography>
+                        <Typography sx={{ wordBreak: 'break-word' }}>
+                            {error instanceof Error ? error.stack : 'No error stack provided.'}
+                        </Typography>
+                    </AccordionDetails>
+                </Accordion>
             </Stack>
         </Box>
     );

--- a/apps/antalmanac/src/routes/ErrorPage.tsx
+++ b/apps/antalmanac/src/routes/ErrorPage.tsx
@@ -1,5 +1,5 @@
 import { ExpandMore } from '@mui/icons-material';
-import { Accordion, AccordionDetails, AccordionSummary, Typography, Button, Stack } from '@mui/material';
+import { Box, Accordion, AccordionDetails, AccordionSummary, Typography, Button, Stack } from '@mui/material';
 import { Link, useLocation, useRouteError } from 'react-router-dom';
 
 export const ErrorPage = () => {
@@ -7,55 +7,55 @@ export const ErrorPage = () => {
     const location = useLocation();
 
     return (
-        <Stack
-            sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                textAlign: 'center',
-                maxWidth: 800,
-                minHeight: '100dvh',
-                margin: 'auto',
-                overflowY: 'scroll',
-            }}
-        >
-            <Stack sx={{ maxHeight: '100dvh', gap: 2, height: 'fit-content', padding: 2 }}>
-                <Typography variant="h3" component="h1">
-                    Oops! Something went wrong.
-                </Typography>
-                <Stack spacing={2}>
-                    <Typography variant="h5" component="p">
-                        This error may be caused by your browser having an out of date version of AntAlmanac.
+        <Box sx={{ height: '100dvh', overflowY: 'scroll' }}>
+            <Stack
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    maxWidth: 800,
+                    minHeight: '100dvh',
+                    margin: 'auto',
+                }}
+            >
+                <Stack sx={{ maxHeight: '100dvh', gap: 2, height: 'fit-content', padding: 2 }}>
+                    <Typography variant="h3" component="h1">
+                        Oops! Something went wrong.
                     </Typography>
-                    <Typography variant="h5" component="p">
-                        Try refreshing the page. If the error persists, please submit a{' '}
-                        <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
-                    </Typography>
+                    <Stack spacing={2}>
+                        <Typography variant="h5" component="p">
+                            This error may be caused by your browser having an out of date version of AntAlmanac.
+                        </Typography>
+                        <Typography variant="h5" component="p">
+                            Try refreshing the page. If the error persists, please submit a{' '}
+                            <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
+                        </Typography>
+                    </Stack>
+                    <Link to="/">
+                        <Button variant="contained" size="large">
+                            Back to Home
+                        </Button>
+                    </Link>
+                    <Accordion defaultExpanded disableGutters sx={{ maxWidth: '100%' }}>
+                        <AccordionSummary expandIcon={<ExpandMore />}>
+                            <Typography component="p">View Error Message</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails
+                            sx={{
+                                display: 'flex',
+                                gap: 1,
+                                textAlign: 'left',
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <Typography sx={{ fontWeight: '600' }}>Route: {location.pathname}</Typography>
+                            <Typography sx={{ wordBreak: 'break-word' }}>
+                                {error instanceof Error ? error.stack : 'No error stack provided.'}
+                            </Typography>
+                        </AccordionDetails>
+                    </Accordion>
                 </Stack>
-                <Link to="/">
-                    <Button variant="contained" size="large">
-                        Back to Home
-                    </Button>
-                </Link>
-                <Accordion defaultExpanded disableGutters sx={{ maxWidth: '100%' }}>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                        <Typography component="p">View Error Message</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails
-                        sx={{
-                            display: 'flex',
-                            gap: 1,
-                            textAlign: 'left',
-                            flexWrap: 'wrap',
-                            whiteSpace: 'normal',
-                            wordWrap: 'break-word',
-                        }}
-                    >
-                        <Typography sx={{ fontWeight: '600' }}>Route: {location.pathname}</Typography>
-
-                        {error instanceof Error ? error.stack : 'No error stack provided.'}
-                    </AccordionDetails>
-                </Accordion>
             </Stack>
-        </Stack>
+        </Box>
     );
 };

--- a/apps/antalmanac/src/routes/ErrorPage.tsx
+++ b/apps/antalmanac/src/routes/ErrorPage.tsx
@@ -1,43 +1,61 @@
-import { Typography, Button, Stack } from '@mui/material';
-import { Link, useRouteError } from 'react-router-dom';
+import { ExpandMore } from '@mui/icons-material';
+import { Accordion, AccordionDetails, AccordionSummary, Typography, Button, Stack } from '@mui/material';
+import { Link, useLocation, useRouteError } from 'react-router-dom';
 
 export const ErrorPage = () => {
     const error = useRouteError();
+    const location = useLocation();
 
     return (
         <Stack
-            spacing={3}
             sx={{
-                padding: '1rem',
                 display: 'flex',
                 justifyContent: 'center',
-                alignItems: 'center',
-                flexDirection: 'column',
-                height: '100vh',
-                gap: 2,
+                textAlign: 'center',
+                maxWidth: 800,
+                minHeight: '100dvh',
+                margin: 'auto',
+                overflowY: 'scroll',
             }}
         >
-            <Typography variant="h3" component="h1">
-                Oops! Something went wrong.
-            </Typography>
-            <Stack spacing={2} sx={{ textAlign: 'center' }}>
-                <Typography variant="h5" component="p">
-                    This error may be caused by your browser having an out of date version of AntAlmanac.
+            <Stack sx={{ maxHeight: '100dvh', gap: 2, height: 'fit-content', padding: 2 }}>
+                <Typography variant="h3" component="h1">
+                    Oops! Something went wrong.
                 </Typography>
-                <Typography variant="h5" component="p">
-                    Try refreshing the page. If the error persists, please submit a{' '}
-                    <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
-                </Typography>
+                <Stack spacing={2}>
+                    <Typography variant="h5" component="p">
+                        This error may be caused by your browser having an out of date version of AntAlmanac.
+                    </Typography>
+                    <Typography variant="h5" component="p">
+                        Try refreshing the page. If the error persists, please submit a{' '}
+                        <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">bug report</Link> with the provided error.
+                    </Typography>
+                </Stack>
+                <Link to="/">
+                    <Button variant="contained" size="large">
+                        Back to Home
+                    </Button>
+                </Link>
+                <Accordion defaultExpanded disableGutters sx={{ maxWidth: '100%' }}>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                        <Typography component="p">View Error Message</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails
+                        sx={{
+                            display: 'flex',
+                            gap: 1,
+                            textAlign: 'left',
+                            flexWrap: 'wrap',
+                            whiteSpace: 'normal',
+                            wordWrap: 'break-word',
+                        }}
+                    >
+                        <Typography sx={{ fontWeight: '600' }}>Route: {location.pathname}</Typography>
+
+                        {error instanceof Error ? error.stack : 'No error stack provided.'}
+                    </AccordionDetails>
+                </Accordion>
             </Stack>
-            <Link to="/">
-                <Button variant="contained" size="large">
-                    Back to Home
-                </Button>
-            </Link>
-            <details open>
-                <summary>View Error Message</summary>
-                <p>{error instanceof Error && <pre>{error.stack}</pre>}</p>
-            </details>
         </Stack>
     );
 };


### PR DESCRIPTION
## Summary
1. Restyles error page for mobile
2. Updates error display to use an `Accordion`
3. Display current route

<img width="400" alt="Screenshot 2024-11-24 at 8 13 06 AM" src="https://github.com/user-attachments/assets/48c6d0cd-da8d-46ff-a7a6-d013a7241482">
<img width="361" alt="Screenshot 2024-11-24 at 8 18 33 AM" src="https://github.com/user-attachments/assets/7ee67bc2-a078-4cae-b975-71fdfb15b7ec">
<img width="400" alt="Screenshot 2024-11-24 at 8 13 52 AM" src="https://github.com/user-attachments/assets/3c7017e3-f2e3-4812-bfba-bcfaacf79e54">
<img width="360" alt="Screenshot 2024-11-24 at 8 15 37 AM" src="https://github.com/user-attachments/assets/4120bb8f-f9ba-403b-a32c-c7b7ec89b936">

## Test Plan
1. throw an `Error` somewhere, somehow (easiest may be to pull locally and manually `throw`)
2. Check error page on desktop, confirming readability and that error is displayed by default
3. Check error page on mobile, same considerations as desktop (especially responsiveness & readability)
4. Check error page on light and dark mode

## Issues
Follows up #968 and #1035 

(I should've caught this originally on #1035, that's my bad)

<!-- [Optional]
## Future Followup
-->
