### PR TITLE
Fix first undo after load

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -481,7 +481,7 @@ export class Schedules {
      */
     revertState() {
         // prevent the user from undoing to an empty state
-        if (this.previousStates.length <= 1) {
+        if (this.previousStates.length === 0) {
             return;
         }
 

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -480,11 +480,6 @@ export class Schedules {
      * All actions that call `addUndoState()` can be reverted.
      */
     revertState() {
-        // prevent the user from undoing to an empty state
-        if (this.previousStates.length === 0) {
-            return;
-        }
-
         const state = this.previousStates.pop();
         if (state !== undefined) {
             this.schedules = state.schedules;


### PR DESCRIPTION
## Summary
- Previously, we checked whether the length of the save states is `<= 1` to disallow, which means that the first state after loading can't be undone.
- That check has been removed, so the state is revertible as long as there is a `previousState`.

## Test Plan
- [ ] Undo works properly before loading a schedule by adding one section and performing undo.
- [ ] Undo does not clear a schedule when it is loaded in.
- [ ] Undo works on the first action (e.g., removing a section) after loading a schedule.
- [ ] Multiple undo's can be performed.

## Issues

Closes #1150 
