### PR TITLE
Persist column filters using local storage

### DIFF
--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -13,6 +13,7 @@ enum LocalStorageKeys {
     autoSave = 'autoSave',
     unsavedActions = 'unsavedActions',
     helpBoxDismissalTime = 'helpBoxDismissalTime',
+    columnToggles = 'columnToggles',
 }
 
 const LSK = LocalStorageKeys;
@@ -184,4 +185,13 @@ export function getLocalStorageHelpBoxDismissalTime() {
 
 export function removeLocalStorageHelpBoxDismissalTime() {
     window.localStorage.removeItem(LSK.helpBoxDismissalTime);
+}
+
+// Helper functions for columnToggles
+export function setLocalStorageColumnToggles(value: string) {
+    window.localStorage.setItem(LSK.columnToggles, value);
+}
+
+export function getLocalStorageColumnToggles() {
+    return window.localStorage.getItem(LSK.columnToggles);
 }

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import { getLocalStorageColumnToggles, setLocalStorageColumnToggles } from '$lib/localStorage';
 
 /**
  * Search results are displayed in a tabular format.
@@ -39,7 +40,8 @@ interface ColumnStore {
 }
 
 // Currently, the mapping/filtering does nothing, but this could be used to enable/disable columns.
-const selectedColumnsInitial = SECTION_TABLE_COLUMNS.map(() => true);
+const storedColumns = getLocalStorageColumnToggles();
+const selectedColumnsInitial = storedColumns ? JSON.parse(storedColumns) : SECTION_TABLE_COLUMNS.map(() => true);
 const activeColumnsInitial = SECTION_TABLE_COLUMNS.filter((_, index) => selectedColumnsInitial[index]);
 
 /**
@@ -55,6 +57,9 @@ export const useColumnStore = create<ColumnStore>((set, _) => {
                 const activeColumns: SectionTableColumn[] = SECTION_TABLE_COLUMNS.filter(
                     (_, index) => selectedColumns[index]
                 );
+
+                setLocalStorageColumnToggles(JSON.stringify(selectedColumns));
+
                 console.log('activeColumns', activeColumns);
                 return { selectedColumns, activeColumns };
             });


### PR DESCRIPTION
## Summary

Add persistence for column toggles using local storage. The selected column toggles are saved automatically when toggled and restored on page load.

## Test Plan

1. Verify that all column toggles are checked on the first page load by default
2. Confirm that changes are saved to local storage when toggling on or off 
3. Refresh the page and verify that the toggles remain as they were set before the refresh

## Issues

Closes #1075 
