### PR TITLE
feat: One row calendar top bar on small screens

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -1,5 +1,9 @@
-import { Undo as UndoIcon, Description as DescriptionIcon } from '@mui/icons-material';
-import { useMediaQuery, Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
+import {
+    Undo as UndoIcon,
+    Description as DescriptionIcon,
+    DescriptionOutlined as DescriptionOutlinedIcon,
+} from '@mui/icons-material';
+import { useTheme, useMediaQuery, Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
 import { useState, useCallback, useEffect, memo } from 'react';
 
 import { undoDelete } from '$actions/AppStoreActions';
@@ -30,11 +34,12 @@ export interface CalendarPaneToolbarProps {
  * The root toolbar will pass down the schedule names to its children.
  */
 export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
+    const theme = useTheme();
     const { showFinalsSchedule, toggleDisplayFinalsSchedule } = props;
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
     const [skeletonScheduleNames, setSkeletonScheduleNames] = useState(AppStore.getSkeletonScheduleNames());
-    const isSmallScreen = useMediaQuery('(max-width: 400px)');
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('xxs'));
 
     const handleToggleFinals = useCallback(() => {
         logAnalytics({
@@ -92,7 +97,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                             id={showFinalsSchedule ? 'finals-button-pressed' : 'finals-button'}
                             disabled={skeletonMode}
                         >
-                            <DescriptionIcon />
+                            {showFinalsSchedule ? <DescriptionIcon /> : <DescriptionOutlinedIcon />}
                         </IconButton>
                     ) : (
                         <Button
@@ -108,7 +113,6 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                     )}
                 </Tooltip>
             </Box>
-
             {!isSmallScreen && <Box flexGrow={1} />}
 
             <Box display="flex" flexWrap="wrap" alignItems="center" gap={0.5}>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -113,7 +113,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                     )}
                 </Tooltip>
             </Box>
-            {!isSmallScreen && <Box flexGrow={1} />}
+            <Box flexGrow={1} />
 
             <Box display="flex" flexWrap="wrap" alignItems="center" gap={0.5}>
                 <ScreenshotButton />

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -99,7 +99,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                             size="small"
                             sx={{
                                 border: '1px solid',
-                                borderColor: showFinalsSchedule ? 'primary' : 'white',
+                                borderColor: showFinalsSchedule ? 'primary' : 'inherit',
                                 borderRadius: '4px',
                                 padding: '3px',
                             }}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -96,6 +96,13 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                             onClick={handleToggleFinals}
                             id={showFinalsSchedule ? 'finals-button-pressed' : 'finals-button'}
                             disabled={skeletonMode}
+                            size="small"
+                            sx={{
+                                border: '1px solid',
+                                borderColor: showFinalsSchedule ? 'primary' : 'white',
+                                borderRadius: '4px',
+                                padding: '3px',
+                            }}
                         >
                             {showFinalsSchedule ? <DescriptionIcon /> : <DescriptionOutlinedIcon />}
                         </IconButton>

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -1,5 +1,5 @@
-import { Undo as UndoIcon } from '@mui/icons-material';
-import { Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
+import { Undo as UndoIcon, Description as DescriptionIcon } from '@mui/icons-material';
+import { useMediaQuery, Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
 import { useState, useCallback, useEffect, memo } from 'react';
 
 import { undoDelete } from '$actions/AppStoreActions';
@@ -34,6 +34,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
     const [skeletonScheduleNames, setSkeletonScheduleNames] = useState(AppStore.getSkeletonScheduleNames());
+    const isSmallScreen = useMediaQuery('(max-width: 400px)');
 
     const handleToggleFinals = useCallback(() => {
         logAnalytics({
@@ -84,20 +85,31 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
             <Box gap={1} display="flex" alignItems="center">
                 <SelectSchedulePopover scheduleNames={skeletonMode ? skeletonScheduleNames : scheduleNames} />
                 <Tooltip title="Toggle showing finals schedule">
-                    <Button
-                        color={showFinalsSchedule ? 'primary' : 'inherit'}
-                        variant={showFinalsSchedule ? 'contained' : 'outlined'}
-                        onClick={handleToggleFinals}
-                        size="small"
-                        id={showFinalsSchedule ? 'finals-button-pressed' : 'finals-button'}
-                        disabled={skeletonMode}
-                    >
-                        Finals
-                    </Button>
+                    {isSmallScreen ? (
+                        <IconButton
+                            color={showFinalsSchedule ? 'primary' : 'inherit'}
+                            onClick={handleToggleFinals}
+                            id={showFinalsSchedule ? 'finals-button-pressed' : 'finals-button'}
+                            disabled={skeletonMode}
+                        >
+                            <DescriptionIcon />
+                        </IconButton>
+                    ) : (
+                        <Button
+                            color={showFinalsSchedule ? 'primary' : 'inherit'}
+                            variant={showFinalsSchedule ? 'contained' : 'outlined'}
+                            onClick={handleToggleFinals}
+                            size="small"
+                            id={showFinalsSchedule ? 'finals-button-pressed' : 'finals-button'}
+                            disabled={skeletonMode}
+                        >
+                            Finals
+                        </Button>
+                    )}
                 </Tooltip>
             </Box>
 
-            <Box flexGrow={1} />
+            {!isSmallScreen && <Box flexGrow={1} />}
 
             <Box display="flex" flexWrap="wrap" alignItems="center" gap={0.5}>
                 <ScreenshotButton />

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -36,6 +36,12 @@ interface Props {
     children?: React.ReactNode;
 }
 
+declare module '@material-ui/core/styles/createBreakpoints' {
+    interface BreakpointOverrides {
+        xxs: true;
+    }
+}
+
 /**
  * sets and provides the MUI theme for the app
  */
@@ -72,6 +78,7 @@ export default function AppThemeProvider(props: Props) {
              * @see https://tailwindcss.com/docs/screens
              */
             values: {
+                xxs: 400,
                 xs: 640,
                 sm: 768,
                 md: 1024,

--- a/apps/antalmanac/src/providers/Themev5.tsx
+++ b/apps/antalmanac/src/providers/Themev5.tsx
@@ -34,6 +34,12 @@ interface Props {
     children?: React.ReactNode;
 }
 
+declare module '@mui/material/styles' {
+    interface BreakpointOverrides {
+        xxs: true;
+    }
+}
+
 /**
  * sets and provides the MUI theme for the app
  */
@@ -100,6 +106,7 @@ export default function AppThemev5Provider(props: Props) {
                      * @see https://tailwindcss.com/docs/screens
                      */
                     values: {
+                        xxs: 400,
                         xs: 640,
                         sm: 768,
                         md: 1024,


### PR DESCRIPTION
## Summary
Changed the "FINALS" button to become a smaller icon on smaller screens, preventing it from becoming two rows.

BEFORE:
![image](https://github.com/user-attachments/assets/bd8fc18e-805a-4229-a200-c2e028eadd0a)

AFTER:
- When the icon is not pressed
<img width="647" alt="image" src="https://github.com/user-attachments/assets/4d0c6c2f-a714-4ecb-8c24-9994dbae3016" />

- When the icon IS pressed
<img width="646" alt="image" src="https://github.com/user-attachments/assets/354ba347-c403-49cc-b5db-d34060c2ae4c" />



## Test Plan
- [ ] Ensure works properly on all kinds of small devices

## Issues
- I make it become an icon at around a 400px width, but it still becomes two rows for very very small screens. But I doubt there are even screens this tiny. If there are, I can change it further.
   - <img width="521" alt="image" src="https://github.com/user-attachments/assets/3cedafe5-e7d5-4d6c-9c4a-599b0b6ae217" />
- Could change the icon but I felt like this one was suiting.

Closes #1026 

<!-- [Optional]
## Future Followup
-->
