### PR TITLE
Added ISEB and Image to Building Catalogue

### DIFF
--- a/apps/antalmanac/src/lib/buildingCatalogue.ts
+++ b/apps/antalmanac/src/lib/buildingCatalogue.ts
@@ -1789,7 +1789,7 @@ export default {
         imageURLs: [],
     },
     83063: {
-        name: 'Interdisciplinary Science and Engineering Building  (ISEB)',
+        name: 'Interdisciplinary Science and Engineering Building (ISEB)',
         lat: 33.6431,
         lng: -117.8437,
         imageURLs: ['463/201130_iseb_0361_sz_1200x800.png'],

--- a/apps/antalmanac/src/lib/buildingCatalogue.ts
+++ b/apps/antalmanac/src/lib/buildingCatalogue.ts
@@ -1788,4 +1788,10 @@ export default {
         lng: -117.84476,
         imageURLs: [],
     },
+    83063: {
+        name: 'Interdisciplinary Science and Engineering Building  (ISEB)',
+        lat: 33.6431,
+        lng: -117.8437,
+        imageURLs: ['463/201130_iseb_0361_sz_1200x800.png'],
+    },
 } as Record<number, Building>;


### PR DESCRIPTION
## Summary
- Added ISEB to building catalogue.
- Used Google Maps for coordinates.
- Added image for its marker
## Test Plan
- Tested on map with ISEB marker

## Images
<img src=https://github.com/user-attachments/assets/cf7bb140-9e72-43a9-9969-7e3ce3aa4b5f width=300px/>

## Issues
Closes #1085 
<!-- [Optional]
## Future Followup
-->
