### PR TITLE
Link to PeterPortal on empty search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -165,14 +165,36 @@ const LoadingMessage = () => {
     );
 };
 
-const ErrorMessage = () => {
+const ErrorMessage = ({ }: { courseData: (WebsocSchool | WebsocDepartment | AACourse)[] }) => {
     const isDark = useThemeStore((store) => store.isDark);
+    const formData = RightPaneStore.getFormData();
+    const deptValue = formData.deptValue?.replace(' ', '').toUpperCase() || 'UNKNOWN';
+    const courseNumber = formData.courseNumber?.replace(/\s+/g, '').toUpperCase() || 'UNKNOWN';
+    const courseName = deptValue !== 'UNKNOWN' && courseNumber !== 'UNKNOWN' 
+        ? `${deptValue}${courseNumber}` 
+        : null;
+    console.log(deptValue);
+    console.log(courseNumber);
     return (
-        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column'}}>
+            {courseName && (
+                <a
+                    href={`https://peterportal.org/course/${courseName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                        textDecoration: 'none',
+                        color: isDark ? '#00aaff' : '#0056b3',
+                        fontSize: '1.4rem', 
+                    }}
+                >
+                    Click to find out when this course will run next on PeterPortal!
+                </a>
+            )}
             <img
                 src={isDark ? darkNoNothing : noNothing}
                 alt="No Results Found"
-                style={{ objectFit: 'contain', width: '80%', height: '80%' }}
+                style={{ objectFit: 'contain', width: '50%', height: '50%', marginBottom: '20px' }}
             />
         </Box>
     );
@@ -285,7 +307,7 @@ export default function CourseRenderPane(props: { id?: number }) {
             {loading ? (
                 <LoadingMessage />
             ) : error || courseData.length === 0 ? (
-                <ErrorMessage />
+                <ErrorMessage courseData={courseData} />
             ) : (
                 <>
                     <RecruitmentBanner />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpBox.tsx
@@ -1,4 +1,5 @@
 import { Close } from '@mui/icons-material';
+import RightPaneStore from '../../RightPaneStore';
 import {
     Paper,
     ImageList,
@@ -31,14 +32,14 @@ interface HelpBoxProps {
     onDismiss: () => void;
 }
 
-function HelpBox({ onDismiss }: HelpBoxProps) {
+function HelpBox({}: HelpBoxProps) {
     return (
         <Paper variant="outlined" sx={{ padding: 2, marginBottom: '10px', marginRight: '5px' }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Typography variant="h5" fontWeight="bold">
                     Need help planning your schedule?
                 </Typography>
-                <IconButton aria-label="close" size="large" color="inherit" onClick={onDismiss}>
+                <IconButton aria-label="close" size="large" color="inherit" onClick={() => RightPaneStore.hideHelpBox()}>
                     <Close fontSize="inherit" />
                 </IconButton>
             </Box>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpMenu.tsx
@@ -36,10 +36,6 @@ export function HelpMenu() {
         }
     };
 
-    const openFeedbackForm = () => {
-        Feedback();
-    };
-
     useEffect(() => {
         const handleHelpBoxChange = (newVisibility: boolean) => {
             setShowHelpBox(newVisibility);
@@ -147,6 +143,24 @@ export function HelpMenu() {
                             <HelpIcon />
                         </IconButton>
                     </Tooltip>
+                </Box>
+            )}
+
+            {showHelpBox && (
+                <Box
+                    sx={{
+                        position: 'fixed',
+                        right: '1rem',
+                        bottom: '5rem',
+                        width: '50%',
+                        height: 'auto',
+                        zIndex: 1000,
+                        overflow: 'auto',
+                    }}
+                >
+                    <Paper variant="outlined" sx={{ padding: 2, boxShadow: 3 }}>
+                        <HelpBox onDismiss={() => RightPaneStore.hideHelpBox()} />
+                    </Paper>
                 </Box>
             )}
         </Box>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/HelpMenu.tsx
@@ -1,0 +1,156 @@
+import FeedbackIcon from '@mui/icons-material/Feedback';
+import HelpIcon from '@mui/icons-material/Help';
+import LightbulbIcon from '@mui/icons-material/Lightbulb';
+import { Fab, Tooltip, Box, IconButton, Paper, keyframes } from '@mui/material';
+import { useEffect, useState } from 'react';
+import RightPaneStore from '$components/RightPane/RightPaneStore';
+
+import HelpBox from '$components/RightPane/CoursePane/SearchForm/HelpBox';
+import { Tutorial } from '$components/Tutorial';
+import Feedback from '$routes/Feedback';
+
+export function HelpMenu() {
+    const [isHovered, setIsHovered] = useState(false);
+    const [isClicked, setIsClicked] = useState(false);
+    const [showHelpBox, setShowHelpBox] = useState(RightPaneStore.getHelpBoxVisible());
+
+    const handleMouseEnter = () => {
+        if (!isClicked) {
+            setIsHovered(true);
+        }
+    };
+
+    const handleMouseLeave = () => {
+        if (!isClicked) {
+            setIsHovered(false);
+        }
+    };
+
+    const handleToggleClick = () => {
+        if (isClicked) {
+            setIsHovered(false);
+            setIsClicked(false);
+        } else {
+            setIsHovered(true);
+            setIsClicked(true);
+        }
+    };
+
+    const openFeedbackForm = () => {
+        Feedback();
+    };
+
+    useEffect(() => {
+        const handleHelpBoxChange = (newVisibility: boolean) => {
+            setShowHelpBox(newVisibility);
+        };
+        RightPaneStore.on('helpBoxChange', handleHelpBoxChange);
+
+        return () => {
+            RightPaneStore.off('helpBoxChange', handleHelpBoxChange);
+        };
+    }, []);
+
+    const riseAnimation = keyframes`
+    0% {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+`;
+
+    return (
+        <Box
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            sx={{
+                position: 'fixed',
+                bottom: '6rem',
+                right: '1rem',
+                zIndex: 999,
+                width: 'auto',
+                display: 'flex',
+                flexDirection: 'column-reverse',
+                alignItems: 'center',
+                gap: '1rem',
+                pointerEvents: 'auto',
+            }}
+        >
+            <Tooltip title="Help Menu">
+                <Fab
+                    color="primary"
+                    aria-label="Help Menu"
+                    onClick={handleToggleClick}
+                    sx={{
+                        width: '4rem',
+                        height: '4rem',
+                        position: 'relative',
+                        transition: 'all 0.3s',
+                    }}
+                >
+                    <LightbulbIcon />
+                </Fab>
+            </Tooltip>
+
+            {(isHovered || isClicked) && (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: '1rem',
+                    }}
+                >
+                    <Box
+                        sx={{
+                            animation: `${riseAnimation} 0.5s ease forwards`,
+                            animationDelay: '0.3s',
+                            opacity: 0,
+                        }}
+                    >
+                        <Tutorial />
+                    </Box>
+
+                    <Tooltip title="Feedback Form">
+                        <IconButton
+                            color="primary"
+                            onClick={Feedback}
+                            size="large"
+                            sx={{
+                                backgroundColor: '#fff',
+                                ':hover': { backgroundColor: '#e0f7fa' },
+                                animation: `${riseAnimation} 0.5s ease forwards`,
+                                animationDelay: '0.2s',
+                                opacity: 0,
+                            }}
+                        >
+                            <FeedbackIcon />
+                        </IconButton>
+                    </Tooltip>
+
+                    <Tooltip title="Help Box">
+                        <IconButton
+                            color="primary"
+                            onClick={() => RightPaneStore.toggleHelpBox()}
+                            size="large"
+                            sx={{
+                                backgroundColor: '#fff',
+                                ':hover': { backgroundColor: '#e0f7fa' },
+                                animation: `${riseAnimation} 0.5s ease forwards`,
+                                animationDelay: '0.1s',
+                                opacity: 0,
+                            }}
+                        >
+                            <HelpIcon />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+            )}
+        </Box>
+    );
+}
+
+export default HelpMenu;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -11,6 +11,7 @@ import HelpBox from './HelpBox';
 import LegacySearch from './LegacySearch';
 import PrivacyPolicyBanner from './PrivacyPolicyBanner';
 import TermSelector from './TermSelector';
+import { HelpMenu } from './HelpMenu';
 
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { getLocalStorageHelpBoxDismissalTime, setLocalStorageHelpBoxDismissalTime } from '$lib/localStorage';
@@ -115,6 +116,8 @@ const SearchForm = (props: { classes: ClassNameMap; toggleSearch: () => void }) 
 
             {displayHelpBox && <HelpBox onDismiss={onHelpBoxDismiss} />}
             <PrivacyPolicyBanner />
+
+            <HelpMenu />
         </div>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -29,6 +29,7 @@ class RightPaneStore extends EventEmitter {
     private formData: Record<string, string>;
     private doDisplaySearch: boolean;
     private openSpotAlertPopoverActive: boolean;
+    private isHelpBoxVisible: boolean;
     private urlCourseCodeValue: string;
     private urlTermValue: string;
     private urlGEValue: string;
@@ -42,6 +43,7 @@ class RightPaneStore extends EventEmitter {
         this.formData = structuredClone(defaultFormValues);
         this.doDisplaySearch = true;
         this.openSpotAlertPopoverActive = false;
+        this.isHelpBoxVisible = false;
         const search = new URLSearchParams(window.location.search);
         this.urlCourseCodeValue = search.get('courseCode') || '';
         this.urlTermValue = search.get('term') || '';
@@ -72,6 +74,25 @@ class RightPaneStore extends EventEmitter {
 
     getDefaultFormData = () => {
         return defaultFormValues;
+    };
+
+    toggleHelpBox = () => {
+        this.isHelpBoxVisible = !this.isHelpBoxVisible;
+        this.emit('helpBoxChange', this.isHelpBoxVisible);
+    };
+
+    showHelpBox = () => {
+        this.isHelpBoxVisible = true;
+        this.emit('helpBoxChange', this.isHelpBoxVisible);
+    };
+
+    hideHelpBox = () => {
+        this.isHelpBoxVisible = false;
+        this.emit('helpBoxChange', this.isHelpBoxVisible);
+    };
+
+    getHelpBoxVisible = () => {
+        return this.isHelpBoxVisible;
     };
 
     getOpenSpotAlertPopoverActive = () => {

--- a/apps/antalmanac/src/components/Tutorial.tsx
+++ b/apps/antalmanac/src/components/Tutorial.tsx
@@ -1,5 +1,5 @@
 import ReplayIcon from '@mui/icons-material/Replay';
-import { Fab, Tooltip } from '@mui/material';
+import { Fab, Tooltip, IconButton } from '@mui/material';
 import { useTour } from '@reactour/tour';
 import { useEffect, useMemo } from 'react';
 
@@ -41,23 +41,17 @@ export function Tutorial() {
     /** Floating action button (FAB) in the bottom right corner to reactivate the tutorial */
     return (
         <Tooltip title="Restart tutorial">
-            <Fab
-                id="tutorial-floater"
+            <IconButton
                 color="primary"
-                aria-label="Restart tutorial"
                 onClick={() => restartTour()}
-                style={{
-                    position: 'fixed',
-                    bottom: '1rem',
-                    right: '1rem',
-                    zIndex: 999,
-                    opacity: 0.5,
-                    width: '4rem',
-                    height: '4rem',
+                size="large"
+                sx={{
+                    backgroundColor: '#fff',
+                    ':hover': { backgroundColor: '#e0f7fa' },
                 }}
             >
                 <ReplayIcon />
-            </Fab>
+            </IconButton>
         </Tooltip>
     );
 }

--- a/apps/antalmanac/src/routes/Feedback.tsx
+++ b/apps/antalmanac/src/routes/Feedback.tsx
@@ -1,6 +1,6 @@
 export const FEEDBACK_LINK = 'https://form.asana.com/?k=fZ3SGnuGknDmzTYdocgIUg&d=1208267282546207';
 
 export default function Feedback() {
-    window.location.replace(FEEDBACK_LINK);
+    window.open(FEEDBACK_LINK, '_blank');
     return null;
 }

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -9,7 +9,6 @@ import Header from '$components/Header';
 import NotificationSnackbar from '$components/NotificationSnackbar';
 import PatchNotes from '$components/PatchNotes';
 import ScheduleManagement from '$components/SharedRoot';
-import { Tutorial } from '$components/Tutorial';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 
 function MobileHome() {
@@ -77,8 +76,6 @@ function DesktopHome() {
                     </Stack>
                 </Split>
             </Stack>
-
-            <Tutorial />
         </>
     );
 }


### PR DESCRIPTION
## Summary
A message appears along with the no result image to redirect users to the searched course on PeterPortal. The message is a hyperlink that will open a new tab directly to the course's page.

## Test Plan
- [ ] Search for a course not offered for the selected quarter to ensure the link appears
- [ ] Click on the link to ensure it opens a new tab
- [ ] Make sure the opened tab is on the correct course page
- [ ] View the message in light and dark mode and see if we like the look

## Issues

Closes #
#1024 

<!-- [Optional]
## Future Followup
-->
Not sure how we want the message/link to look so I kept it simple for now.
