### PR TITLE
bug: disabled quick search from custom event

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
@@ -4,7 +4,6 @@ import { EventWrapperProps } from 'react-big-calendar';
 import { shallow } from 'zustand/shallow';
 
 import type { CalendarEvent } from '$components/Calendar/CourseCalendarEvent';
-import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { useQuickSearchForClasses } from '$lib/helpers';
 import { useSelectedEventStore } from '$stores/SelectedEventStore';
 
@@ -26,8 +25,8 @@ export const CalendarCourseEventWrapper = ({ children, ...props }: CalendarCours
             e.preventDefault();
             e.stopPropagation();
 
-            if (props.event && (e.metaKey || e.ctrlKey)) {
-                const courseInfo = props.event as CourseEvent;
+            if (props.event && !props.event.isCustomEvent && (e.metaKey || e.ctrlKey)) {
+                const courseInfo = props.event;
                 quickSearch(courseInfo.deptValue, courseInfo.courseNumber, courseInfo.term);
             } else {
                 setSelectedEvent(e, props.event);


### PR DESCRIPTION
## Summary
Disables the `ctrl/cmd` + `click` search feature on custom events that would give a misleading error message (see below)

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/80804d34-15fe-4ecd-adea-684d2681c657" />

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
