### PR TITLE
Schedule Name Alt Text Expansion

### DIFF
--- a/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -83,20 +83,20 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
 
     return (
         <Box>
-            <Button
-                size="small"
-                color="inherit"
-                variant="outlined"
-                onClick={handleClick}
-                sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
-            >
-                <Tooltip title={currentScheduleName} enterDelay={200} disableInteractive placement="right">
+            <Tooltip title={currentScheduleName} enterDelay={200} disableInteractive>
+                <Button
+                    size="small"
+                    color="inherit"
+                    variant="outlined"
+                    onClick={handleClick}
+                    sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
+                >
                     <Typography whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden" textTransform="none">
                         {currentScheduleName}
                     </Typography>
-                </Tooltip>
-                <ArrowDropDownIcon />
-            </Button>
+                    <ArrowDropDownIcon />
+                </Button>
+            </Tooltip>
 
             <Popover
                 open={open}
@@ -108,24 +108,22 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                     {props.scheduleNames.map((name, index) => (
                         <Box key={index} display="flex" alignItems="center" gap={1}>
                             <Box flexGrow={1}>
-                                <Button
-                                    color="inherit"
-                                    sx={{
-                                        minWidth,
-                                        maxWidth,
-                                        width: '100%',
-                                        display: 'flex',
-                                        justifyContent: 'flex-start',
-                                        background:
-                                            index === currentScheduleIndex ? theme.palette.action.selected : undefined,
-                                        '&:hover': {
-                                            backgroundColor: theme.palette.action.hover,
-                                            transition: 'background-color 0.2s',
-                                        },
-                                    }}
-                                    onClick={createScheduleSelector(index)}
-                                >
-                                    <Tooltip title={name} enterDelay={200} disableInteractive placement="right">
+                                <Tooltip title={name} enterDelay={200} disableInteractive>
+                                    <Button
+                                        color="inherit"
+                                        sx={{
+                                            minWidth,
+                                            maxWidth,
+                                            width: '100%',
+                                            display: 'flex',
+                                            justifyContent: 'flex-start',
+                                            background:
+                                                index === currentScheduleIndex
+                                                    ? theme.palette.action.selected
+                                                    : undefined,
+                                        }}
+                                        onClick={createScheduleSelector(index)}
+                                    >
                                         <Typography
                                             overflow="hidden"
                                             whiteSpace="nowrap"
@@ -134,8 +132,8 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                                         >
                                             {name}
                                         </Typography>
-                                    </Tooltip>
-                                </Button>
+                                    </Button>
+                                </Tooltip>
                             </Box>
                             <Box display="flex" alignItems="center" gap={0.5}>
                                 <CopyScheduleButton index={index} disabled={skeletonMode} />

--- a/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -1,6 +1,6 @@
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
 import { Box, Button, Popover, Typography, useTheme, Tooltip } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState, useRef, ReactElement, cloneElement } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { changeCurrentSchedule } from '$actions/AppStoreActions';
 import { AddScheduleButton } from '$components/Calendar/toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton';
@@ -25,32 +25,6 @@ function createScheduleSelector(index: number) {
     return () => {
         handleScheduleChange(index);
     };
-}
-
-function TooltipIfTruncated({ children, text }: { children: ReactElement; text: string }) {
-    const textElementRef = useRef<HTMLElement>();
-    const [isTextTruncated, setIsTextTruncated] = useState(false);
-
-    useEffect(() => {
-        const element = textElementRef.current;
-        if (element) {
-            setIsTextTruncated(element.scrollWidth > element.clientWidth);
-        }
-    }, [text]);
-
-    const childrenWithRef = cloneElement(children, {
-        ref: textElementRef,
-    });
-
-    if (!isTextTruncated) {
-        return childrenWithRef;
-    }
-
-    return (
-        <Tooltip title={text} enterDelay={200} disableInteractive>
-            {childrenWithRef}
-        </Tooltip>
-    );
 }
 
 /**
@@ -116,9 +90,11 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                 onClick={handleClick}
                 sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
             >
-                <Typography whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden" textTransform="none">
-                    {currentScheduleName}
-                </Typography>
+                <Tooltip title={currentScheduleName} enterDelay={200} disableInteractive placement="right">
+                    <Typography whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden" textTransform="none">
+                        {currentScheduleName}
+                    </Typography>
+                </Tooltip>
                 <ArrowDropDownIcon />
             </Button>
 
@@ -149,7 +125,7 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                                     }}
                                     onClick={createScheduleSelector(index)}
                                 >
-                                    <TooltipIfTruncated text={name}>
+                                    <Tooltip title={name} enterDelay={200} disableInteractive placement="right">
                                         <Typography
                                             overflow="hidden"
                                             whiteSpace="nowrap"
@@ -158,7 +134,7 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                                         >
                                             {name}
                                         </Typography>
-                                    </TooltipIfTruncated>
+                                    </Tooltip>
                                 </Button>
                             </Box>
                             <Box display="flex" alignItems="center" gap={0.5}>

--- a/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -1,6 +1,6 @@
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
-import { Box, Button, Popover, Typography, useTheme } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Button, Popover, Typography, useTheme, Tooltip } from '@mui/material';
+import { useCallback, useEffect, useMemo, useState, useRef, ReactElement } from 'react';
 
 import { changeCurrentSchedule } from '$actions/AppStoreActions';
 import { AddScheduleButton } from '$components/Calendar/toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton';
@@ -25,6 +25,32 @@ function createScheduleSelector(index: number) {
     return () => {
         handleScheduleChange(index);
     };
+}
+
+function TooltipIfTruncated({ children, text }: { children: ReactElement; text: string }) {
+    const textElementRef = useRef<HTMLElement>();
+    const [isTextTruncated, setIsTextTruncated] = useState(false);
+
+    useEffect(() => {
+        const element = textElementRef.current;
+        if (element) {
+            setIsTextTruncated(element.scrollWidth > element.clientWidth);
+        }
+    }, [text]);
+
+    const childrenWithRef = React.cloneElement(children, {
+        ref: textElementRef,
+    });
+
+    if (!isTextTruncated) {
+        return childrenWithRef;
+    }
+
+    return (
+        <Tooltip title={text} enterDelay={200}>
+            {childrenWithRef}
+        </Tooltip>
+    );
 }
 
 /**
@@ -116,17 +142,23 @@ export function SelectSchedulePopover(props: { scheduleNames: string[] }) {
                                         justifyContent: 'flex-start',
                                         background:
                                             index === currentScheduleIndex ? theme.palette.action.selected : undefined,
+                                        '&:hover': {
+                                            backgroundColor: theme.palette.action.hover,
+                                            transition: 'background-color 0.2s',
+                                        },
                                     }}
                                     onClick={createScheduleSelector(index)}
                                 >
-                                    <Typography
-                                        overflow="hidden"
-                                        whiteSpace="nowrap"
-                                        textTransform="none"
-                                        textOverflow="ellipsis"
-                                    >
-                                        {name}
-                                    </Typography>
+                                    <TooltipIfTruncated text={name}>
+                                        <Typography
+                                            overflow="hidden"
+                                            whiteSpace="nowrap"
+                                            textTransform="none"
+                                            textOverflow="ellipsis"
+                                        >
+                                            {name}
+                                        </Typography>
+                                    </TooltipIfTruncated>
                                 </Button>
                             </Box>
                             <Box display="flex" alignItems="center" gap={0.5}>

--- a/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -1,6 +1,6 @@
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
 import { Box, Button, Popover, Typography, useTheme, Tooltip } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState, useRef, ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState, useRef, ReactElement, cloneElement } from 'react';
 
 import { changeCurrentSchedule } from '$actions/AppStoreActions';
 import { AddScheduleButton } from '$components/Calendar/toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton';
@@ -38,7 +38,7 @@ function TooltipIfTruncated({ children, text }: { children: ReactElement; text: 
         }
     }, [text]);
 
-    const childrenWithRef = React.cloneElement(children, {
+    const childrenWithRef = cloneElement(children, {
         ref: textElementRef,
     });
 
@@ -47,7 +47,7 @@ function TooltipIfTruncated({ children, text }: { children: ReactElement; text: 
     }
 
     return (
-        <Tooltip title={text} enterDelay={200}>
+        <Tooltip title={text} enterDelay={200} disableInteractive>
             {childrenWithRef}
         </Tooltip>
     );


### PR DESCRIPTION
## Summary
Added an alt text pop up that displays the full names of schedules who's names were truncated.

Key features:
- Tooltip only appears for truncated schedule names
- Non-interactive tooltip that doesn't block clicking on other schedule items
- 200ms delay to prevent unwanted popups during quick mouse movements
- Maintains existing button styling and interaction behavior

![AntalmanacHoverChange](https://github.com/user-attachments/assets/eb7b1785-3220-4614-a21d-3cc5d8cf22e9)
## Test Plan
1. Create a schedule with a long name
2. Verify the name is truncated in the dropdown menu
3. Hover over the truncated name to confirm the tooltip appears showing the full name

## Issues

Closes #1072

<!-- [Optional]
## Future Followup
-->
