### PR TITLE
Added link to PeterPortal course page when there's no result.

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -185,27 +185,37 @@ const ErrorMessage = ({ }: { courseData: (WebsocSchool | WebsocDepartment | AACo
                   backgroundColor: isDark ? '#2a3136' : 'rgb(240, 248, 255)', 
                   border: `1px solid ${isDark ? '#202224' : '#90caf9'}`, 
                   color: isDark ? '#ece6e6' : '#1e88e5', 
-                  fontSize: '1.1rem',
+                  fontSize: '1rem',
                   '& .MuiAlertTitle-root': {
-                    fontSize: '1.3rem',
+                    fontSize: '1.1rem',
                   },
-                  padding: '8px',
+                  padding: '0.6rem',
                   boxSizing: 'border-box',
-                  marginTop: '35px',
+                  marginTop: '3rem',
                 '&:hover': {
                     backgroundColor: isDark ? '#1f2529' : 'rgb(230, 240, 255)',
                 },
                 }}
               >
-                <AlertTitle>Click HERE to see when {courseName} will be offered next on PeterPortal!</AlertTitle>
+                <AlertTitle>
+                    <span style={{ color: 'black' }}>
+                        Search for{' '}
+                        <span
+                        style={{color: '#5191D6', textDecoration: 'underline', }}
+                        >
+                        {deptValue} {courseNumber}
+                        </span>{' '}
+                        on PeterPortal
+                    </span>
+                </AlertTitle>
                 
               </Alert>
             )}
-            { <img
+            <img
                 src={isDark ? darkNoNothing : noNothing}
                 alt="No Results Found"
                 style={{ objectFit: 'contain', width: '80%', height: '80%' }}
-            /> }
+            />
         </Box>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -165,10 +165,30 @@ const LoadingMessage = () => {
     );
 };
 
-const ErrorMessage = () => {
+const ErrorMessage = ({ }: { courseData: (WebsocSchool | WebsocDepartment | AACourse)[] }) => {
     const isDark = useThemeStore((store) => store.isDark);
+    const formData = RightPaneStore.getFormData();
+    const deptValue = formData.deptValue?.replace(' ', '').toUpperCase() || 'UNKNOWN';
+    const courseNumber = formData.courseNumber?.replace(/\s+/g, '').toUpperCase() || 'UNKNOWN';
+    const courseName = deptValue !== 'UNKNOWN' && courseNumber !== 'UNKNOWN' 
+        ? `${deptValue}${courseNumber}` 
+        : null;
     return (
-        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column'}}>
+            {courseName && (
+                <a
+                    href={`https://peterportal.org/course/${courseName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                        textDecoration: 'none',
+                        color: isDark ? '#00aaff' : '#0056b3',
+                        fontSize: '1.4rem', 
+                    }}
+                >
+                    Click to find out when this course will run next on PeterPortal!
+                </a>
+            )}
             <img
                 src={isDark ? darkNoNothing : noNothing}
                 alt="No Results Found"
@@ -285,7 +305,7 @@ export default function CourseRenderPane(props: { id?: number }) {
             {loading ? (
                 <LoadingMessage />
             ) : error || courseData.length === 0 ? (
-                <ErrorMessage />
+                <ErrorMessage courseData={courseData} />
             ) : (
                 <>
                     <RecruitmentBanner />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,5 +1,5 @@
 import { Close } from '@mui/icons-material';
-import { Alert, Box, IconButton, useMediaQuery } from '@mui/material';
+import { Alert, AlertTitle, Box, IconButton, useMediaQuery } from '@mui/material';
 import { AACourse, AASection, WebsocDepartment, WebsocSchool, WebsocAPIResponse, GE } from '@packages/antalmanac-types';
 import { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
@@ -176,24 +176,36 @@ const ErrorMessage = ({ }: { courseData: (WebsocSchool | WebsocDepartment | AACo
     return (
         <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column'}}>
             {courseName && (
-                <a
-                    href={`https://peterportal.org/course/${courseName}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                        textDecoration: 'none',
-                        color: isDark ? '#00aaff' : '#0056b3',
-                        fontSize: '1.4rem', 
-                    }}
-                >
-                    Click to find out when this course will run next on PeterPortal!
-                </a>
+                <Alert
+                severity="info"
+                onClick={() => window.open(`https://peterportal.org/course/${courseName}`, '_blank')}
+                sx={{
+                  width: '100%',
+                  cursor: 'pointer',
+                  backgroundColor: isDark ? '#2a3136' : 'rgb(240, 248, 255)', 
+                  border: `1px solid ${isDark ? '#202224' : '#90caf9'}`, 
+                  color: isDark ? '#ece6e6' : '#1e88e5', 
+                  fontSize: '1.1rem',
+                  '& .MuiAlertTitle-root': {
+                    fontSize: '1.3rem',
+                  },
+                  padding: '8px',
+                  boxSizing: 'border-box',
+                  marginTop: '35px',
+                '&:hover': {
+                    backgroundColor: isDark ? '#1f2529' : 'rgb(230, 240, 255)',
+                },
+                }}
+              >
+                <AlertTitle>Click HERE to see when {courseName} will be offered next on PeterPortal!</AlertTitle>
+                
+              </Alert>
             )}
-            <img
+            { <img
                 src={isDark ? darkNoNothing : noNothing}
                 alt="No Results Found"
                 style={{ objectFit: 'contain', width: '80%', height: '80%' }}
-            />
+            /> }
         </Box>
     );
 };


### PR DESCRIPTION
## Summary
A message appears along with the no result image to redirect users to the searched course on PeterPortal. The message is a hyperlink that will open a new tab directly to the course's page.

## Test Plan
- [ ] Search for a course not offered for the selected quarter to ensure the link appears
- [ ] Click on the link to ensure it opens a new tab
- [ ] Make sure the opened tab is on the correct course page
- [ ] View the message in light and dark mode and see if we like the look

## Issues

Closes #
#1024 

<!-- [Optional]
## Future Followup
-->
Not sure how we want the message/link to look so I kept it simple for now.
