### PR TITLE
fix: remove box messing with tooltip offset

### DIFF
--- a/apps/antalmanac/src/components/buttons/Copy.tsx
+++ b/apps/antalmanac/src/components/buttons/Copy.tsx
@@ -1,5 +1,5 @@
 import { ContentCopy } from '@mui/icons-material';
-import { Box, IconButton, SxProps, Tooltip } from '@mui/material';
+import { IconButton, SxProps, Tooltip } from '@mui/material';
 import { useCallback, useState } from 'react';
 
 import CopyScheduleDialog from '$components/dialogs/CopySchedule';
@@ -22,7 +22,7 @@ export function CopyScheduleButton({ index, disabled, buttonSx }: CopyScheduleBu
     }, []);
 
     return (
-        <Box>
+        <>
             <Tooltip title="Copy Schedule">
                 <span>
                     <IconButton sx={buttonSx} onClick={handleOpen} size="small" disabled={disabled}>
@@ -31,6 +31,6 @@ export function CopyScheduleButton({ index, disabled, buttonSx }: CopyScheduleBu
                 </span>
             </Tooltip>
             <CopyScheduleDialog fullWidth open={open} index={index} onClose={handleClose} />
-        </Box>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
The tooltip offset inconsistency for `Copy Schedule` was caused by wrapping the tooltip in a Box. This was changed to an empty tag to match what was used for the other tooltips.

## Test Plan
Hover over the buttons and ensure the tooltips are all the same offset
![chrome-capture-2024-12-30](https://github.com/user-attachments/assets/0fd8b2ef-5301-4549-9161-40e597d22304)

Closes #1093