### PR TITLE
Corrected link for Anteater API in the README in the apps/backend folder

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -4,7 +4,7 @@ This is the dedicated backend for [AntAlmanac](https://antalmanac.com),
 which is primarily responsible for managing user data and internal information.
 
 This is **_NOT_** for retrieving enrollment data from UCI;
-[Anteater API](https://docs.icssc.club/developer/anteaterapi) is a separate ICSSC project dedicated
+[Anteater API](https://docs.icssc.club/docs/developer/anteaterapi) is a separate ICSSC project dedicated
 to providing us this information.
 
 # Setup


### PR DESCRIPTION
## Summary

In the readme in the apps/backend folder, there is a link to the developer docs for Anteater API. The current link is https://docs.icssc.club/developer/anteaterapi, which is the wrong link (try it, you'll get a 404). This pull request just replaces that link with the correct link, which is https://docs.icssc.club/docs/developer/anteaterapi (notice the `/docs/` in the middle). Yes, I literally only added 5 characters in this pull request.

## Test Plan

- [ ] Verify that the link routes to the correct URL now.

## Issues

There (probably, I haven't checked) isn't an issue for this, but I figured it'd be easier to create this PR right now instead of letting you guys know in discord or making an issue, since its literally just the smallest thing.

<!-- [Optional]
## Future Followup
-->
