### PR TITLE
fix: leftpad section codes

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -531,7 +531,7 @@ export class Schedules {
                 for (const shortCourse of shortCourseSchedule.courses) {
                     const courseInfoMap = courseInfoDict.get(shortCourse.term);
                     if (courseInfoMap !== undefined) {
-                        const courseInfo = courseInfoMap[shortCourse.sectionCode];
+                        const courseInfo = courseInfoMap[shortCourse.sectionCode.padStart(5, '0')];
                         if (courseInfo === undefined) {
                             // Class doesn't exist/was cancelled
                             continue;
@@ -555,6 +555,13 @@ export class Schedules {
                     // just give each schedule an empty schedule note
                     this.scheduleNoteMap[scheduleNoteId] = '';
                 }
+
+                console.log({
+                    scheduleName: shortCourseSchedule.scheduleName,
+                    courses: courses,
+                    customEvents: shortCourseSchedule.customEvents,
+                    scheduleNoteId: scheduleNoteId,
+                });
 
                 this.schedules.push({
                     scheduleName: shortCourseSchedule.scheduleName,

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -556,13 +556,6 @@ export class Schedules {
                     this.scheduleNoteMap[scheduleNoteId] = '';
                 }
 
-                console.log({
-                    scheduleName: shortCourseSchedule.scheduleName,
-                    courses: courses,
-                    customEvents: shortCourseSchedule.customEvents,
-                    scheduleNoteId: scheduleNoteId,
-                });
-
                 this.schedules.push({
                     scheduleName: shortCourseSchedule.scheduleName,
                     courses: courses,


### PR DESCRIPTION
## Summary
1. Courses with section codes less than 5 digits long are stored in AntAlmanac as is (`5001` -> `5001`). The API provides them as 5 digit leftpad strings. This was resulting in us not correctly loading in courses (most critically, BIO SCI).

<img width="636" alt="Screenshot_2024-12-21_at_8 07 13_PM" src="https://github.com/user-attachments/assets/286e9ac0-03d0-4087-b024-b528c3e3b566" />

Above: Saved AA Data
Below: API response

## Test Plan
1. Add and save courses from the 0 - 9,999 section code range
3. Loading the courses in should work as expected
4. Add and save courses from the 10,000 - 99,999 range.
5. Loading the courses should be as expected
6. Doing both together should work as expected

## Issues
Closes Bug Report

<!-- [Optional]
## Future Followup
-->
