### PR TITLE
chore: spring 2025

### DIFF
--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -29,6 +29,7 @@ class Term {
  * Months are 0-indexed
  */
 const termData = [
+    new Term('2025 Spring', '2025 Spring Quarter', [2025, 2, 31], [2025, 5, 7]),
     new Term('2025 Winter', '2025 Winter Quarter', [2025, 0, 6], [2025, 2, 15]),
     new Term('2024 Fall', '2024 Fall Quarter', [2024, 8, 26], [2024, 11, 7]),
     new Term('2024 Summer2', '2024 Summer Session 2', [2024, 7, 5], [2024, 8, 10]),


### PR DESCRIPTION
## Summary
1. Adds Spring 2025

```ts
    new Term('2025 Spring', '2025 Spring Quarter', [2025, 2, 31], [2025, 5, 7]),
```
Instruction begins on 3/31, Finals start on June 7th (months are 0 index, days are 1 index)

https://www.reg.uci.edu/calendars/quarterly/2024-2025/quarterly24-25.html

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
