### PR TITLE
feat: syllabus (web) cell

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -42,6 +42,7 @@ const columnLabels: Record<SectionTableColumn, string> = {
     sectionEnrollment: 'Enrollment',
     restrictions: 'Restrictions',
     status: 'Status',
+    web: 'Web',
 };
 
 /**

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -42,7 +42,7 @@ const columnLabels: Record<SectionTableColumn, string> = {
     sectionEnrollment: 'Enrollment',
     restrictions: 'Restrictions',
     status: 'Status',
-    web: 'Web',
+    syllabus: 'Syllabus',
 };
 
 /**

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -71,6 +71,10 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
         label: 'Status',
         width: '8%',
     },
+    web: {
+        label: 'Web',
+        width: '8%',
+    },
 };
 const tableHeaderColumnEntries = Object.entries(tableHeaderColumns);
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -71,8 +71,8 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
         label: 'Status',
         width: '8%',
     },
-    web: {
-        label: 'Web',
+    syllabus: {
+        label: 'Syllabus',
         width: '8%',
     },
 };

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
@@ -4,11 +4,11 @@ import { Link } from 'react-router-dom';
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { useThemeStore } from '$stores/SettingsStore';
 
-interface WebCellProps {
+interface SyllabusCellProps {
     webURL: WebsocSectionStatus;
 }
 
-export const WebCell = ({ webURL }: WebCellProps) => {
+export const SyllabusCell = ({ webURL }: SyllabusCellProps) => {
     const isDark = useThemeStore((store) => store.isDark);
 
     if (!webURL) {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/WebCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/WebCell.tsx
@@ -1,0 +1,25 @@
+import { WebsocSectionStatus } from '@packages/antalmanac-types';
+import { Link } from 'react-router-dom';
+
+import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { useThemeStore } from '$stores/SettingsStore';
+
+interface WebCellProps {
+    webURL: WebsocSectionStatus;
+}
+
+export const WebCell = ({ webURL }: WebCellProps) => {
+    const isDark = useThemeStore((store) => store.isDark);
+
+    if (!webURL) {
+        return <TableBodyCellContainer>{null}</TableBodyCellContainer>;
+    }
+
+    return (
+        <TableBodyCellContainer>
+            <Link to={webURL} target="_blank" referrerPolicy="no-referrer" color={isDark ? 'dodgerblue' : 'blue'}>
+                Link
+            </Link>
+        </TableBodyCellContainer>
+    );
+};

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -13,7 +13,7 @@ import { InstructorsCell } from '$components/RightPane/SectionTable/SectionTable
 import { LocationsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell';
 import { RestrictionsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell';
 import { StatusCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/StatusCell';
-import { WebCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/WebCell';
+import { SyllabusCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell';
 import AppStore from '$stores/AppStore';
 import { useColumnStore, type SectionTableColumn } from '$stores/ColumnStore';
 import { useHoveredStore } from '$stores/HoveredStore';
@@ -41,7 +41,7 @@ const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     sectionEnrollment: EnrollmentCell,
     restrictions: RestrictionsCell,
     status: StatusCell,
-    web: WebCell,
+    syllabus: SyllabusCell,
 };
 
 export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -111,8 +111,6 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
         return {};
     }, [allowHighlight, isDark, scheduleConflict, addedCourse]);
 
-    console.log(courseDetails);
-
     return (
         <TableRow
             /**

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -13,6 +13,7 @@ import { InstructorsCell } from '$components/RightPane/SectionTable/SectionTable
 import { LocationsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell';
 import { RestrictionsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell';
 import { StatusCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/StatusCell';
+import { WebCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/WebCell';
 import AppStore from '$stores/AppStore';
 import { useColumnStore, type SectionTableColumn } from '$stores/ColumnStore';
 import { useHoveredStore } from '$stores/HoveredStore';
@@ -40,6 +41,7 @@ const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     sectionEnrollment: EnrollmentCell,
     restrictions: RestrictionsCell,
     status: StatusCell,
+    web: WebCell,
 };
 
 export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
@@ -108,6 +110,8 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
 
         return {};
     }, [allowHighlight, isDark, scheduleConflict, addedCourse]);
+
+    console.log(courseDetails);
 
     return (
         <TableRow

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -19,7 +19,7 @@ export const SECTION_TABLE_COLUMNS = [
     'sectionEnrollment',
     'restrictions',
     'status',
-    'web',
+    'syllabus',
 ] as const;
 
 export type SectionTableColumn = (typeof SECTION_TABLE_COLUMNS)[number];

--- a/apps/antalmanac/src/stores/ColumnStore.ts
+++ b/apps/antalmanac/src/stores/ColumnStore.ts
@@ -19,6 +19,7 @@ export const SECTION_TABLE_COLUMNS = [
     'sectionEnrollment',
     'restrictions',
     'status',
+    'web',
 ] as const;
 
 export type SectionTableColumn = (typeof SECTION_TABLE_COLUMNS)[number];


### PR DESCRIPTION
## Summary
1. Adds the newly scraped Web column to AA results

![chrome-capture-2025-0-14](https://github.com/user-attachments/assets/08fcbc1f-7822-45f9-bef9-a202a0f59339)

## Test Plan
1. Click the thing, go to link
3. Should work with Column hiding
4. Should work on light, dark mode
5. Should work on Search, Added page

## Issues
Closes #1113

<!-- [Optional]
## Future Followup
-->
