### PR TITLE
style: improvements to tabs, course/added panes

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -336,7 +336,7 @@ function AddedSectionsGrid() {
                 <ClearScheduleButton buttonSx={buttonSx} />
                 <ColumnToggleDropdown />
             </Box>
-            <Box style={{ marginTop: 50 }}>
+            <Box style={{ marginTop: 56 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
                 {courses.length < 1 ? NoCoursesBox : null}
                 <Box display="flex" flexDirection="column" gap={1}>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -154,7 +154,6 @@ export function CoursePaneButtonRow(props: CoursePaneButtonRowProps) {
                 display: props.showSearch ? 'block' : 'none',
                 width: '100%',
                 zIndex: 3,
-                marginBottom: 8,
                 position: 'absolute',
             }}
         >

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -179,7 +179,6 @@ const ErrorMessage = () => {
             sx={{
                 height: '100%',
                 display: 'flex',
-                justifyContent: 'center',
                 alignItems: 'center',
                 flexDirection: 'column',
             }}
@@ -321,6 +320,8 @@ export default function CourseRenderPane(props: { id?: number }) {
 
     return (
         <>
+            <Box sx={{ height: '56px' }} />
+
             {loading ? (
                 <LoadingMessage />
             ) : error || courseData.length === 0 ? (
@@ -329,7 +330,6 @@ export default function CourseRenderPane(props: { id?: number }) {
                 <>
                     <RecruitmentBanner />
                     <Box>
-                        <Box sx={{ height: '50px', marginBottom: '5px' }} />
                         {courseData.map((_: WebsocSchool | WebsocDepartment | AACourse, index: number) => {
                             let heightEstimate = 200;
                             if ((courseData[index] as AACourse).sections !== undefined)

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTab.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTab.tsx
@@ -28,15 +28,19 @@ export const ScheduleManagementTab = ({ tab, value }: ScheduleManagementTabProps
             icon={tab.icon}
             iconPosition={isMobile ? 'top' : 'start'}
             sx={{
-                ...(!isMobile
+                ...(isMobile
                     ? {
+                          minHeight: 'unset',
+                          minWidth: '25%',
+                          height: 56,
+                      }
+                    : {
                           minHeight: 'auto',
                           height: '44px',
                           padding: 3,
                           minWidth: '33%',
-                      }
-                    : { minWidth: '25%' }),
-                display: !isMobile && tab.mobile ? 'none' : 'flex',
+                      }),
+                display: isMobile || !tab.mobile ? 'flex' : 'none',
                 ...(isDark ? { '&.Mui-selected': { color: 'white' } } : {}),
             }}
             label={tab.label}


### PR DESCRIPTION
## Summary
1. A bit of miscellaneous improvements to the course pane and the added pane (fixes the positioning of the Peterportal Alert)
2. Reduce size of tabs on mobile

## Before
<img width="400" src="https://github.com/user-attachments/assets/90561256-eeb9-47dd-adcc-a148a267626e" />

<img width="400" src="https://github.com/user-attachments/assets/32d56e33-8ed2-4777-9559-2f274a0b0ec1" />
