### PR TITLE
feat: Course Shorcut Search From Calendar Events  

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -9,11 +9,14 @@ import { Calendar, DateLocalizer, momentLocalizer, Views } from 'react-big-calen
 import CalendarToolbar from './CalendarToolbar';
 import CourseCalendarEvent, { CalendarEvent, CourseEvent } from './CourseCalendarEvent';
 
+import depts from '$components/RightPane/CoursePane/SearchForm/DeptSearchBar/depts';
 import locationIds from '$lib/location_ids';
 import { getDefaultFinalsStartDate, getFinalsStartDateForTerm } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
+import { useQuickClassStore } from '$stores/QuickClassStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
+import { useTabStore } from '$stores/TabStore';
 
 const localizer = momentLocalizer(moment);
 
@@ -31,7 +34,6 @@ const AntAlmanacEvent = ({ event }: { event: CalendarEvent }) => {
             >
                 <Box>{event.title}</Box>
             </Box>
-
             <Box style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', fontSize: '0.7rem' }}>
                 <Box>{Object.keys(locationIds).find((key) => locationIds[key] === parseInt(event.building))}</Box>
             </Box>
@@ -111,6 +113,22 @@ export default function ScheduleCalendar(_props?: ScheduleCalendarProps) {
             setAnchorEl((prevAnchorEl) => (prevAnchorEl === currentTarget ? null : currentTarget));
             setCourseInMoreInfo(event);
             setCalendarEventKey(Math.random());
+        }
+    };
+
+    const shortCutClick = () => {
+        const decompCourseInfo: string[] | undefined = courseInMoreInfo?.title.match(/^(.*)\s(\S+)$/)?.slice(1);
+        const tabNum = useTabStore.getState().activeTab;
+
+        // tabNum == 1 locks this feature to only the Search page (even on mobile)
+        if (decompCourseInfo && tabNum == 1) {
+            const deptIdx: number = depts.findIndex((item) => item.deptValue === decompCourseInfo[0]);
+            useQuickClassStore.getState().setValue({
+                term: (courseInMoreInfo as CourseEvent)?.term,
+                deptLabel: depts[deptIdx].deptLabel,
+                deptValue: decompCourseInfo[0],
+                courseNumber: decompCourseInfo[1],
+            });
         }
     };
 
@@ -286,6 +304,7 @@ export default function ScheduleCalendar(_props?: ScheduleCalendarProps) {
                     showMultiDayTimes={false}
                     components={{ event: AntAlmanacEvent }}
                     onSelectEvent={handleEventClick}
+                    onDoubleClickEvent={() => shortCutClick()}
                 />
             </Box>
         </Box>

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -2,13 +2,10 @@ import { AppBar, Toolbar } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 
-
 import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
 import { Logo } from './Logo';
 import AppDrawer from './SettingsMenu';
-
-import { useQuickClassStore } from '$stores/QuickClassStore';
 
 const styles = {
     appBar: {
@@ -38,14 +35,10 @@ interface CustomAppBarProps {
 }
 
 const Header = ({ classes }: CustomAppBarProps) => {
-    function dosomething() {
-        useQuickClassStore.getState().setValue('34270');
-    }
     return (
         <AppBar position="static" className={classes.appBar}>
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
                 <Logo />
-                <button onClick={dosomething}>test</button>
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <LoadSaveScheduleFunctionality />
                     <Import key="studylist" />

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -2,10 +2,13 @@ import { AppBar, Toolbar } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 
+
 import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
 import { Logo } from './Logo';
 import AppDrawer from './SettingsMenu';
+
+import { useQuickClassStore } from '$stores/QuickClassStore';
 
 const styles = {
     appBar: {
@@ -35,11 +38,14 @@ interface CustomAppBarProps {
 }
 
 const Header = ({ classes }: CustomAppBarProps) => {
+    function dosomething() {
+        useQuickClassStore.getState().setValue('34270');
+    }
     return (
         <AppBar position="static" className={classes.appBar}>
             <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
                 <Logo />
-
+                <button onClick={dosomething}>test</button>
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <LoadSaveScheduleFunctionality />
                     <Import key="studylist" />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -12,6 +12,7 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { Grades } from '$lib/grades';
 import { WebSOC } from '$lib/websoc';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
+import { useQuickClassStore } from '$stores/QuickClassStore';
 
 function RightPane() {
     const { key, forceUpdate, searchIsDisplayed, displaySearch, displaySections } = useCoursePaneStore();
@@ -27,6 +28,11 @@ function RightPane() {
             );
         }
     }, [displaySections, forceUpdate]);
+
+    useQuickClassStore.subscribe((state) => {
+        RightPaneStore.updateFormValue('sectionCode', state.value);
+        handleSearch();
+    });
 
     const refreshSearch = useCallback(() => {
         logAnalytics({

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -30,7 +30,10 @@ export function CoursePaneRoot() {
     }, [displaySections, forceUpdate]);
 
     useQuickClassStore.subscribe((state) => {
-        RightPaneStore.updateFormValue('sectionCode', state.value);
+        const decomp = state.value;
+        RightPaneStore.updateFormValue('deptLabel', decomp.deptLabel);
+        RightPaneStore.updateFormValue('deptValue', decomp.deptValue);
+        RightPaneStore.updateFormValue('courseNumber', decomp.courseNumber);
         handleSearch();
     });
 

--- a/apps/antalmanac/src/stores/QuickClassStore.ts
+++ b/apps/antalmanac/src/stores/QuickClassStore.ts
@@ -1,14 +1,22 @@
 import { create } from 'zustand';
 
+type CourseInfo = {
+    term: string; // e.g., "Fall 2024", "Spring 2025"
+    deptLabel: string; // e.g., "COMPSCI", "MATH"
+    courseNumber: string; // e.g., "171", "101"
+    deptValue: string; // e.g., "171", "101"
+};
+
 interface QuickClassStore {
-    value: string;
-    setValue: (newValue: string) => void;
+    value: CourseInfo;
+    setValue: (newValue: CourseInfo) => void;
 }
+
 export const useQuickClassStore = create<QuickClassStore>((set) => ({
-    value: '', // Initial value of the string
-    setValue: (newValue: string) => {
+    value: { term: '', deptLabel: '', courseNumber: '', deptValue: '' },
+    setValue: (newValue: CourseInfo) => {
         set(() => ({
-            value: newValue, // Update the string value
+            value: newValue,
         }));
     },
 }));

--- a/apps/antalmanac/src/stores/QuickClassStore.ts
+++ b/apps/antalmanac/src/stores/QuickClassStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface QuickClassStore {
+    value: string;
+    setValue: (newValue: string) => void;
+}
+export const useQuickClassStore = create<QuickClassStore>((set) => ({
+    value: '', // Initial value of the string
+    setValue: (newValue: string) => {
+        set(() => ({
+            value: newValue, // Update the string value
+        }));
+    },
+}));


### PR DESCRIPTION
## Summary
Users can now quickly search for courses they've selected by double clicking the event in their calendar 

This is meant to enhance the user experience by reducing the redundancy of having re-search a course if a user wants to select or preview different time slots 

[Video Demo](https://vimeo.com/1041581472?share=copy#t=0)

## Test Plan
- Add different lec/dis/sem to the calendar and double clicking the event will bring up the course and all associated disc/lecs 
- Using the shortcut and searching shouldn't affect either actions (this was a problem in development)

## Issues
- This feature is locked for mobile to avoid clunky behavior 
- The search is only preformed when the user is on the Search tab. If the user is on the 'Added' or 'Map' the search won't display (this is subject to change based on how the feature feels)
 
Closes #1046

<!-- [Optional]
## Future Followup
-->
