### PR TITLE
Refactor repeated focusMap component

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -6,11 +6,11 @@ import { WebsocSectionFinalExam } from '@packages/antalmanac-types';
 import { useEffect, useRef } from 'react';
 import { Event } from 'react-big-calendar';
 
-import { MapLink } from '../buttons/MapLink';
 
 import { deleteCourse, deleteCustomEvent } from '$actions/AppStoreActions';
 import CustomEventDialog from '$components/Calendar/Toolbar/CustomEventDialog/';
 import ColorPicker from '$components/ColorPicker';
+import { MapLink } from '$components/buttons/MapLink';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import buildingCatalogue from '$lib/buildingCatalogue';
 import { clickToCopy, useQuickSearchForClasses } from '$lib/helpers';

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -3,9 +3,10 @@ import { Theme, withStyles } from '@material-ui/core/styles';
 import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
 import { Delete, Search } from '@material-ui/icons';
 import { WebsocSectionFinalExam } from '@packages/antalmanac-types';
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { Event } from 'react-big-calendar';
-import { Link } from 'react-router-dom';
+
+import { MapLink } from '../buttons/MapLink';
 
 import { deleteCourse, deleteCustomEvent } from '$actions/AppStoreActions';
 import CustomEventDialog from '$components/Calendar/Toolbar/CustomEventDialog/';
@@ -15,8 +16,7 @@ import buildingCatalogue from '$lib/buildingCatalogue';
 import { clickToCopy, useQuickSearchForClasses } from '$lib/helpers';
 import locationIds from '$lib/location_ids';
 import AppStore from '$stores/AppStore';
-import { useTimeFormatStore, useThemeStore } from '$stores/SettingsStore';
-import { useTabStore } from '$stores/TabStore';
+import { useTimeFormatStore } from '$stores/SettingsStore';
 import { formatTimes } from '$stores/calendarizeHelpers';
 
 const styles: Styles<Theme, object> = {
@@ -164,15 +164,9 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
         };
     }, []);
 
-    const { setActiveTab } = useTabStore();
     const quickSearch = useQuickSearchForClasses();
 
     const { isMilitaryTime } = useTimeFormatStore();
-    const isDark = useThemeStore((store) => store.isDark);
-
-    const focusMap = useCallback(() => {
-        setActiveTab(2);
-    }, [setActiveTab]);
 
     const { classes, selectedEvent } = props;
 
@@ -262,14 +256,10 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                             <td className={`${classes.multiline} ${classes.rightCells}`}>
                                 {locations.map((location) => (
                                     <div key={`${sectionCode} @ ${location.building} ${location.room}`}>
-                                        <Link
-                                            className={classes.clickableLocation}
-                                            to={`/map?location=${locationIds[location.building] ?? 0}`}
-                                            onClick={focusMap}
-                                            color={isDark ? '#1cbeff' : 'blue'}
-                                        >
-                                            {location.building} {location.room}
-                                        </Link>
+                                        <MapLink
+                                            buildingId={locationIds[location.building] ?? '0'}
+                                            room={`${location.building} ${location.room}`}
+                                        />
                                     </div>
                                 ))}
                             </td>
@@ -302,13 +292,7 @@ const CourseCalendarEvent = (props: CourseCalendarEventProps) => {
                 {building && (
                     <div className={classes.table}>
                         Location:&nbsp;
-                        <Link
-                            className={classes.clickableLocation}
-                            to={`/map?location=${building ?? 0}`}
-                            onClick={focusMap}
-                        >
-                            {buildingCatalogue[+building]?.name ?? ''}
-                        </Link>
+                        <MapLink buildingId={+building} room={buildingCatalogue[+building]?.name ?? ''} />
                     </div>
                 )}
                 <div className={classes.buttonBar}>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -60,7 +60,7 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
     const { setActiveTab } = useTabStore();
 
     const focusMap = useCallback(() => {
-        setActiveTab(2);
+        setActiveTab(1);
     }, [setActiveTab]);
 
     return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -2,18 +2,17 @@ import { Delete } from '@mui/icons-material';
 import { Box, Card, CardActions, CardHeader, IconButton, Tooltip } from '@mui/material';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
 import moment from 'moment';
-import { useEffect, useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 import ColorPicker from '../../ColorPicker';
 
 import { deleteCustomEvent } from '$actions/AppStoreActions';
 import CustomEventDialog from '$components/Calendar/Toolbar/CustomEventDialog/';
+import { MapLink } from '$components/buttons/MapLink';
 import analyticsEnum from '$lib/analytics';
 import buildingCatalogue from '$lib/buildingCatalogue';
 import AppStore from '$stores/AppStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
-import { useTabStore } from '$stores/TabStore';
 
 interface CustomEventDetailViewProps {
     scheduleNames: string[];
@@ -57,12 +56,6 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
         return `${startTime.format(timeFormat)} — ${endTime.format(timeFormat)} • ${daysString}`;
     };
 
-    const { setActiveTab } = useTabStore();
-
-    const focusMap = useCallback(() => {
-        setActiveTab(1);
-    }, [setActiveTab]);
-
     return (
         <Card>
             <CardHeader
@@ -74,9 +67,10 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
                 }}
             />
             <Box sx={{ margin: '0.75rem', color: '#bbbbbb', fontSize: '1rem' }}>
-                <Link to={`/map?location=${customEvent.building ?? 0}`} onClick={focusMap}>
-                    {(customEvent.building && buildingCatalogue[+customEvent.building]?.name) || ''}
-                </Link>
+                <MapLink
+                    buildingId={Number(customEvent.building) || 0}
+                    room={(customEvent.building && buildingCatalogue[+customEvent.building]?.name) || ''}
+                />
             </Box>
 
             {!skeletonMode && (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
@@ -1,12 +1,11 @@
 import { Box } from '@mui/material';
 import { WebsocSectionMeeting } from '@packages/antalmanac-types';
-import { Fragment, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Fragment } from 'react';
+
+import { MapLink } from '../../../../buttons/MapLink';
 
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import locationIds from '$lib/location_ids';
-import { useThemeStore } from '$stores/SettingsStore';
-import { useTabStore } from '$stores/TabStore';
 
 interface LocationsCellProps {
     meetings: WebsocSectionMeeting[];
@@ -14,13 +13,6 @@ interface LocationsCellProps {
 }
 
 export const LocationsCell = ({ meetings }: LocationsCellProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
-    const { setActiveTab } = useTabStore();
-
-    const focusMap = useCallback(() => {
-        setActiveTab(2);
-    }, [setActiveTab]);
-
     return (
         <TableBodyCellContainer>
             {meetings.map((meeting) => {
@@ -30,16 +22,7 @@ export const LocationsCell = ({ meetings }: LocationsCellProps) => {
                         const buildingId = locationIds[buildingName];
                         return (
                             <Fragment key={meeting.timeIsTBA + bldg}>
-                                <Link
-                                    style={{
-                                        textDecoration: 'none',
-                                    }}
-                                    to={`/map?location=${buildingId}`}
-                                    onClick={focusMap}
-                                    color={isDark ? 'dodgerblue' : 'blue'}
-                                >
-                                    {bldg}
-                                </Link>
+                                <MapLink buildingId={buildingId} room={bldg} />
                                 <br />
                             </Fragment>
                         );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
@@ -2,9 +2,8 @@ import { Box } from '@mui/material';
 import { WebsocSectionMeeting } from '@packages/antalmanac-types';
 import { Fragment } from 'react';
 
-import { MapLink } from '../../../../buttons/MapLink';
-
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { MapLink } from '$components/buttons/MapLink';
 import locationIds from '$lib/location_ids';
 
 interface LocationsCellProps {

--- a/apps/antalmanac/src/components/buttons/MapLink.tsx
+++ b/apps/antalmanac/src/components/buttons/MapLink.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback } from 'react';
+import { Link } from 'react-router-dom';
+
+import { useThemeStore } from '$stores/SettingsStore';
+import { useTabStore } from '$stores/TabStore';
+
+interface MapLinkProps {
+    buildingId: number;
+    room: string;
+}
+
+export const MapLink = ({ buildingId, room }: MapLinkProps) => {
+    const { setActiveTab } = useTabStore();
+    const isDark = useThemeStore((store) => store.isDark);
+
+    const focusMap = useCallback(() => {
+        setActiveTab(2);
+    }, [setActiveTab]);
+
+    return (
+        <Link
+            to={`/map?location=${buildingId}`}
+            onClick={focusMap}
+            style={{
+                textDecoration: 'none',
+                color: isDark ? 'dodgerblue' : 'blue',
+            }}
+        >
+            {room}
+        </Link>
+    );
+};


### PR DESCRIPTION
## Summary
- Created a reusable `MapLink` component to replace the redundant `focusMap` implementation in `CourseCalendarEvent.tsx` and `LocationsCell.tsx`
- Refactored the `focusMap` functionality into the `MapLink` component
- Directly call the stores of `setActiveTab` and `isDark`
- Removed mobile tab fixes 
- Cleaned up unused imports

## Test Plan
- Tested functionality on both mobile and desktop
- Made sure focusMap worked without functionality of the tabs as absolute string keys for now
 
## Issues

Originally from #1106 

<!-- [Optional]
## Future Followup
-->
