### PR TITLE
feat: restyle custom events modal

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -171,7 +171,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                 <DialogTitle id="form-dialog-title">
                     {props.customEvent ? 'Edit a Custom Event' : 'Add a Custom Event'}
                 </DialogTitle>
-                <DialogContent>
+                <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
                     <FormControl fullWidth>
                         <TextField
                             id="event-name-input"
@@ -183,10 +183,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                             margin="dense"
                         />
                     </FormControl>
-                    <FormControl
-                        fullWidth
-                        sx={{ display: 'flex', flexDirection: 'row', gap: '12px', marginTop: '12px' }}
-                    >
+                    <FormControl fullWidth sx={{ display: 'flex', flexDirection: 'row', gap: '12px' }}>
                         <TextField
                             onChange={handleStartTimeChange}
                             label="Start Time"

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -213,7 +213,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                         />
                     </form>
                     <DaySelector onSelectDay={handleDayChange} days={props.customEvent?.days} />
-                    <BuildingSelect value={building} onChange={handleBuildingChange} />
+                    <BuildingSelect value={building} onChange={handleBuildingChange} variant="outlined" />
                     <ScheduleSelector
                         scheduleIndices={scheduleIndices}
                         onSelectScheduleIndices={handleSelectScheduleIndices}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -167,7 +167,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                 </Tooltip>
             )}
             <Dialog open={open} onClose={handleClose} maxWidth={'xs'}>
-                <DialogTitle id="form-dialog-title" style={{ marginBottom: -10 }}>
+                <DialogTitle id="form-dialog-title">
                     Add a Custom Event
                 </DialogTitle>
                 <DialogContent>
@@ -179,10 +179,9 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                             required={true}
                             value={title}
                             onChange={handleEventNameChange}
-                            style={{ marginTop: 10, width: '100%' }}
                         />
                     </FormControl>
-                    <form noValidate style={{ display: 'flex', gap: 0, marginTop: 10 }}>
+                    <FormControl fullWidth sx={{ display: 'flex', flexDirection: 'row', gap: '10px' }}>
                         <TextField
                             onChange={handleStartTimeChange}
                             label="Start Time"
@@ -195,7 +194,6 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                             inputProps={{
                                 step: 300,
                             }}
-                            style={{ marginRight: 5, marginTop: 10 }}
                         />
                         <TextField
                             onChange={handleEndTimeChange}
@@ -209,7 +207,6 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                             inputProps={{
                                 step: 300,
                             }}
-                            style={{ marginTop: 10 }}
                         />
                     </form>
                     <DaySelector onSelectDay={handleDayChange} days={props.customEvent?.days} />

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -4,10 +4,9 @@ import {
     Dialog,
     DialogActions,
     DialogContent,
+    DialogTitle,
     FormControl,
     IconButton,
-    Input,
-    InputLabel,
     TextField,
     Tooltip,
 } from '@mui/material';
@@ -167,38 +166,50 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                     </IconButton>
                 </Tooltip>
             )}
-            <Dialog open={open} onClose={handleClose} maxWidth={'lg'}>
+            <Dialog open={open} onClose={handleClose} maxWidth={'xs'}>
+                <DialogTitle id="form-dialog-title" style={{ marginBottom: -10 }}>
+                    Add a Custom Event
+                </DialogTitle>
                 <DialogContent>
-                    <FormControl>
-                        <InputLabel htmlFor="EventNameInput">Event Name</InputLabel>
-                        <Input required={true} value={title} onChange={handleEventNameChange} />
+                    <FormControl fullWidth>
+                        <TextField
+                            id="outlined-basic"
+                            label="Event Name"
+                            variant="outlined"
+                            required={true}
+                            value={title}
+                            onChange={handleEventNameChange}
+                            style={{ marginTop: 10, width: '100%' }}
+                        />
                     </FormControl>
-                    <form noValidate style={{ display: 'flex', gap: 5, marginTop: 5 }}>
+                    <form noValidate style={{ display: 'flex', gap: 0, marginTop: 10 }}>
                         <TextField
                             onChange={handleStartTimeChange}
                             label="Start Time"
                             type="time"
                             defaultValue={start}
+                            fullWidth
                             InputLabelProps={{
                                 shrink: true,
                             }}
                             inputProps={{
                                 step: 300,
                             }}
-                            style={{ marginRight: 5, marginTop: 5 }}
+                            style={{ marginRight: 5, marginTop: 10 }}
                         />
                         <TextField
                             onChange={handleEndTimeChange}
                             label="End Time"
                             type="time"
                             defaultValue={end}
+                            fullWidth
                             InputLabelProps={{
                                 shrink: true,
                             }}
                             inputProps={{
                                 step: 300,
                             }}
-                            style={{ marginRight: 5, marginTop: 5 }}
+                            style={{ marginTop: 10 }}
                         />
                     </form>
                     <DaySelector onSelectDay={handleDayChange} days={props.customEvent?.days} />
@@ -211,7 +222,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                     />
                 </DialogContent>
 
-                <DialogActions>
+                <DialogActions style={{ padding: '0px 16px 16px' }}>
                     <Button onClick={handleClose} color={isDark ? 'secondary' : 'primary'}>
                         Cancel
                     </Button>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -139,6 +139,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
     }, []);
 
     const isDark = useThemeStore.getState().isDark;
+
     return (
         <>
             {props.customEvent ? (
@@ -168,20 +169,24 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
             )}
             <Dialog open={open} onClose={handleClose} maxWidth={'xs'}>
                 <DialogTitle id="form-dialog-title">
-                    Add a Custom Event
+                    {props.customEvent ? 'Edit a Custom Event' : 'Add a Custom Event'}
                 </DialogTitle>
                 <DialogContent>
                     <FormControl fullWidth>
                         <TextField
-                            id="outlined-basic"
+                            id="event-name-input"
                             label="Event Name"
                             variant="outlined"
                             required={true}
                             value={title}
                             onChange={handleEventNameChange}
+                            margin="dense"
                         />
                     </FormControl>
-                    <FormControl fullWidth sx={{ display: 'flex', flexDirection: 'row', gap: '10px' }}>
+                    <FormControl
+                        fullWidth
+                        sx={{ display: 'flex', flexDirection: 'row', gap: '12px', marginTop: '12px' }}
+                    >
                         <TextField
                             onChange={handleStartTimeChange}
                             label="Start Time"
@@ -208,7 +213,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                                 step: 300,
                             }}
                         />
-                    </form>
+                    </FormControl>
                     <DaySelector onSelectDay={handleDayChange} days={props.customEvent?.days} />
                     <BuildingSelect value={building} onChange={handleBuildingChange} variant="outlined" />
                     <ScheduleSelector
@@ -219,16 +224,12 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
                     />
                 </DialogContent>
 
-                <DialogActions style={{ padding: '0px 16px 16px' }}>
+                <DialogActions>
                     <Button onClick={handleClose} color={isDark ? 'secondary' : 'primary'}>
                         Cancel
                     </Button>
                     <Button onClick={handleSubmit} variant="contained" color="primary" disabled={disabled}>
-                        {disabled
-                            ? 'Schedule and day must be checked'
-                            : props.customEvent
-                              ? 'Save Changes'
-                              : 'Add Event'}
+                        {disabled ? 'Specify schedule and day' : props.customEvent ? 'Save Changes' : 'Add Event'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -1,8 +1,6 @@
 import { Button, Box } from '@material-ui/core';
 import { useEffect, useState } from 'react';
 
-import { useThemeStore } from '$stores/SettingsStore';
-
 const normal_days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 interface DaySelectorProps {
@@ -12,8 +10,6 @@ interface DaySelectorProps {
 
 const DaySelector = ({ days = [false, false, false, false, false, false, false], onSelectDay }: DaySelectorProps) => {
     const [selectedDays, setSelectedDays] = useState(days);
-
-    const { isDark } = useThemeStore();
 
     useEffect(() => {
         onSelectDay(selectedDays);
@@ -30,7 +26,7 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
             sx={{
                 display: 'flex',
                 flexDirection: 'row',
-                justifyContent: 'space-evenly',
+                justifyContent: 'space-between',
                 marginTop: 10,
                 marginBottom: 10,
                 marginLeft: -5,
@@ -42,16 +38,17 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                     key={index}
                     variant={selectedDays[index] ? 'contained' : 'outlined'}
                     size="small"
+                    fullWidth
                     onClick={() => {
                         handleChange(index);
                     }}
-                    color={isDark ? 'default' : 'primary'}
+                    color={'default'}
                     style={{
+                        display: 'block',
+                        aspectRatio: 1 / 1,
                         margin: 5,
-                        width: 40,
-                        maxWidth: 40,
                         minWidth: 20,
-                        aspectRatio: 1,
+                        minBlockSize: 40,
                     }}
                 >
                     {day[0]}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -32,6 +32,7 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                 marginLeft: -5,
                 marginRight: -5,
             }}
+                    style={{ gap: '10px' }}
         >
             {normal_days.map((day, index) => (
                 <Button
@@ -39,9 +40,7 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                     variant={selectedDays[index] ? 'contained' : 'outlined'}
                     size="small"
                     fullWidth
-                    onClick={() => {
-                        handleChange(index);
-                    }}
+                    onClick={() => handleChange(index)}
                     color={'default'}
                     style={{
                         display: 'block',

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -27,12 +27,10 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                 display: 'flex',
                 flexDirection: 'row',
                 justifyContent: 'space-between',
-                marginTop: 10,
-                marginBottom: 10,
-                marginLeft: -5,
-                marginRight: -5,
+                marginTop: 12,
+                marginBottom: 12,
             }}
-                    style={{ gap: '10px' }}
+            style={{ gap: '12px' }}
         >
             {normal_days.map((day, index) => (
                 <Button
@@ -45,9 +43,8 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                     style={{
                         display: 'block',
                         aspectRatio: 1 / 1,
-                        margin: 5,
                         minWidth: 20,
-                        minBlockSize: 40,
+                        minHeight: 40,
                     }}
                 >
                     {day[0]}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -27,8 +27,6 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                 display: 'flex',
                 flexDirection: 'row',
                 justifyContent: 'space-between',
-                marginTop: 12,
-                marginBottom: 12,
             }}
             style={{ gap: '12px' }}
         >

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -30,8 +30,11 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
             sx={{
                 display: 'flex',
                 flexDirection: 'row',
-                justifyContent: 'center',
-                padding: 5,
+                justifyContent: 'space-evenly',
+                marginTop: 10,
+                marginBottom: 10,
+                marginLeft: -5,
+                marginRight: -5,
             }}
         >
             {normal_days.map((day, index) => (
@@ -45,8 +48,9 @@ const DaySelector = ({ days = [false, false, false, false, false, false, false],
                     color={isDark ? 'default' : 'primary'}
                     style={{
                         margin: 5,
+                        width: 40,
                         maxWidth: 40,
-                        minWidth: 40,
+                        minWidth: 20,
                         aspectRatio: 1,
                     }}
                 >

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -1,6 +1,8 @@
 import Checkbox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
+import FormLabel from '@material-ui/core/FormLabel';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
 import { PureComponent } from 'react';
 
@@ -39,24 +41,29 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
 
     render() {
         return (
-            <FormGroup row>
-                {this.props.scheduleNames.map((name, index) => {
-                    return (
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={this.state.scheduleIndices.includes(index)}
-                                    onChange={this.handleChange(index)}
-                                    value={index + 1}
-                                    color="primary"
-                                />
-                            }
-                            label={name}
-                            key={name}
-                        />
-                    );
-                })}
-            </FormGroup>
+            <FormControl style={{ marginTop: 10 }}>
+                <FormLabel component="legend" style={{ marginTop: 10 }}>
+                    Select schedules
+                </FormLabel>
+                <FormGroup row>
+                    {this.props.scheduleNames.map((name, index) => {
+                        return (
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={this.state.scheduleIndices.includes(index)}
+                                        onChange={this.handleChange(index)}
+                                        value={index + 1}
+                                        color="primary"
+                                    />
+                                }
+                                label={name}
+                                key={name}
+                            />
+                        );
+                    })}
+                </FormGroup>
+            </FormControl>
         );
     }
 }

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -1,9 +1,12 @@
-import Checkbox from '@material-ui/core/Checkbox';
 import FormControl from '@material-ui/core/FormControl';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormLabel from '@material-ui/core/FormLabel';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { int } from 'aws-sdk/clients/datapipeline';
 import { PureComponent } from 'react';
 
 interface ScheduleSelectorProps {
@@ -22,47 +25,44 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
         scheduleIndices: this.props.scheduleIndices,
     };
 
-    handleChange = (dayIndex: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
-        const checked = event.target.checked;
+    handleChange = (event: SelectChangeEvent<typeof this.state.scheduleIndices>) => {
+        const value = event.target.value as number[];
 
-        this.setState(
-            (prevState) => {
-                const newScheduleIndices = checked
-                    ? [...prevState.scheduleIndices, dayIndex]
-                    : prevState.scheduleIndices.filter((scheduleIndex) => {
-                          return scheduleIndex !== dayIndex;
-                      });
-
-                return { scheduleIndices: newScheduleIndices };
-            },
-            () => this.props.onSelectScheduleIndices(this.state.scheduleIndices)
-        );
+        this.setState({ scheduleIndices: value }, () => this.props.onSelectScheduleIndices(this.state.scheduleIndices));
     };
 
     render() {
         return (
-            <FormControl style={{ marginTop: 10 }}>
-                <FormLabel component="legend" style={{ marginTop: 10 }}>
+            <FormControl style={{ marginTop: 10, maxWidth: 400 }} fullWidth variant="outlined">
+                <InputLabel id="schedule-select-label" htmlFor="select-multiple-chip">
                     Select schedules
-                </FormLabel>
-                <FormGroup row>
-                    {this.props.scheduleNames.map((name, index) => {
+                </InputLabel>
+                <Select
+                    labelId="schedule-select-label"
+                    id="schedule-select"
+                    size="small"
+                    style={{ marginTop: 2 }}
+                    multiple
+                    value={this.state.scheduleIndices}
+                    defaultValue={this.state.scheduleIndices}
+                    onChange={this.handleChange}
+                    input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
+                    renderValue={(selected) => (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                            {selected.map((value: int) => {
+                                return <Chip key={value} label={this.props.scheduleNames[value]} />;
+                            })}
+                        </Box>
+                    )}
+                >
+                    {this.props.scheduleNames.map((name: string, index: int) => {
                         return (
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        checked={this.state.scheduleIndices.includes(index)}
-                                        onChange={this.handleChange(index)}
-                                        value={index + 1}
-                                        color="primary"
-                                    />
-                                }
-                                label={name}
-                                key={name}
-                            />
+                            <MenuItem key={index} value={index}>
+                                {name}
+                            </MenuItem>
                         );
                     })}
-                </FormGroup>
+                </Select>
             </FormControl>
         );
     }

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -6,7 +6,6 @@ import MenuItem from '@mui/material/MenuItem';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import { int } from 'aws-sdk/clients/datapipeline';
 import { PureComponent } from 'react';
 
 interface ScheduleSelectorProps {
@@ -49,13 +48,13 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
                     input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
                     renderValue={(selected) => (
                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                            {selected.map((value: int) => {
+                            {selected.map((value: number) => {
                                 return <Chip key={value} label={this.props.scheduleNames[value]} />;
                             })}
                         </Box>
                     )}
                 >
-                    {this.props.scheduleNames.map((name: string, index: int) => {
+                    {this.props.scheduleNames.map((name: string, index: number) => {
                         return (
                             <MenuItem key={index} value={index}>
                                 {name}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -32,7 +32,7 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
 
     render() {
         return (
-            <FormControl style={{ marginTop: 10, maxWidth: 400 }} fullWidth variant="outlined">
+            <FormControl style={{ marginTop: '12px', maxWidth: 400 }} fullWidth variant="outlined">
                 <InputLabel id="schedule-select-label" htmlFor="select-multiple-chip">
                     Select schedules
                 </InputLabel>
@@ -40,7 +40,6 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
                     labelId="schedule-select-label"
                     id="schedule-select"
                     size="small"
-                    style={{ marginTop: 2 }}
                     multiple
                     value={this.state.scheduleIndices}
                     defaultValue={this.state.scheduleIndices}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -32,7 +32,7 @@ class ScheduleSelector extends PureComponent<ScheduleSelectorProps, ScheduleSele
 
     render() {
         return (
-            <FormControl style={{ marginTop: '12px', maxWidth: 400 }} fullWidth variant="outlined">
+            <FormControl style={{ maxWidth: 400 }} fullWidth variant="outlined">
                 <InputLabel id="schedule-select-label" htmlFor="select-multiple-chip">
                     Select schedules
                 </InputLabel>

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -313,7 +313,7 @@ export default function CourseMap() {
                             <Tab key={day} label={day} sx={{ padding: 1, minHeight: 'auto', minWidth: '10%' }} />
                         ))}
                     </Tabs>
-                    <BuildingSelect onChange={onBuildingChange} />
+                    <BuildingSelect onChange={onBuildingChange} variant="filled" />
                 </Paper>
 
                 <TileLayer

--- a/apps/antalmanac/src/components/inputs/building-select.tsx
+++ b/apps/antalmanac/src/components/inputs/building-select.tsx
@@ -21,6 +21,7 @@ const buildings: ExtendedBuilding[] = Object.entries(buildingCatalogue)
 export type BuildingSelectProps = {
     value?: string;
     onChange?: (building?: ExtendedBuilding | null) => unknown;
+    variant?: 'standard' | 'filled' | 'outlined' | undefined;
 };
 
 export function BuildingSelect(props: BuildingSelectProps) {
@@ -53,7 +54,7 @@ export function BuildingSelect(props: BuildingSelectProps) {
             isOptionEqualToValue={(option, value) => option.id === value?.id}
             getOptionLabel={(option) => option.name ?? ''}
             onChange={handleChange}
-            renderInput={(params) => <TextField {...params} label="Search for a place" variant="filled" />}
+            renderInput={(params) => <TextField {...params} label="Search for a place" variant={props.variant} />}
         />
     );
 }


### PR DESCRIPTION
## Summary
Restyled the custom events modal:
- Changed schedule select from checkbox to chip multiple select
  - This is so not all the schedules appear in the main modal (the mass of checkboxes for every schedule is what I'm assuming is mainly contributing to the "ugliness" of the modal)
- Added select variant to Building select props to maintain consistency of outlined style
  - Building select in custom events modal is now outlined variant, while in Maps it is the filled variant
<img width="578" alt="image" src="https://github.com/user-attachments/assets/56b5123b-53c7-49c9-8dc7-d40d2281217c">

It should look better with multiple schedules selected now.
<img width="520" alt="image" src="https://github.com/user-attachments/assets/8a8d7cb0-8c54-4095-ae48-f8ffb67aa5fc">


## Test Plan
Test on different device viewports: Computer (16x9); Tablet (iPad Pro); phone (iPhone 14 pro max); small phone (iPhone SE or any width < 400px)
Test with multiple schedules: 5, 10, 20 schedules selected & make sure the modal doesn't turn ugly.
Test that schedules are selected and the custom event is properly added for all schedules chosen
Test that schedules can be correctly deselected and that they don't have the custom event added to them
Test that the Building selector correctly searches up places in both the custom events modal and Map view, since I made a few changes to it

## Issues

Closes #1025

<!-- [Optional]
## Future Followup
-->
