### PR TITLE
feat/refactor: Spring 25, select most recent term

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -16,6 +16,12 @@ import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 
+moment.updateLocale('es-us', {
+    week: {
+        dow: 6,
+    },
+});
+
 const CALENDAR_LOCALIZER: DateLocalizer = momentLocalizer(moment);
 const CALENDAR_VIEWS: ViewsProps<CalendarEvent, object> = [Views.WEEK, Views.WORK_WEEK];
 const CALENDAR_COMPONENTS: Components<CalendarEvent, object> = {
@@ -127,18 +133,6 @@ export const ScheduleCalendar = memo(() => {
         }),
         [calendarGutterTimeFormat, calendarTimeFormat, finalsDateFormat, showFinalsSchedule]
     );
-
-    useEffect(() => {
-        /**
-         * If a final is on a Saturday or Sunday, let the calendar start on Saturday
-         */
-        // eslint-disable-next-line import/no-named-as-default-member -- moment doesn't expose named exports: https://github.com/vitejs/vite-plugin-react/issues/202
-        moment.updateLocale('es-us', {
-            week: {
-                dow: hasWeekendCourse && showFinalsSchedule ? 6 : 0,
-            },
-        });
-    }, [hasWeekendCourse, showFinalsSchedule]);
 
     useEffect(() => {
         const updateEventsInCalendar = () => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -135,7 +135,7 @@ export const ScheduleCalendar = memo(() => {
         // eslint-disable-next-line import/no-named-as-default-member -- moment doesn't expose named exports: https://github.com/vitejs/vite-plugin-react/issues/202
         moment.updateLocale('en-us', {
             week: {
-                dow: showFinalsSchedule ? 6 : hasWeekendCourse ? 7 : 1,
+                dow: hasWeekendCourse && showFinalsSchedule ? 6 : 0,
             },
         });
     }, [hasWeekendCourse, showFinalsSchedule]);

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -16,12 +16,6 @@ import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 
-moment.updateLocale('es-us', {
-    week: {
-        dow: 6,
-    },
-});
-
 const CALENDAR_LOCALIZER: DateLocalizer = momentLocalizer(moment);
 const CALENDAR_VIEWS: ViewsProps<CalendarEvent, object> = [Views.WEEK, Views.WORK_WEEK];
 const CALENDAR_COMPONENTS: Components<CalendarEvent, object> = {
@@ -133,6 +127,18 @@ export const ScheduleCalendar = memo(() => {
         }),
         [calendarGutterTimeFormat, calendarTimeFormat, finalsDateFormat, showFinalsSchedule]
     );
+
+    useEffect(() => {
+        /**
+         * If a final is on a Saturday or Sunday, let the calendar start on Saturday
+         */
+        // eslint-disable-next-line import/no-named-as-default-member -- moment doesn't expose named exports: https://github.com/vitejs/vite-plugin-react/issues/202
+        moment.updateLocale('en-us', {
+            week: {
+                dow: showFinalsSchedule ? 6 : hasWeekendCourse ? 7 : 1,
+            },
+        });
+    }, [hasWeekendCourse, showFinalsSchedule]);
 
     useEffect(() => {
         const updateEventsInCalendar = () => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -5,15 +5,13 @@ import { Box } from '@material-ui/core';
 import moment from 'moment';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Calendar, Components, DateLocalizer, momentLocalizer, Views, ViewsProps } from 'react-big-calendar';
-import { shallow } from 'zustand/shallow';
-
-import { CalendarEvent, CourseEvent } from './CourseCalendarEvent';
 
 import { CalendarCourseEvent } from '$components/Calendar/CalendarCourseEvent';
 import { CalendarCourseEventWrapper } from '$components/Calendar/CalendarCourseEventWrapper';
 import { CalendarEventPopover } from '$components/Calendar/CalendarEventPopover';
+import { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CalendarToolbar } from '$components/Calendar/Toolbar/CalendarToolbar';
-import { getDefaultFinalsStartDate, getFinalsStartDateForTerm } from '$lib/termData';
+import { getTerm } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
@@ -34,10 +32,7 @@ export const ScheduleCalendar = memo(() => {
     const [scheduleNames, setScheduleNames] = useState(() => AppStore.getScheduleNames());
 
     const { isMilitaryTime } = useTimeFormatStore();
-    const [hoveredCalendarizedCourses, hoveredCalendarizedFinal] = useHoveredStore(
-        (state) => [state.hoveredCalendarizedCourses, state.hoveredCalendarizedFinal],
-        shallow
-    );
+    const { hoveredCalendarizedCourses, hoveredCalendarizedFinal } = useHoveredStore();
 
     const getEventsForCalendar = useCallback((): CalendarEvent[] => {
         if (showFinalsSchedule)
@@ -111,11 +106,7 @@ export const ScheduleCalendar = memo(() => {
 
     const onlyCourseEvents = eventsInCalendar.filter((e) => !e.isCustomEvent) as CourseEvent[];
 
-    const finalsDate = hoveredCalendarizedFinal
-        ? getFinalsStartDateForTerm(hoveredCalendarizedFinal.term)
-        : onlyCourseEvents.length > 0
-        ? getFinalsStartDateForTerm(onlyCourseEvents[0].term)
-        : getDefaultFinalsStartDate();
+    const finalsDate = getTerm(hoveredCalendarizedFinal?.term ?? onlyCourseEvents.at(0)?.term).getFinalsStartDate();
 
     const finalsDateFormat = finalsDate ? 'ddd MM/DD' : 'ddd';
     const date = showFinalsSchedule && finalsDate ? finalsDate : new Date(2018, 0, 1);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/TermSelector.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/TermSelector.tsx
@@ -3,27 +3,15 @@ import { ChangeEvent, useEffect, useState } from 'react';
 
 import RightPaneStore from '../../RightPaneStore';
 
-import { termData } from '$lib/termData';
+import { getSocAvailableTerms } from '$lib/termData';
 
 interface TermSelectorProps {
-    changeTerm: (field: string, value: string) => void;
     fieldName: string;
+    changeTerm: (field: string, value: string) => void;
 }
 
-function TermSelector(props: TermSelectorProps) {
-    const { changeTerm, fieldName } = props;
-
-    const getTerm = () => {
-        const urlTerm = RightPaneStore.getUrlTermValue();
-
-        if (urlTerm) {
-            RightPaneStore.updateFormValue('term', urlTerm);
-        }
-
-        return RightPaneStore.getFormData().term;
-    };
-
-    const [term, setTerm] = useState(getTerm());
+function TermSelector({ fieldName, changeTerm }: TermSelectorProps) {
+    const [term, setTerm] = useState(() => RightPaneStore.getFormData().term);
 
     const handleChange = (event: ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         const newValue = event.target.value as string;
@@ -52,7 +40,7 @@ function TermSelector(props: TermSelectorProps) {
         <FormControl fullWidth>
             <InputLabel>Term</InputLabel>
             <Select value={term} onChange={handleChange}>
-                {termData.map((term, index) => (
+                {getSocAvailableTerms().map((term, index) => (
                     <MenuItem key={index} value={term.shortName}>
                         {term.longName}
                     </MenuItem>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
@@ -14,20 +14,20 @@ interface LocationsCellProps {
 export const LocationsCell = ({ meetings }: LocationsCellProps) => {
     return (
         <TableBodyCellContainer>
-            {meetings.map((meeting) => {
+            {meetings.map((meeting, index) => {
                 return !meeting.timeIsTBA ? (
                     meeting.bldg.map((bldg) => {
                         const [buildingName = ''] = bldg.split(' ');
                         const buildingId = locationIds[buildingName];
                         return (
-                            <Fragment key={meeting.timeIsTBA + bldg}>
+                            <Fragment key={index}>
                                 <MapLink buildingId={buildingId} room={bldg} />
                                 <br />
                             </Fragment>
                         );
                     })
                 ) : (
-                    <Box>{'TBA'}</Box>
+                    <Box key={index}>{'TBA'}</Box>
                 );
             })}
         </TableBodyCellContainer>

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -8,11 +8,11 @@ import { openSnackbar } from '$actions/AppStoreActions';
 import { CustomEvent, FinalExam } from '$components/Calendar/CourseCalendarEvent';
 import analyticsEnum, { logAnalytics } from '$lib/analytics';
 import buildingCatalogue from '$lib/locations/buildingCatalogue';
-import { getDefaultTerm, termData } from '$lib/termData';
+import { getDefaultTerm, getSocAvailableTerms } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 
 export const quarterStartDates = Object.fromEntries(
-    termData
+    getSocAvailableTerms()
         .filter((term) => term.startDate !== undefined)
         .map((term) => [term.shortName, term.startDate as [number, number, number]])
 );

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -1,6 +1,5 @@
-import { termData } from './termData';
-
 import trpc from '$lib/api/trpc';
+import { getSocAvailableTerms } from '$lib/termData';
 
 // This represents the enrollment history of a course section during one quarter
 export interface EnrollmentHistoryGraphQL {
@@ -46,7 +45,7 @@ export interface EnrollmentHistoryDay {
 export class DepartmentEnrollmentHistory {
     // Each key in the cache will be the department and courseNumber concatenated
     static enrollmentHistoryCache: Record<string, EnrollmentHistory[] | null> = {};
-    static termShortNames: string[] = termData.map((term) => term.shortName);
+    static termShortNames: string[] = getSocAvailableTerms().map((term) => term.shortName);
 
     department: string;
 
@@ -56,8 +55,9 @@ export class DepartmentEnrollmentHistory {
 
     async find(courseNumber: string): Promise<EnrollmentHistory[] | null> {
         const cacheKey = this.department + courseNumber;
-        return (DepartmentEnrollmentHistory.enrollmentHistoryCache[cacheKey] ??=
-            await this.queryEnrollmentHistory(courseNumber));
+        return (DepartmentEnrollmentHistory.enrollmentHistoryCache[cacheKey] ??= await this.queryEnrollmentHistory(
+            courseNumber
+        ));
     }
 
     async queryEnrollmentHistory(courseNumber: string): Promise<EnrollmentHistory[] | null> {

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -146,7 +146,7 @@ function getDefaultTerm(events: (CustomEvent | CourseEvent)[] = []): Term {
 
         const [year, month, day] = t.socAvailableDate;
 
-        return new Date() >= new Date(Date.UTC(year, month, day, 8, 0, 0)); // Midnight PST
+        return new Date() >= new Date(year, month, day);
     });
 
     for (const event of events) {

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -171,4 +171,21 @@ function getTerm(termShortName?: string): Term {
     return termData.find((t) => t.shortName === termShortName) ?? getDefaultTerm();
 }
 
-export { termData, getTerm, getDefaultTerm };
+/**
+ * Returns all terms that are available on SOC
+ */
+function getSocAvailableTerms(): Term[] {
+    const socAvailableIndex = termData.findIndex((t) => {
+        const socAvailableDate = t.getSocAvailableDate();
+
+        if (!socAvailableDate) {
+            return false;
+        }
+
+        return Date.now() >= socAvailableDate.getTime();
+    });
+
+    return termData.slice(socAvailableIndex);
+}
+
+export { termData, getTerm, getDefaultTerm, getSocAvailableTerms };

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -134,7 +134,7 @@ const termData = [
  * If an array of events is provided, select the first term found.
  */
 function getDefaultTerm(events: (CustomEvent | CourseEvent)[] = []): Term {
-    let term = termData.find((t) => {
+    let term = getSocAvailableTerms().find((t) => {
         if (!t.socAvailableDate) {
             return false;
         }
@@ -146,7 +146,7 @@ function getDefaultTerm(events: (CustomEvent | CourseEvent)[] = []): Term {
 
         const [year, month, day] = t.socAvailableDate;
 
-        return new Date() >= new Date(year, month, day);
+        return new Date(2025, 6, 1) >= new Date(year, month, day);
     });
 
     for (const event of events) {
@@ -188,4 +188,4 @@ function getSocAvailableTerms(): Term[] {
     return termData.slice(socAvailableIndex);
 }
 
-export { termData, getTerm, getDefaultTerm, getSocAvailableTerms };
+export { getTerm, getDefaultTerm, getSocAvailableTerms };

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -10,7 +10,7 @@ import type {
 
 import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } from './calendarizeHelpers';
 
-import { termData } from '$lib/termData';
+import { getDefaultTerm } from '$lib/termData';
 import { WebSOC } from '$lib/websoc';
 import { getColorForNewSection } from '$stores/scheduleHelpers';
 
@@ -38,7 +38,7 @@ export class Schedules {
 
         this.schedules = [
             {
-                scheduleName: `${termData[0].shortName.replaceAll(' ', '-')}`,
+                scheduleName: `${getDefaultTerm().shortName.replaceAll(' ', '-')}`,
                 courses: [],
                 customEvents: [],
                 scheduleNoteId: scheduleNoteId,
@@ -63,7 +63,7 @@ export class Schedules {
     }
 
     getDefaultScheduleName() {
-        return termData[0].shortName.replaceAll(' ', '-');
+        return getDefaultTerm().shortName.replaceAll(' ', '-');
     }
 
     getCurrentScheduleIndex() {

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -6,7 +6,7 @@ import type {
 } from '@packages/antalmanac-types';
 
 import { CourseEvent, CustomEvent, Location } from '$components/Calendar/CourseCalendarEvent';
-import { getFinalsStartForTerm } from '$lib/termData';
+import { getTerm } from '$lib/termData';
 import { notNull, getReferencesOccurring } from '$lib/utils';
 
 export const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
@@ -127,7 +127,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
              * Fallback to January 2018 if no finals start date is available.
              * finalsDay is handled later by day since it varies by day.
              */
-            const [finalsYear, finalsMonth, finalsDay] = [...(getFinalsStartForTerm(course.term) ?? [2018, 0])];
+            const [finalsYear, finalsMonth, finalsDay] = [...(getTerm(course.term).finalsStartDate ?? [2018, 0])];
 
             return dayIndicesOccurring.map((dayIndex) => ({
                 color: course.section.color,

--- a/apps/antalmanac/tests/termData.tsx
+++ b/apps/antalmanac/tests/termData.tsx
@@ -1,17 +1,9 @@
 import { describe, test, expect } from 'vitest';
 
 import { CourseEvent } from '$components/Calendar/CourseCalendarEvent';
-import { getDefaultTerm, defaultTerm, termData } from '$lib/termData';
+import { getDefaultTerm } from '$lib/termData';
 
 describe('termData', () => {
-    /**
-     * Leaky/abstracted test because it knows how the function actually works.
-     */
-    test('uses default term index if no events is provided', () => {
-        const term = getDefaultTerm();
-        expect(term.shortName).toEqual(termData[defaultTerm]);
-    });
-
     test('uses first term found in event list if provided', () => {
         const event: CourseEvent = {
             locations: [],


### PR DESCRIPTION
## Summary
1. Term data now selects `defaultTerm` based on the term which has the most recent and available SOC. If none are present, it defaults to index 0 (though it will always be present).
2. Adds Spring 2025 through Fall 2025

## Test Plan
1. Loading in should select the correct default term (Spring 2025, once it becomes 2/8) -- best way to test would be to modify `getDefaultTerm` and adjust what day it is

```ts
function getDefaultTerm(events: (CustomEvent | CourseEvent)[] = []): Term {
...
        return new Date() >= new Date(year, month, day); // edit this line
    });
...
}
```

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
