### PR TITLE
feat: improvements to save state

### DIFF
--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -336,6 +336,7 @@ class AppStore extends EventEmitter {
         this.unsavedChanges = false;
 
         await actionTypesStore.loadScheduleFromLocalSave();
+        this.schedule.clearPreviousStates();
 
         this.emit('addedCoursesChange');
         this.emit('customEventsChange');
@@ -430,6 +431,8 @@ class AppStore extends EventEmitter {
 
     termsInSchedule = (term: string) =>
         new Set([term, ...this.schedule.getCurrentCourses().map((course) => course.term)]);
+
+    getPreviousStates = () => this.schedule.getPreviousStates();
 }
 
 const store = new AppStore();

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -447,6 +447,20 @@ export class Schedules {
     }
 
     /**
+     * Getter for previous states
+     */
+    getPreviousStates() {
+        return this.previousStates;
+    }
+
+    /**
+     * Clears previous states
+     */
+    clearPreviousStates() {
+        this.previousStates = [];
+    }
+
+    /**
      * Appends a copy of the current schedule to previous states to revert to
      * Previous states are capped to 50
      */
@@ -466,6 +480,11 @@ export class Schedules {
      * All actions that call `addUndoState()` can be reverted.
      */
     revertState() {
+        // prevent the user from undoing to an empty state
+        if (this.previousStates.length <= 1) {
+            return;
+        }
+
         const state = this.previousStates.pop();
         if (state !== undefined) {
             this.schedules = state.schedules;


### PR DESCRIPTION
## Summary
1. Prevents "undo" if it would return the user to an empty state. This prevents autosave from wiping the user's schedule since we can never return to an empty state
2. Clears "states" when loading in a new username. This prevents undoing to another user's schedule and having that autosaved.

## Test Plan
1. Load a schedule. Try and undo (`ctrl + z`). Nothing should happen.
2. Undoing should still work, but not on the very first action you take
3. Load a schedule. Load a different schedule. Undo should do nothing.

## Issues

Closes #1133

<!-- [Optional]
## Future Followup
-->
