### PR TITLE
Redirect to the root route on undefined route

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -4,7 +4,7 @@ import { TourProvider } from '@reactour/tour';
 import { SnackbarProvider } from 'notistack';
 import { useEffect } from 'react';
 import ReactGA4 from 'react-ga4';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 
 import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
@@ -29,6 +29,10 @@ const BrowserRouter = createBrowserRouter([
         path: '/feedback',
         element: <Feedback />,
         errorElement: <ErrorPage />,
+    },
+    {
+        path: '*',
+        element: <Navigate to="/" replace />,
     },
 ]);
 


### PR DESCRIPTION
## Summary

Add a redirection to the main route if the given route is undefined

## Test Plan

Any other route than /xyz should be replaced now with root route "/"

## Issues

Closes #1047 

## Future Followup

Consider enhancing this redirection logic by checking if a valid route exists higher in the navigation stack and redirecting to it instead of the root route.
