### PR TITLE
fix: hide scrollbars on mobile devices

### DIFF
--- a/apps/antalmanac/src/App.css
+++ b/apps/antalmanac/src/App.css
@@ -10,3 +10,14 @@
     font-size: 30pt;
     color: white;
 }
+
+/* Hide the scrollbars on mobile devices */
+@media (max-width: 768px) {
+    ::-webkit-scrollbar {
+        display: none;
+    }
+
+    * {
+        scrollbar-width: none;
+    }
+}


### PR DESCRIPTION
## Summary
This fix hides the scrollbars on mobile devices to optimize screen real estate. It addresses the issue where scrollbars take up substantial space, particularly in the section table and the calendar pane.

## Test Plan
1. Test on mobile devices (iOS, Android) using modern browsers like Chrome, Safari, and Firefox.
2. Ensure that scrollbars are hidden when the viewport width is less than 768px.

## Issues
Closes #1061

