### PR TITLE
ci: add DB_URL to staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -28,6 +28,7 @@ env:
     VITE_TILES_ENDPOINT: ${{ secrets.VITE_TILES_ENDPOINT}}
     GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+    DB_URL: ${{ secrets.STAGING_DB_URL }}
     ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 
     # Turborepo credentials.


### PR DESCRIPTION
## Summary

Add `DB_URL` to staging deploy. Necessary for #993 builds to work, since GitHub actions reads workflows from main.

## Test Plan

After this is merged #993 should be able to deploy properly