### PR TITLE
chore(readme): style and accuracy when referring to anteater api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A summary of the libraries we use are listed below.
 
 ### Backend
 - [tRPC](https://trpc.io) - type-safe API access layer for the AntAlmanac API.
-- [Anteater API](https://docs.icssc.club/developer/anteaterapi) - API maintained by ICSSC for retrieving UCI data.
+- [Anteater API](https://docs.icssc.club/docs/about/anteaterapi) - API maintained by ICSSC for retrieving UCI data.
 - [Drizzle ORM](https://orm.drizzle.team/) - [high-performance](https://orm.drizzle.team/benchmarks) type-safe SQL-like access layer compatiable with all major SQL dialects. 
 
 ### Tooling

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -3,9 +3,9 @@
 This is the dedicated backend for [AntAlmanac](https://antalmanac.com),
 which is primarily responsible for managing user data and internal information.
 
-This is **_NOT_** for retrieving enrollment data from UCI;
-[Anteater API](https://docs.icssc.club/docs/developer/anteaterapi) is a separate ICSSC project dedicated
-to providing us this information.
+This is **_NOT_** for retrieving course, enrollment, or similar data from UCI;
+[Anteater API](https://docs.icssc.club/docs/developer/anteaterapi), a separate ICSSC project,
+provides this information.
 
 # Setup
 
@@ -17,9 +17,8 @@ to providing us this information.
 - Populate the keys following the instructions below.
     - Note that the Mapbox API key can be left blank, which will cause the app to default to OSM's tiles.
 
-## AnteaterAPI Key
-- The key is required to send course information requests to AnteaterAPI.
-- It can be acquired from the [AnteaterAPI Dashboard](https://dashboard.anteaterapi.com).
+## Anteater API Key
+- An Anteater API key is required to send course information requests to Anteater API. You can obtain one on the [Anteater API Dashboard](https://dashboard.anteaterapi.com).
 
 ## Local Database
 - Install PostgreSQL and pgAdmin.


### PR DESCRIPTION
## Summary

Follow up [#1143](https://github.com/icssc/AntAlmanac/pull/1143#issuecomment-2638906757).
Also some style nits, e.g. "AnteaterAPI" should be "Anteater API".

## Test Plan

Not a code change. The GitHub preview of the changed files is sufficient for review.

## Issues

No backing issue.
