### PR TITLE
Increase lambda timeout to 10 seconds

### DIFF
--- a/apps/cdk/src/stacks/backend.ts
+++ b/apps/cdk/src/stacks/backend.ts
@@ -53,7 +53,7 @@ export class BackendStack extends Stack {
             runtime: lambda.Runtime.NODEJS_18_X,
             code: lambda.Code.fromAsset('../backend/dist'),
             handler: 'lambda.handler',
-            timeout: Duration.seconds(5),
+            timeout: Duration.seconds(10),
             memorySize: 256,
             environment: {
                 ...env,


### PR DESCRIPTION
## Summary
- We were having some timeouts on save, possibly because our DB queries were taking longer than the previous five-second limit.
- Manually increasing the limit on the current deployment fixed the issue.
- The problem might be that, with auto-save, we send multiple requests that have to written and overwritten sequentially, and the "queue time" can exceed five seconds.

## Future Follow-Up
- Have a timer so we don't auto-save every action.
- Somehow cancel the previous update to a schedule if a new one comes in. Not sure how this is possible.