### PR TITLE
fix: add copy, rename, and delete as unsaved actions properly

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -57,6 +57,11 @@ export interface ClearScheduleAction {
     type: 'clearSchedule';
 }
 
+export interface AddScheduleAction {
+    type: 'addSchedule';
+    newScheduleName: string;
+}
+
 export interface RenameScheduleAction {
     type: 'renameSchedule';
     scheduleIndex: number;
@@ -89,6 +94,7 @@ export type ActionType =
     | EditCustomEventAction
     | ChangeCustomEventColorAction
     | ClearScheduleAction
+    | AddScheduleAction
     | RenameScheduleAction
     | DeleteScheduleAction
     | CopyScheduleAction
@@ -171,6 +177,9 @@ class ActionTypesStore extends EventEmitter {
                     break;
                 case 'clearSchedule':
                     AppStore.schedule.clearCurrentSchedule();
+                    break;
+                case 'addSchedule':
+                    AppStore.schedule.addNewSchedule(action.newScheduleName);
                     break;
                 case 'renameSchedule':
                     AppStore.schedule.renameSchedule(action.scheduleIndex, action.newScheduleName);

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -57,8 +57,20 @@ export interface ClearScheduleAction {
     type: 'clearSchedule';
 }
 
+export interface RenameScheduleAction {
+    type: 'renameSchedule';
+    scheduleIndex: number;
+    newScheduleName: string;
+}
+
+export interface DeleteScheduleAction {
+    type: 'deleteSchedule';
+    scheduleIndex: number;
+}
+
 export interface CopyScheduleAction {
     type: 'copySchedule';
+    scheduleIndex: number;
     newScheduleName: string;
 }
 
@@ -77,6 +89,8 @@ export type ActionType =
     | EditCustomEventAction
     | ChangeCustomEventColorAction
     | ClearScheduleAction
+    | RenameScheduleAction
+    | DeleteScheduleAction
     | CopyScheduleAction
     | ChangeCourseColorAction
     | UndoAction;
@@ -158,8 +172,14 @@ class ActionTypesStore extends EventEmitter {
                 case 'clearSchedule':
                     AppStore.schedule.clearCurrentSchedule();
                     break;
+                case 'renameSchedule':
+                    AppStore.schedule.renameSchedule(action.scheduleIndex, action.newScheduleName);
+                    break;
                 case 'copySchedule':
-                    AppStore.schedule.copySchedule(action.newScheduleName);
+                    AppStore.schedule.copySchedule(action.scheduleIndex, action.newScheduleName);
+                    break;
+                case 'deleteSchedule':
+                    AppStore.schedule.deleteSchedule(action.scheduleIndex);
                     break;
                 default:
                     break;

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -250,14 +250,14 @@ export const changeCourseColor = (sectionCode: string, term: string, newColor: s
     AppStore.changeCourseColor(sectionCode, term, newColor);
 };
 
-export const copySchedule = (newScheduleName: string, options?: CopyScheduleOptions) => {
+export const copySchedule = (scheduleIndex: number, newScheduleName: string, options?: CopyScheduleOptions) => {
     logAnalytics({
         category: analyticsEnum.addedClasses.title,
         action: analyticsEnum.addedClasses.actions.COPY_SCHEDULE,
     });
 
     try {
-        AppStore.copySchedule(newScheduleName);
+        AppStore.copySchedule(scheduleIndex, newScheduleName);
         options?.onSuccess(newScheduleName);
     } catch (error) {
         options?.onError(newScheduleName);
@@ -268,8 +268,8 @@ export const addSchedule = (scheduleName: string) => {
     AppStore.addSchedule(scheduleName);
 };
 
-export const renameSchedule = (scheduleName: string, scheduleIndex: number) => {
-    AppStore.renameSchedule(scheduleName, scheduleIndex);
+export const renameSchedule = (scheduleIndex: number, scheduleName: string) => {
+    AppStore.renameSchedule(scheduleIndex, scheduleName);
 };
 
 export const deleteSchedule = (scheduleIndex: number) => {

--- a/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/EditSchedule/ScheduleNameDialog.tsx
@@ -77,7 +77,7 @@ const ScheduleNameDialog = forwardRef((props: ScheduleNameDialogProps, ref) => {
         onClose?.();
 
         if (rename) {
-            renameSchedule(scheduleName, scheduleRenameIndex as number); // typecast works b/c this function only runs when `const rename = scheduleRenameIndex !== undefined` is true.
+            renameSchedule(scheduleRenameIndex as number, scheduleName); // typecast works b/c this function only runs when `const rename = scheduleRenameIndex !== undefined` is true.
         } else {
             addSchedule(scheduleName);
         }

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -13,7 +13,7 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
     const isDark = useThemeStore((store) => store.isDark);
 
     const [name, setName] = useState(
-        AppStore.getNextScheduleName(AppStore.getDefaultScheduleName(), AppStore.getScheduleNames().length)
+        AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName())
     );
 
     const handleCancel = () => {
@@ -48,7 +48,7 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
     };
 
     const handleScheduleNamesChange = useCallback(() => {
-        setName(AppStore.getNextScheduleName(AppStore.getDefaultScheduleName(), AppStore.getScheduleNames().length));
+        setName(AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName()));
     }, []);
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -13,7 +13,7 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
     const isDark = useThemeStore((store) => store.isDark);
 
     const [name, setName] = useState(
-        AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName())
+        AppStore.getNextScheduleName(() => AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName())
     );
 
     const handleCancel = () => {

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -31,7 +31,7 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
     }, [onClose]);
 
     const handleCopy = useCallback(() => {
-        copySchedule(name);
+        copySchedule(index, name);
         onClose?.({}, 'escapeKeyDown');
     }, [onClose, name]);
 

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -45,7 +45,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
     }, []);
 
     const submitName = useCallback(() => {
-        renameSchedule(name, index);
+        renameSchedule(index, name);
         onClose?.({}, 'escapeKeyDown');
     }, [onClose, name, index]);
 

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -17,6 +17,7 @@ import type {
     DeleteScheduleAction,
     ChangeCourseColorAction,
     UndoAction,
+    AddScheduleAction,
 } from '$actions/ActionTypesStore';
 import { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { SnackbarPosition } from '$components/NotificationSnackbar';
@@ -282,6 +283,12 @@ class AppStore extends EventEmitter {
         // another key/value pair to keep track of the section codes for that schedule,
         // and redirect the user to the new schedule
         this.schedule.addNewSchedule(newScheduleName);
+        this.unsavedChanges = true;
+        const action: AddScheduleAction = {
+            type: 'addSchedule',
+            newScheduleName: newScheduleName,
+        };
+        actionTypesStore.autoSaveSchedule(action);
         this.emit('scheduleNamesChange');
         this.emit('currentScheduleIndexChange');
         this.emit('scheduleNotesChange');

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -13,6 +13,8 @@ import type {
     ChangeCustomEventColorAction,
     ClearScheduleAction,
     CopyScheduleAction,
+    RenameScheduleAction,
+    DeleteScheduleAction,
     ChangeCourseColorAction,
     UndoAction,
 } from '$actions/ActionTypesStore';
@@ -71,8 +73,8 @@ class AppStore extends EventEmitter {
         }
     }
 
-    getNextScheduleName(newScheduleName: string, scheduleIndex: number) {
-        return this.schedule.getNextScheduleName(newScheduleName, scheduleIndex);
+    getNextScheduleName(scheduleIndex: number, newScheduleName: string) {
+        return this.schedule.getNextScheduleName(scheduleIndex, newScheduleName);
     }
 
     getDefaultScheduleName() {
@@ -285,8 +287,15 @@ class AppStore extends EventEmitter {
         this.emit('scheduleNotesChange');
     }
 
-    renameSchedule(scheduleName: string, scheduleIndex: number) {
-        this.schedule.renameSchedule(scheduleName, scheduleIndex);
+    renameSchedule(scheduleIndex: number, newScheduleName: string) {
+        this.schedule.renameSchedule(scheduleIndex, newScheduleName);
+        this.unsavedChanges = true;
+        const action: RenameScheduleAction = {
+            type: 'renameSchedule',
+            scheduleIndex: scheduleIndex,
+            newScheduleName: newScheduleName,
+        };
+        actionTypesStore.autoSaveSchedule(action);
         this.emit('scheduleNamesChange');
     }
 
@@ -295,11 +304,12 @@ class AppStore extends EventEmitter {
         window.localStorage.removeItem('unsavedActions');
     }
 
-    copySchedule(newScheduleName: string) {
-        this.schedule.copySchedule(newScheduleName);
+    copySchedule(scheduleIndex: number, newScheduleName: string) {
+        this.schedule.copySchedule(scheduleIndex, newScheduleName);
         this.unsavedChanges = true;
         const action: CopyScheduleAction = {
             type: 'copySchedule',
+            scheduleIndex: scheduleIndex,
             newScheduleName: newScheduleName,
         };
         actionTypesStore.autoSaveSchedule(action);
@@ -364,6 +374,12 @@ class AppStore extends EventEmitter {
 
     deleteSchedule(scheduleIndex: number) {
         this.schedule.deleteSchedule(scheduleIndex);
+        this.unsavedChanges = true;
+        const action: DeleteScheduleAction = {
+            type: 'deleteSchedule',
+            scheduleIndex: scheduleIndex,
+        };
+        actionTypesStore.autoSaveSchedule(action);
         this.emit('scheduleNamesChange');
         this.emit('currentScheduleIndexChange');
         this.emit('addedCoursesChange');


### PR DESCRIPTION
## Summary
- Copying, renaming, and deleting schedules are now stored as unsaved actions and can be re-loaded if the user wants to 
- Fixes "an issue where duplicating a schedule that was not currently selected would incorrectly create a new schedule containing the events of the currently selected schedule, instead of duplicating the intended schedule," a bug also fixed in #1089; will fix merge conflicts after either one gets merged into main
- Slight code refactoring for consistency

## Test Plan
- Create several schedules with some events. Duplicate, rename, and delete some. Take note of the order and state of these schedules. Reload the page without saving these changes and load the unsaved changes. Ensure the loaded changes match the schedule states prior to reloading

Closes #1090