### PR TITLE
ci: bump upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -68,7 +68,7 @@ jobs:
               run: pnpm --filter "antalmanac" build
 
             - name: Upload built artifacts
-              uses: actions/upload-pages-artifact@v2
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: apps/antalmanac/build
 


### PR DESCRIPTION
## Summary
`upload-artifacts@v3` is deprecated. This PR updates `upload-pages-artifacts@v2` to `v3`.

## Test Plan
1. Deploys

## Issues
Closes #1144

<!-- [Optional]
## Future Followup
-->
