### PR TITLE
style: fix antalmanac MUI stylings (and UX)

### DIFF
--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,53 +1,39 @@
-import { AppBar, Toolbar } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import { ClassNameMap } from '@material-ui/core/styles/withStyles';
+import { AppBar, Box } from '@mui/material';
 
 import Import from './Import';
 import LoadSaveScheduleFunctionality from './LoadSaveFunctionality';
 import { Logo } from './Logo';
 import AppDrawer from './SettingsMenu';
 
-const styles = {
-    appBar: {
-        marginBottom: '4px',
-        boxShadow: 'none',
-        minHeight: 0,
-        height: '50px',
-    },
-    buttonMargin: {
-        marginRight: '4px',
-    },
-    fallback: {
-        height: '100%',
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    menuIconContainer: {
-        padding: '0.25rem',
-        display: 'flex',
-    },
-};
+import { BLUE } from '$src/globals';
 
-interface CustomAppBarProps {
-    classes: ClassNameMap;
-}
-
-const Header = ({ classes }: CustomAppBarProps) => {
+export function Header() {
     return (
-        <AppBar position="static" className={classes.appBar}>
-            <Toolbar variant="dense" style={{ padding: '5px', display: 'flex', justifyContent: 'space-between' }}>
+        <AppBar
+            position="static"
+            sx={{
+                height: 52,
+                padding: 1,
+                boxShadow: 'none',
+                backgroundColor: BLUE,
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    height: '100%',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                }}
+            >
                 <Logo />
 
-                <div style={{ display: 'flex', flexDirection: 'row' }}>
+                <Box style={{ display: 'flex', flexDirection: 'row' }}>
                     <LoadSaveScheduleFunctionality />
                     <Import key="studylist" />
                     <AppDrawer key="settings" />
-                </div>
-            </Toolbar>
+                </Box>
+            </Box>
         </AppBar>
     );
-};
-
-export default withStyles(styles)(Header);
+}

--- a/apps/antalmanac/src/components/Header/index.tsx
+++ b/apps/antalmanac/src/components/Header/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Header';

--- a/apps/antalmanac/src/components/PatchNotes.tsx
+++ b/apps/antalmanac/src/components/PatchNotes.tsx
@@ -38,7 +38,7 @@ function PatchNotesBackdrop(props: BackdropProps) {
  * PatchNotes follows structure/layout of AboutPage.tsx
  */
 function PatchNotes() {
-    const [open, setOpen] = useState(isOutdated());
+    const [open, setOpen] = useState(() => isOutdated());
 
     const handleClose = useCallback(() => {
         setLocalStoragePatchNotesKey(latestPatchNotesUpdate);

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -330,7 +330,7 @@ function AddedSectionsGrid() {
     );
 
     return (
-        <Box display="flex" flexDirection="column" gap={1} marginX={0.5}>
+        <Box display="flex" flexDirection="column" gap={1}>
             <Box display="flex" width={1} position="absolute" zIndex="2">
                 <CopyScheduleButton index={scheduleIndex} buttonSx={buttonSx} />
                 <ClearScheduleButton buttonSx={buttonSx} />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -54,7 +54,7 @@ export function CoursePaneRoot() {
     }, [handleKeydown]);
 
     return (
-        <Box height={'0px'} flexGrow={1} marginX={0.5}>
+        <Box height={'0px'} flexGrow={1}>
             <CoursePaneButtonRow
                 showSearch={!searchIsDisplayed}
                 onDismissSearchResults={displaySearch}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -58,8 +58,8 @@ const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
 };
 const RecruitmentBanner = () => {
     const [bannerVisibility, setBannerVisibility] = useState(true);
-
-    const isDark = useThemeStore((store) => store.isDark);
+    const theme = useTheme();
+    const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
     // Display recruitment banner if more than 11 weeks (in ms) has passed since last dismissal
     const recruitmentDismissalTime = getLocalStorageRecruitmentDismissalTime();
@@ -71,7 +71,10 @@ const RecruitmentBanner = () => {
     );
     const displayRecruitmentBanner = bannerVisibility && !dismissedRecently && isSearchCS;
 
-    const isMobileScreen = useMediaQuery('(max-width: 750px)');
+    const handleClick = () => {
+        setLocalStorageRecruitmentDismissalTime(Date.now().toString());
+        setBannerVisibility(false);
+    };
 
     return (
         <Box sx={{ position: 'fixed', bottom: 5, right: isMobileScreen ? 5 : 75, zIndex: 999 }}>
@@ -80,19 +83,12 @@ const RecruitmentBanner = () => {
                     icon={false}
                     severity="info"
                     style={{
-                        color: isDark ? '#ece6e6' : '#2e2e2e',
-                        backgroundColor: isDark ? '#2e2e2e' : '#ece6e6',
+                        color: 'unset',
+                        backgroundColor: theme.palette.background.paper,
+                        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
                     }}
                     action={
-                        <IconButton
-                            aria-label="close"
-                            size="small"
-                            color="inherit"
-                            onClick={() => {
-                                setLocalStorageRecruitmentDismissalTime(Date.now().toString());
-                                setBannerVisibility(false);
-                            }}
-                        >
+                        <IconButton aria-label="close" size="small" color="inherit" onClick={handleClick}>
                             <Close fontSize="inherit" />
                         </IconButton>
                     }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/DeptSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DeptSearchBar/DeptSearchBar.tsx
@@ -13,7 +13,6 @@ import { getLocalStorageFavorites, setLocalStorageFavorites } from '$lib/localSt
 const style = {
     formControl: {
         flexGrow: 1,
-        marginRight: 15,
         width: '50%',
     },
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -194,6 +194,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                         }}
                         fullWidth
                         label={'Search'}
+                        placeholder="Search for courses"
                     />
                 )}
                 autoHighlight={true}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -194,7 +194,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                         }}
                         fullWidth
                         label={'Search'}
-                        placeholder="Search for courses"
+                        placeholder="Search for courses, departments, GEs..."
                     />
                 )}
                 autoHighlight={true}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/GESelector.tsx
@@ -22,7 +22,6 @@ const geList: { value: string; label: string }[] = [
 const styles = {
     formControl: {
         flexGrow: 1,
-        marginRight: 15,
         width: '50%',
     },
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LegacySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LegacySearch.tsx
@@ -1,6 +1,4 @@
-import { Button, Theme } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import { ClassNameMap, Styles } from '@material-ui/core/styles/withStyles';
+import { Box, Button } from '@mui/material';
 
 import AdvancedSearch from './AdvancedSearch/AdvancedSearch';
 import CourseNumberSearchBar from './CourseNumberSearchBar';
@@ -8,81 +6,36 @@ import DeptSearchBar from './DeptSearchBar/DeptSearchBar';
 import GESelector from './GESelector';
 import SectionCodeSearchBar from './SectionCodeSearchBar';
 
-const styles: Styles<Theme, object> = {
-    container: {
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'relative',
-    },
-    collapse: {
-        display: 'inline-flex',
-        cursor: 'pointer',
-        marginTop: 20,
-        marginBottom: 10,
-    },
-    search: {
-        display: 'flex',
-        justifyContent: 'center',
-        borderTop: 'solid 8px transparent',
-    },
-    margin: {
-        borderTop: 'solid 8px transparent',
-        display: 'inline-flex',
-        width: '100%',
-    },
-    new: {
-        width: '55%',
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-    },
-    searchButton: {
-        width: '50%',
-    },
-    buttonContainer: {
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        gap: 16,
-    },
-};
+interface LegacySearchProps {
+    onSubmit: VoidFunction;
+    onReset: VoidFunction;
+}
 
-function LegacySearch(props: { classes: ClassNameMap; onSubmit: () => void; onReset: () => void }) {
-    const { classes, onSubmit, onReset } = props;
-
+export function LegacySearch({ onSubmit, onReset }: LegacySearchProps) {
     return (
-        <>
-            <div className={classes.margin}>
-                <DeptSearchBar />
-                <CourseNumberSearchBar />
-            </div>
-
-            <div className={classes.margin}>
-                <GESelector />
-                <SectionCodeSearchBar />
-            </div>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Box>
+                <Box sx={{ display: 'flex', width: '100%', gap: 2 }}>
+                    <DeptSearchBar />
+                    <CourseNumberSearchBar />
+                </Box>
+                <Box sx={{ display: 'flex', width: '100%', gap: 2 }}>
+                    <GESelector />
+                    <SectionCodeSearchBar />
+                </Box>
+            </Box>
 
             <AdvancedSearch />
 
-            <div className={classes.search}>
-                <div className={classes.buttonContainer}>
-                    <Button
-                        className={classes.searchButton}
-                        color="primary"
-                        variant="contained"
-                        onClick={onSubmit}
-                        type="submit"
-                    >
-                        Search
-                    </Button>
+            <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%', gap: 2 }}>
+                <Button color="primary" variant="contained" type="submit" onClick={onSubmit} sx={{ width: '50%' }}>
+                    Search
+                </Button>
 
-                    <Button variant="contained" onClick={onReset}>
-                        Reset
-                    </Button>
-                </div>
-            </div>
-        </>
+                <Button variant="contained" color="secondary" onClick={onReset}>
+                    Reset
+                </Button>
+            </Box>
+        </Box>
     );
 }
-
-export default withStyles(styles)(LegacySearch);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchForm.tsx
@@ -8,10 +8,10 @@ import RightPaneStore from '../../RightPaneStore';
 
 import FuzzySearch from './FuzzySearch';
 import HelpBox from './HelpBox';
-import LegacySearch from './LegacySearch';
 import PrivacyPolicyBanner from './PrivacyPolicyBanner';
 import TermSelector from './TermSelector';
 
+import { LegacySearch } from '$components/RightPane/CoursePane/SearchForm/LegacySearch';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import { getLocalStorageHelpBoxDismissalTime, setLocalStorageHelpBoxDismissalTime } from '$lib/localStorage';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
@@ -27,11 +27,11 @@ const styles: Styles<Theme, object> = {
         display: 'flex',
         flexDirection: 'column',
         position: 'relative',
+        gap: 16,
     },
     searchBar: {
         display: 'flex',
         flexDirection: 'row',
-        marginTop: '1rem',
     },
     margin: {
         borderTop: 'solid 8px transparent',

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBar.tsx
@@ -6,11 +6,10 @@ import { Skeleton } from '@material-ui/lab';
 import type { PrerequisiteTree } from '@packages/antalmanac-types';
 import { useState } from 'react';
 
-import { MOBILE_BREAKPOINT } from '../../../../globals';
-
 import PrereqTree from '$components/RightPane/SectionTable/PrereqTree';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import trpc from '$lib/api/trpc';
+import { MOBILE_BREAKPOINT } from '$src/globals';
 
 const styles = () => ({
     rightSpace: {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
@@ -1,6 +1,5 @@
-import { Button, Paper, Popper } from '@material-ui/core';
-import { useMediaQuery, useTheme } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { Box, Button, Paper, Popover, useMediaQuery, useTheme } from '@mui/material';
+import { useCallback, useState } from 'react';
 
 import { logAnalytics } from '$lib/analytics';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
@@ -25,65 +24,38 @@ export const CourseInfoButton = ({
     const theme = useTheme();
     const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
-    const [popupAnchor, setPopupAnchor] = useState<HTMLElement | null>(null);
-    const [isClicked, setIsClicked] = useState(false);
-
-    useEffect(() => {
-        // When the user clicks on the button, it triggers both onMouseEnter
-        // and onClick. In order to log the analytics only once, we should
-        // have this hook when the popupAnchor changes
-        if (popupAnchor) {
-            logAnalytics({
-                category: analyticsCategory,
-                action: analyticsAction,
-            });
-        }
-    }, [popupAnchor, analyticsCategory, analyticsAction]);
-
-    const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
-        // If there is popup content, allow the content to be shown when the button is hovered
-        // Note that on mobile devices, hovering is not possible, so the popup still needs to be able
-        // to appear when the button is clicked
-        if (popupContent) {
-            setPopupAnchor(event.currentTarget);
-        }
-    };
-
-    const handleMouseLeave = () => {
-        if (popupContent) {
-            setIsClicked(false);
-            setPopupAnchor(null);
-        }
-    };
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
     const scheduleManagementWidth = useScheduleManagementStore((state) => state.scheduleManagementWidth);
     const compact =
         isMobileScreen || (scheduleManagementWidth && scheduleManagementWidth < theme.breakpoints.values.xs);
 
-    return (
-        <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} style={{ display: 'flex' }}>
-            <Button
-                variant="contained"
-                size="small"
-                color="primary"
-                onClick={(event: React.MouseEvent<HTMLElement>) => {
-                    if (redirectLink) {
-                        window.open(redirectLink);
-                    }
+    const handleClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
+        logAnalytics({
+            category: analyticsCategory,
+            action: analyticsAction,
+        });
 
-                    if (popupContent) {
-                        // This is mostly used for devices that don't support hovering
-                        // and thus only support clicking to open/close the popup
-                        // If isClicked is true, then the popup is currently visible; otherwise, if
-                        // isClicked is false, then the popup is currently hidden
-                        setPopupAnchor(isClicked ? null : event.currentTarget);
-                        setIsClicked((prev) => !prev);
-                    }
-                }}
-            >
+        if (redirectLink) {
+            window.open(redirectLink);
+            return;
+        }
+
+        if (popupContent) {
+            setAnchorEl(anchorEl ? null : event.currentTarget);
+        }
+    }, []);
+
+    const handleClose = useCallback(() => {
+        setAnchorEl(null);
+    }, []);
+
+    return (
+        <Box sx={{ display: 'flex' }}>
+            <Button variant="contained" size="small" color="primary" onClick={handleClick}>
                 <span style={{ display: 'flex', gap: 4 }}>
                     {icon}
-                    {!compact && (
+                    {compact ? null : (
                         <span
                             style={{
                                 whiteSpace: 'nowrap',
@@ -97,11 +69,19 @@ export const CourseInfoButton = ({
                 </span>
             </Button>
 
-            {popupContent && (
-                <Popper anchorEl={popupAnchor} open={Boolean(popupAnchor)} placement="bottom">
+            {popupContent ? (
+                <Popover
+                    open={Boolean(anchorEl)}
+                    anchorEl={anchorEl}
+                    onClose={handleClose}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    }}
+                >
                     <Paper>{popupContent}</Paper>
-                </Popper>
-            )}
-        </div>
+                </Popover>
+            ) : null}
+        </Box>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@material-ui/core';
 import { Search } from '@material-ui/icons';
+import { Button } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { useCallback } from 'react';
 
@@ -18,16 +18,14 @@ export function CourseInfoSearchButton({ courseDetails, term }: { courseDetails:
     }, [courseNumber, deptCode, term]);
 
     return (
-        <div>
-            <Button
-                variant="contained"
-                size="small"
-                color="primary"
-                style={{ minWidth: 'fit-content' }}
-                onClick={handleClick}
-            >
-                <Search />
-            </Button>
-        </div>
+        <Button
+            variant="contained"
+            size="small"
+            color="primary"
+            style={{ minWidth: 'fit-content' }}
+            onClick={handleClick}
+        >
+            <Search />
+        </Button>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton.tsx
@@ -1,4 +1,4 @@
-import { Search } from '@material-ui/icons';
+import { Search } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { useCallback } from 'react';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -12,9 +12,8 @@ import {
     Legend,
 } from 'recharts';
 
-import { MOBILE_BREAKPOINT } from '../../../globals';
-
 import { DepartmentEnrollmentHistory, EnrollmentHistory } from '$lib/enrollmentHistory';
+import { MOBILE_BREAKPOINT } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
 
 type PopupHeaderCallback = () => void;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -13,8 +13,6 @@ import {
 import { Assessment, Help, RateReview, ShowChart as ShowChartIcon } from '@material-ui/icons';
 import { useMemo } from 'react';
 
-import { MOBILE_BREAKPOINT } from '../../../globals';
-
 import { EnrollmentHistoryPopup } from './EnrollmentHistoryPopup';
 import GradesPopup from './GradesPopup';
 import { SectionTableProps } from './SectionTable.types';
@@ -24,6 +22,7 @@ import { CourseInfoButton } from '$components/RightPane/SectionTable/CourseInfo/
 import { CourseInfoSearchButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton';
 import { SectionTableBody } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBody';
 import analyticsEnum from '$lib/analytics';
+import { MOBILE_BREAKPOINT } from '$src/globals';
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import { useTabStore } from '$stores/TabStore';
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
@@ -3,11 +3,10 @@ import { Box, IconButton, Menu, MenuItem, TableCell, Tooltip, useMediaQuery } fr
 import { AASection, CourseDetails } from '@packages/antalmanac-types';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 
-import { MOBILE_BREAKPOINT } from '../../../../../globals';
-
 import { addCourse, deleteCourse, openSnackbar } from '$actions/AppStoreActions';
 import ColorPicker from '$components/ColorPicker';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
+import { MOBILE_BREAKPOINT } from '$src/globals';
 import AppStore from '$stores/AppStore';
 
 /**

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DetailsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DetailsCell.tsx
@@ -1,9 +1,8 @@
 import { Box, useMediaQuery } from '@mui/material';
 import { WebsocSectionType } from '@packages/antalmanac-types';
 
-import { MOBILE_BREAKPOINT } from '../../../../../globals';
-
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { MOBILE_BREAKPOINT } from '$src/globals';
 
 const SECTION_COLORS = {
     Act: { color: '#c87137' },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -1,13 +1,12 @@
 import { Button, Popover, useMediaQuery } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 
-import { MOBILE_BREAKPOINT } from '../../../../../globals';
 
 import GradesPopup from '$components/RightPane/SectionTable/GradesPopup';
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { Grades } from '$lib/grades';
+import { BLUE, DODGER_BLUE, MOBILE_BREAKPOINT } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
-
 
 async function getGpaData(deptCode: string, courseNumber: string, instructors: string[]) {
     const namedInstructors = instructors.filter((instructor) => instructor !== 'STAFF');
@@ -62,12 +61,14 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
     return (
         <TableBodyCellContainer>
             <Button
-                style={{
-                    color: isDark ? 'dodgerblue' : 'blue',
-                    padding: 0,
+                sx={{
+                    paddingX: 1,
+                    paddingY: 0,
                     minWidth: 0,
                     fontWeight: 400,
                     fontSize: '1rem',
+                    // one-off styling as GPA Button is clickable (but not a link)
+                    color: isDark ? DODGER_BLUE : BLUE,
                 }}
                 onClick={handleClick}
                 variant="text"
@@ -79,8 +80,6 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
                 onClose={hideDistribution}
                 anchorEl={anchorEl}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                disableRestoreFocus
             >
                 <GradesPopup
                     deptCode={deptCode}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { Link } from 'react-router-dom';
 
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 
@@ -15,13 +16,13 @@ export const InstructorsCell = ({ instructors }: InstructorsCellProps) => {
         const lastName = profName.substring(0, profName.indexOf(','));
         return (
             <Box key={profName}>
-                <a
-                    href={`https://www.ratemyprofessors.com/search/professors/1074?q=${lastName}`}
+                <Link
+                    to={`https://www.ratemyprofessors.com/search/professors/1074?q=${lastName}`}
                     target="_blank"
                     rel="noopener noreferrer"
                 >
                     {profName}
-                </a>
+                </Link>
             </Box>
         );
     });

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
@@ -2,22 +2,19 @@ import { WebsocSectionStatus } from '@packages/antalmanac-types';
 import { Link } from 'react-router-dom';
 
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
-import { useThemeStore } from '$stores/SettingsStore';
 
 interface SyllabusCellProps {
     webURL: WebsocSectionStatus;
 }
 
 export const SyllabusCell = ({ webURL }: SyllabusCellProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
-
     if (!webURL) {
         return <TableBodyCellContainer>{null}</TableBodyCellContainer>;
     }
 
     return (
         <TableBodyCellContainer>
-            <Link to={webURL} target="_blank" referrerPolicy="no-referrer" color={isDark ? 'dodgerblue' : 'blue'}>
+            <Link to={webURL} target="_blank" referrerPolicy="no-referrer">
                 Link
             </Link>
         </TableBodyCellContainer>

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTab.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTab.tsx
@@ -2,7 +2,6 @@ import { Tab, useMediaQuery, useTheme } from '@mui/material';
 import { Link } from 'react-router-dom';
 
 import { ScheduleManagementTabInfo } from '$components/ScheduleManagement/ScheduleManagementTabs';
-import { useThemeStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
 
 interface ScheduleManagementTabProps {
@@ -12,7 +11,6 @@ interface ScheduleManagementTabProps {
 
 export const ScheduleManagementTab = ({ tab, value }: ScheduleManagementTabProps) => {
     const { setActiveTabValue } = useTabStore();
-    const isDark = useThemeStore((store) => store.isDark);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -41,7 +39,6 @@ export const ScheduleManagementTab = ({ tab, value }: ScheduleManagementTabProps
                           minWidth: '33%',
                       }),
                 display: isMobile || !tab.mobile ? 'flex' : 'none',
-                ...(isDark ? { '&.Mui-selected': { color: 'white' } } : {}),
             }}
             label={tab.label}
             onClick={handleClick}

--- a/apps/antalmanac/src/components/buttons/MapLink.tsx
+++ b/apps/antalmanac/src/components/buttons/MapLink.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useThemeStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
 
 interface MapLinkProps {
@@ -11,7 +10,6 @@ interface MapLinkProps {
 
 export const MapLink = ({ buildingId, room }: MapLinkProps) => {
     const { setActiveTab } = useTabStore();
-    const isDark = useThemeStore((store) => store.isDark);
 
     const focusMap = useCallback(() => {
         setActiveTab('map');
@@ -23,7 +21,6 @@ export const MapLink = ({ buildingId, room }: MapLinkProps) => {
             onClick={focusMap}
             style={{
                 textDecoration: 'none',
-                color: isDark ? 'dodgerblue' : 'blue',
             }}
         >
             {room}

--- a/apps/antalmanac/src/globals.ts
+++ b/apps/antalmanac/src/globals.ts
@@ -1,1 +1,3 @@
 export const MOBILE_BREAKPOINT = '960px';
+export const DODGER_BLUE = '#1e90ff';
+export const BLUE = '#305db7';

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -223,7 +223,7 @@ export function getTermLength(quarter: string) {
  */
 export function getRRule(bydays: string[], quarter: string) {
     /**
-     * Number of occurences in the quarter
+     * Number of occurrences in the quarter
      */
     let count = getTermLength(quarter) * bydays.length;
 

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -1,4 +1,4 @@
-import { createTheme, CssBaseline } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { useEffect } from 'react';
 
@@ -69,10 +69,5 @@ export default function AppThemeProvider(props: Props) {
         spacing: 4,
     });
 
-    return (
-        <ThemeProvider theme={AppTheme}>
-            <CssBaseline />
-            {props.children}
-        </ThemeProvider>
-    );
+    return <ThemeProvider theme={AppTheme}>{props.children}</ThemeProvider>;
 }

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -1,8 +1,36 @@
 import { createTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
+import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 import { useEffect } from 'react';
 
+import { DODGER_BLUE } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
+
+const lightTheme: PaletteOptions = {
+    primary: {
+        main: '#5191d6',
+    },
+    secondary: {
+        main: '#ffffff',
+    },
+    background: {
+        default: '#fafafa',
+        paper: '#fff',
+    },
+};
+
+const darkTheme: PaletteOptions = {
+    primary: {
+        main: DODGER_BLUE,
+    },
+    secondary: {
+        main: '#ffffff',
+    },
+    background: {
+        default: '#303030',
+        paper: '#424242',
+    },
+};
 
 interface Props {
     children?: React.ReactNode;
@@ -53,18 +81,7 @@ export default function AppThemeProvider(props: Props) {
         },
         palette: {
             type: appTheme == 'dark' ? 'dark' : 'light',
-            primary: {
-                light: '#5191d6',
-                main: '#305db7',
-                dark: '#003a75',
-                contrastText: '#fff',
-            },
-            secondary: {
-                light: '#ffff52',
-                main: '#ffffff',
-                dark: '#c7a100',
-                contrastText: '#000',
-            },
+            ...(appTheme == 'dark' ? darkTheme : lightTheme),
         },
         spacing: 4,
     });

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -1,4 +1,4 @@
-import { createTheme } from '@material-ui/core';
+import { createTheme, CssBaseline } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { useEffect } from 'react';
 
@@ -51,11 +51,6 @@ export default function AppThemeProvider(props: Props) {
                 xl: 1536,
             },
         },
-        typography: {
-            htmlFontSize: parseInt(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'), 10),
-            fontSize:
-                parseInt(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'), 10) * 0.9,
-        },
         palette: {
             type: appTheme == 'dark' ? 'dark' : 'light',
             primary: {
@@ -74,5 +69,10 @@ export default function AppThemeProvider(props: Props) {
         spacing: 4,
     });
 
-    return <ThemeProvider theme={AppTheme}>{props.children}</ThemeProvider>;
+    return (
+        <ThemeProvider theme={AppTheme}>
+            <CssBaseline />
+            {props.children}
+        </ThemeProvider>
+    );
 }

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 import { useEffect } from 'react';
 
-import { DODGER_BLUE } from '$src/globals';
+import { BLUE, DODGER_BLUE } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
 
 const lightTheme: PaletteOptions = {
@@ -61,7 +61,7 @@ export default function AppThemeProvider(props: Props) {
             MuiCssBaseline: {
                 '@global': {
                     a: {
-                        color: appTheme == 'dark' ? 'dodgerBlue' : 'blue',
+                        color: appTheme == 'dark' ? DODGER_BLUE : BLUE,
                     },
                 },
             },

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -1,6 +1,7 @@
 import { createTheme, CssBaseline, ThemeProvider, type PaletteOptions } from '@mui/material';
 import { useEffect, useMemo } from 'react';
 
+import { DODGER_BLUE } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
 
 const lightTheme: PaletteOptions = {
@@ -18,7 +19,7 @@ const lightTheme: PaletteOptions = {
 
 const darkTheme: PaletteOptions = {
     primary: {
-        main: '#305db7',
+        main: DODGER_BLUE,
     },
     secondary: {
         main: '#ffffff',
@@ -70,6 +71,25 @@ export default function AppThemev5Provider(props: Props) {
                             paper: {
                                 backgroundImage: 'none',
                             },
+                        },
+                    },
+                    MuiAppBar: {
+                        styleOverrides: {
+                            root: {
+                                backgroundImage: 'none',
+                            },
+                        },
+                    },
+                    MuiButton: {
+                        styleOverrides: {
+                            root: ({ ownerState }) => ({
+                                ...(ownerState.variant === 'contained' && {
+                                    backgroundColor: '#305db7',
+                                    ':hover': {
+                                        backgroundColor: '#003A75',
+                                    },
+                                }),
+                            }),
                         },
                     },
                 },

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -64,6 +64,14 @@ export default function AppThemev5Provider(props: Props) {
                             },
                         },
                     },
+                    // https://github.com/mui/material-ui/issues/43683#issuecomment-2492787970
+                    MuiDialog: {
+                        styleOverrides: {
+                            paper: {
+                                backgroundImage: 'none',
+                            },
+                        },
+                    },
                 },
                 breakpoints: {
                     /**

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -1,7 +1,7 @@
 import { createTheme, CssBaseline, ThemeProvider, type PaletteOptions } from '@mui/material';
 import { useEffect, useMemo } from 'react';
 
-import { DODGER_BLUE } from '$src/globals';
+import { BLUE, DODGER_BLUE } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
 
 const lightTheme: PaletteOptions = {
@@ -61,7 +61,7 @@ export default function AppThemev5Provider(props: Props) {
                     MuiCssBaseline: {
                         styleOverrides: {
                             a: {
-                                color: appTheme === 'dark' ? 'dodgerblue' : 'blue',
+                                color: appTheme === 'dark' ? DODGER_BLUE : BLUE,
                             },
                         },
                     },
@@ -84,7 +84,7 @@ export default function AppThemev5Provider(props: Props) {
                         styleOverrides: {
                             root: ({ ownerState }) => ({
                                 ...(ownerState.variant === 'contained' && {
-                                    backgroundColor: '#305db7',
+                                    backgroundColor: BLUE,
                                     ':hover': {
                                         backgroundColor: '#003A75',
                                     },
@@ -107,8 +107,8 @@ export default function AppThemev5Provider(props: Props) {
                     },
                 },
                 palette: {
-                    mode: appTheme == 'dark' ? 'dark' : 'light',
-                    ...(appTheme == 'dark' ? darkTheme : lightTheme),
+                    mode: appTheme === 'dark' ? 'dark' : 'light',
+                    ...(appTheme === 'dark' ? darkTheme : lightTheme),
                 },
             }),
         [appTheme]

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -83,12 +83,13 @@ export default function AppThemev5Provider(props: Props) {
                     MuiButton: {
                         styleOverrides: {
                             root: ({ ownerState }) => ({
-                                ...(ownerState.variant === 'contained' && {
-                                    backgroundColor: BLUE,
-                                    ':hover': {
-                                        backgroundColor: '#003A75',
-                                    },
-                                }),
+                                ...(ownerState.variant === 'contained' &&
+                                    ownerState.color === 'primary' && {
+                                        backgroundColor: BLUE,
+                                        ':hover': {
+                                            backgroundColor: '#003A75',
+                                        },
+                                    }),
                             }),
                         },
                     },

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -5,11 +5,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import Split from 'react-split';
 
 import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
-import Header from '$components/Header';
+import { Header } from '$components/Header/Header';
 import NotificationSnackbar from '$components/NotificationSnackbar';
 import PatchNotes from '$components/PatchNotes';
 import { ScheduleManagement } from '$components/ScheduleManagement/ScheduleManagement';
 import { Tutorial } from '$components/Tutorial';
+import { BLUE } from '$src/globals';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 
 function MobileHome() {
@@ -22,7 +23,6 @@ function MobileHome() {
 }
 
 function DesktopHome() {
-    const theme = useTheme();
     const setScheduleManagementWidth = useScheduleManagementStore((state) => state.setScheduleManagementWidth);
 
     const scheduleManagementRef = useRef<HTMLDivElement>(null);
@@ -62,10 +62,12 @@ function DesktopHome() {
                     dragInterval={1}
                     direction="horizontal"
                     cursor="col-resize"
-                    style={{ display: 'flex', flexGrow: 1 }}
+                    style={{ display: 'flex', flexGrow: 1, marginTop: 4 }}
                     gutterStyle={() => ({
-                        backgroundColor: theme.palette.primary.main,
+                        backgroundColor: BLUE,
                         width: '10px',
+                        // gutter contents are slightly offset to the right, this centers the content
+                        paddingRight: '1px',
                     })}
                     onDrag={handleDrag}
                 >

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -1,6 +1,6 @@
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import { CssBaseline, useMediaQuery, useTheme, Stack } from '@mui/material';
+import { useMediaQuery, useTheme, Stack } from '@mui/material';
 import { useCallback, useEffect, useRef } from 'react';
 import Split from 'react-split';
 
@@ -90,8 +90,6 @@ export default function Home() {
 
     return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <CssBaseline />
-
             <PatchNotes />
 
             {isMobileScreen ? <MobileHome /> : <DesktopHome />}

--- a/apps/antalmanac/tsconfig.json
+++ b/apps/antalmanac/tsconfig.json
@@ -23,7 +23,8 @@
             "$lib/*": ["src/lib/*"],
             "$providers/*": ["src/providers/*"],
             "$routes/*": ["src/routes/*"],
-            "$stores/*": ["src/stores/*"]
+            "$stores/*": ["src/stores/*"],
+            "$src/*": ["src/*"]
         }
     }
 }

--- a/apps/antalmanac/vite.config.ts
+++ b/apps/antalmanac/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
             $lib: resolve(__dirname, './src/lib'),
             $providers: resolve(__dirname, './src/providers'),
             $routes: resolve(__dirname, './src/routes'),
+            $src: resolve(__dirname, './src'),
             $stores: resolve(__dirname, './src/stores'),
         },
     },


### PR DESCRIPTION
## Context
AntAlmanac has a few styling (and UX) issues that noticeably degrade the user experience. This PR is (hopefully) the first of a few PRs aiming to finally bring AA to MUI v5 (though v6 is out now...) and to resolve many problems littering the codebase (e.g. mobile breakpoints).

A few of the larger problems are detailed below:

### Unreadable primary colors on dark mode
<p align="center">
<img width="400" src="https://github.com/user-attachments/assets/bf238d84-ed24-4b08-88f7-05d111e2fb1d">
<br/>
What does the blue text even say?
</p>

### Computationally expensive, visually blocking elements `onHover`
<p align="center">
<img width="400" src="https://github.com/user-attachments/assets/ffe95978-a87f-4d00-a755-9c9c966b9e34">
<br/>
A considerable amount of time is wasted moving the mouse off of an unwanted hover
</p>

## Summary
In terms of LOC, this PR is not particularly big but it does touch most parts of our UI.

A (mostly comprehensive, but probably non-exhaustive) list of changes are listed here:

1. Adds `src/` as an alias (e.g. `../../**/globals` -> `$src/globals`)
2. Refactors `Header`
3. Restyles `RecruitmentBanner`
4. Converted `CourseInfoButton` into an `onClick` button, rather than `onHover`

![chrome-capture-2025-0-30](https://github.com/user-attachments/assets/a944101f-6763-4844-a0b7-0314d29dd94d)

5. Added `BLUE` (#305db7, darker) and `DODGER_BLUE` (#1e90ff, lighter) as globals
6. Made course info buttons always `BLUE`
7. Made clickable text (e.g. link text, MapLink, GPA Cell) `BLUE` on dark mode and `DODGER_BLUE` on light mode
8. Set Split to always be `BLUE` and fixed dot centering
9. Dark mode's primary color is now `DODGER_BLUE` (most noticeable in tab indicators, inputs, selects)
10. Updated `Theme` and `ThemeV5` to be virtually identical (will eventually get rid of `Theme`)
11. Added overrides to fix dialogs (left is new)

<img width="1728" alt="Screenshot 2025-01-30 at 10 22 02 PM" src="https://github.com/user-attachments/assets/8c2796fb-b371-4e8f-8197-497635fea27c" />

## Test Plan
There are no logic changes here, so it's somewhat hard to give a step-by-step, as many of our PRs do for their test plans. 

My recommendation is to quite literally attempt every flow within AntAlmanac that you can imagine, on both light and dark.

A (non-exhaustive) checklist might be:
- [ ] Search page (filters, searching)
- [ ] Search results page (adding courses, removing courses, GPA button, link buttons (e.g. MapLink), course info buttons)
- [ ] Added page
- [ ] Map page (tabs, days, markers)
- [ ] Header
- [ ] Settings Drawer
- [ ] Calendar

## Closes
#1073