### PR TITLE
Increase backend lambda timeout to 20 seconds

### DIFF
--- a/apps/cdk/src/stacks/backend.ts
+++ b/apps/cdk/src/stacks/backend.ts
@@ -53,7 +53,7 @@ export class BackendStack extends Stack {
             runtime: lambda.Runtime.NODEJS_18_X,
             code: lambda.Code.fromAsset('../backend/dist'),
             handler: 'lambda.handler',
-            timeout: Duration.seconds(10),
+            timeout: Duration.seconds(20),
             memorySize: 256,
             environment: {
                 ...env,


### PR DESCRIPTION
## Summary
- Some large schedules are taking more than 10 seconds to save, which causes the lambda to time out.
- This is only a temporary fix. We need to optimize schedule saves.

## Future Followup
- #1114 
