### PR TITLE
feat: add terms to custom events

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -286,20 +286,22 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
             <Paper className={classes.customEventContainer} ref={paperRef}>
                 <div className={classes.title}>{title}</div>
                 {building && (
-                    <div className={classes.table}>
-                        Location:&nbsp;
-                        <Link
-                            className={classes.clickableLocation}
-                            to={`/map?location=${building ?? 0}`}
-                            onClick={focusMap}
-                        >
-                            {buildingCatalogue[+building]?.name ?? ''}
-                        </Link>
-                    </div>
+                    <tr className={classes.table}>
+                        <td className={classes.alignToTop}>Location</td>
+                        <td className={classes.rightCells}>
+                            <Link
+                                className={classes.clickableLocation}
+                                to={`/map?location=${building ?? 0}`}
+                                onClick={focusMap}
+                            >
+                                {buildingCatalogue[+building]?.name ?? ''}
+                            </Link>
+                        </td>
+                    </tr>
                 )}
                 {term && (
                     <tr className={classes.table}>
-                        <td className={classes.alignToTop}>Term:&nbsp;</td>
+                        <td className={classes.alignToTop}>Term</td>
                         <td className={classes.rightCells}>{term}</td>
                     </tr>
                 )}

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -131,6 +131,7 @@ export interface CustomEvent extends CommonCalendarEvent {
     isCustomEvent: true;
     building: string;
     days: string[];
+    term: string;
 }
 
 export type CalendarEvent = CourseEvent | CustomEvent;
@@ -280,7 +281,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
             </Paper>
         );
     } else {
-        const { title, customEventID, building } = selectedEvent;
+        const { title, customEventID, building, term } = selectedEvent;
         return (
             <Paper className={classes.customEventContainer} ref={paperRef}>
                 <div className={classes.title}>{title}</div>
@@ -295,6 +296,12 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                             {buildingCatalogue[+building]?.name ?? ''}
                         </Link>
                     </div>
+                )}
+                {term && (
+                    <tr className={classes.table}>
+                        <td className={classes.alignToTop}>Term:&nbsp;</td>
+                        <td className={classes.rightCells}>{term}</td>
+                    </tr>
                 )}
                 <div className={classes.buttonBar}>
                     <div className={`${classes.colorPicker}`}>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -20,6 +20,7 @@ import ScheduleSelector from './ScheduleSelector';
 import { addCustomEvent, editCustomEvent } from '$actions/AppStoreActions';
 import { BuildingSelect, ExtendedBuilding } from '$components/inputs/building-select';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import { getLatestTermByShortName } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
@@ -36,6 +37,7 @@ const defaultCustomEventValues: RepeatingCustomEvent = {
     days: [false, false, false, false, false, false, false],
     customEventID: 0,
     building: undefined,
+    term: undefined,
 };
 
 function CustomEventDialogs(props: CustomEventDialogProps) {
@@ -110,6 +112,8 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
     const handleAddToCalendar = () => {
         if (!days.some((day) => day) || scheduleIndices.length === 0) return;
 
+        const termsShortNames = AppStore.schedule.getCoursesFromSchedules(scheduleIndices).map((course) => course.term);
+
         const newCustomEvent: RepeatingCustomEvent = {
             color: props.customEvent ? props.customEvent.color : '#551a8b',
             title: title,
@@ -118,6 +122,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
             end: end,
             customEventID: props.customEvent ? props.customEvent.customEventID : Date.now(),
             building: building,
+            term: getLatestTermByShortName(termsShortNames)?.shortName,
         };
 
         resetForm();

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog.tsx
@@ -112,7 +112,10 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
     const handleAddToCalendar = () => {
         if (!days.some((day) => day) || scheduleIndices.length === 0) return;
 
-        const termsShortNames = AppStore.schedule.getCoursesFromSchedules(scheduleIndices).map((course) => course.term);
+        const termsInScheduleShortNames = AppStore.schedule
+            .getCoursesFromSchedules(scheduleIndices)
+            .map((course) => course.term);
+        const latestTermInSchedule = getLatestTermByShortName(termsInScheduleShortNames)?.shortName;
 
         const newCustomEvent: RepeatingCustomEvent = {
             color: props.customEvent ? props.customEvent.color : '#551a8b',
@@ -122,7 +125,7 @@ function CustomEventDialogs(props: CustomEventDialogProps) {
             end: end,
             customEventID: props.customEvent ? props.customEvent.customEventID : Date.now(),
             building: building,
-            term: getLatestTermByShortName(termsShortNames)?.shortName,
+            term: latestTermInSchedule,
         };
 
         resetForm();

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -146,6 +146,56 @@ function getFinalsStartDateForTerm(term: string) {
     return year && month && day ? new Date(year, month, day + 1) : undefined;
 }
 
+/**
+ * Get latest term by short name.
+ *
+ * By default, use a static index.
+ * If an array of terms short names is provided, select the term with the latest start date.
+ * for example, if the events array contains terms from 2023 Winter, 2024 Spring and 2023 Summer the function will return 2024 Spring
+ */
+
+function getLatestTermByShortName(termsShortNames: string[] = []): Term {
+    if (termsShortNames.length === 0) {
+        return termData[defaultTerm];
+    }
+
+    // Initialize latestTerm as the oldest term in termData
+    let latestTermIndex = termData.length - 1;
+    let latestTerm = termData[latestTermIndex];
+    let foundMatchingTerm = false;
+
+    for (const termShortName of termsShortNames) {
+        const existingTermIndex = termData.findIndex((t) => t.shortName === termShortName);
+        const existingTerm = termData[existingTermIndex];
+        foundMatchingTerm = true;
+
+        // Compare start dates of existingTerm and latestTerm to determine which term is the latest
+        if (existingTerm.startDate && latestTerm.startDate) {
+            const existingStartDate = new Date(...existingTerm.startDate);
+            const latestStartDate = new Date(...latestTerm.startDate);
+
+            if (existingStartDate > latestStartDate) {
+                latestTerm = existingTerm;
+                latestTermIndex = existingTermIndex;
+            }
+
+            // If latestTerm or existingTerm does not have a startDate, set latestTerm to term with the smallest index
+        } else {
+            if (existingTermIndex < latestTermIndex) {
+                latestTerm = existingTerm;
+                latestTermIndex = existingTermIndex;
+            }
+        }
+    }
+
+    if (foundMatchingTerm) {
+        return latestTerm;
+    } else {
+        // Return defaultTerm if no matching terms are found in termData
+        return termData[defaultTerm];
+    }
+}
+
 export {
     defaultTerm,
     getDefaultTerm,
@@ -154,4 +204,5 @@ export {
     getDefaultFinalsStartDate,
     getFinalsStartForTerm,
     getFinalsStartDateForTerm,
+    getLatestTermByShortName,
 };

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -5,8 +5,8 @@ import type {
     ScheduleUndoState,
     ShortCourseSchedule,
     RepeatingCustomEvent,
+    CourseInfo,
 } from '@packages/antalmanac-types';
-import type { CourseInfo } from '@packages/antalmanac-types';
 
 import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } from './calendarizeHelpers';
 
@@ -178,6 +178,16 @@ export class Schedules {
      */
     getAllCourses() {
         return this.schedules.map((schedule) => schedule.courses).flat(1);
+    }
+
+    /**
+     * Get combined list of courses from schedules specified by the given indices.
+     */
+    getCoursesFromSchedules(scheduleIndices: number[]) {
+        return scheduleIndices
+            .filter((index) => index >= 0 && index < this.getNumberOfSchedules())
+            .map((index) => this.schedules[index].courses)
+            .flat(1);
     }
 
     /**

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -189,6 +189,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
                 title: customEvent.title,
                 building: customEvent.building ?? '',
                 days,
+                term: customEvent.term ?? '',
             };
         });
     });

--- a/apps/antalmanac/tests/calendarize-helpers.test.ts
+++ b/apps/antalmanac/tests/calendarize-helpers.test.ts
@@ -211,6 +211,7 @@ describe('calendarize-helpers', () => {
             title: 'title',
             building: '',
             days: ['Su', 'Tu', 'Th', 'Sa'],
+            term: '2018 Winter',
         },
         {
             isCustomEvent: true,
@@ -221,6 +222,7 @@ describe('calendarize-helpers', () => {
             title: 'title',
             building: '',
             days: ['Su', 'Tu', 'Th', 'Sa'],
+            term: '2018 Winter',
         },
         {
             isCustomEvent: true,
@@ -231,6 +233,7 @@ describe('calendarize-helpers', () => {
             title: 'title',
             building: '',
             days: ['Su', 'Tu', 'Th', 'Sa'],
+            term: '2018 Winter',
         },
         {
             isCustomEvent: true,
@@ -241,6 +244,7 @@ describe('calendarize-helpers', () => {
             title: 'title',
             building: '',
             days: ['Su', 'Tu', 'Th', 'Sa'],
+            term: '2018 Winter',
         },
     ];
 

--- a/apps/antalmanac/tests/custom-events.test.ts
+++ b/apps/antalmanac/tests/custom-events.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'vitest';
 import { RepeatingCustomEvent, RepeatingCustomEventSchema } from '@packages/antalmanac-types';
+import { describe, test, expect } from 'vitest';
 
 describe('Custom Events', () => {
     const customEvent: RepeatingCustomEvent = {
@@ -10,6 +10,7 @@ describe('Custom Events', () => {
         customEventID: 999,
         color: 'placeholderColor',
         building: undefined,
+        term: '2023 Fall',
     };
 
     test('schema does not throw error when building property exists and is undefined', async () => {

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -78,6 +78,7 @@ describe('download-ics', () => {
                 isCustomEvent: true,
                 days: ['M', 'W', 'F'],
                 building: 'placeholderCustomEventBuilding',
+                term: '2023 Fall', // Cannot be a random placeholder; it has to be in `quarterStartDates` otherwise it'll be undefined
             },
         ];
 

--- a/apps/backend/src/db/schema/schedule/custom_event.ts
+++ b/apps/backend/src/db/schema/schedule/custom_event.ts
@@ -30,6 +30,8 @@ export const customEvents = pgTable(
         building: text('building'),
 
         lastUpdated: timestamp('last_updated', { withTimezone: true }).defaultNow(),
+
+        term: text('term'),
     }
 );
 

--- a/apps/backend/src/lib/rds.ts
+++ b/apps/backend/src/lib/rds.ts
@@ -216,6 +216,7 @@ export class RDS {
             color: event.color,
             building: event.building,
             lastUpdated: new Date(),
+            term: event.term
         }));
 
         await db.transaction(async (tx) => await tx.insert(customEvents).values(dbCustomEvents));
@@ -328,6 +329,7 @@ export class RDS {
                     days: customEvent.days.split('').map((day) => day === '1'),
                     color: customEvent.color ?? undefined,
                     building: customEvent.building ?? undefined,
+                    term: customEvent.term ?? undefined,
                 });
             }
 

--- a/packages/types/src/customevent.ts
+++ b/packages/types/src/customevent.ts
@@ -8,6 +8,7 @@ export const RepeatingCustomEventSchema = type({
     customEventID: 'string | number', // Unique only within the schedule.
     'color?': 'string',
     'building?': 'string | undefined',
+    'term?': 'string | undefined',
 });
 
 export type RepeatingCustomEvent = typeof RepeatingCustomEventSchema.infer;


### PR DESCRIPTION
## Summary
The change addresses the issue of assigning a term to a custom event when it is created. Previously, when users created custom events, no term was assigned to them. With this update, we now ensure that each custom event is associated with a term.

The term is obtained from the associated ScheduleCourse in the schedule. If the schedule contains classes from multiple terms (e.g., Fall 2023 and Spring 2023), the latest term is selected. If no term is found in the schedule, the default term will be used.

## Test Plan
1. Test creation of a custom event with a single term in the schedule. Verify that the custom event is assigned the correct term.
2. Test creation of a custom event with multiple terms in the schedule. Ensure the latest term is assigned to the custom event.
3. Test creation of a custom event with no associated terms in the schedule. Verify that the default term is applied.
4. Ensure that edge cases like missing terms or incorrect term names in the schedule are handled correctly and fall back to the default term.
5. Verify that custom events are correctly displayed with their respective terms in calendar view - CustomEventDialog.
6. Test that after removing some scheduleCourses, the correct term is still assigned to the custom event, reflecting the updated state of the schedule.

## Issues
Closes #762
