### PR TITLE
Bump node version to 22

### DIFF
--- a/.github/actions/setup-node-and-pnpm/action.yml
+++ b/.github/actions/setup-node-and-pnpm/action.yml
@@ -9,9 +9,9 @@ runs:
 
     steps:
         - name: Setup Node.js environment
-          uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
+          uses: actions/setup-node@v4
           with:
-              node-version: lts/*
+              node-version: 22
 
         - name: Install pnpm
           uses: pnpm/action-setup@v2

--- a/apps/cdk/package.json
+++ b/apps/cdk/package.json
@@ -33,8 +33,5 @@
         "tsx": "^4.19.2",
         "typescript": "5.6.3"
     },
-    "packageManager": "pnpm@8.6.12",
-    "engines": {
-        "node": ">=18"
-    }
+    "packageManager": "pnpm@8.6.12"
 }

--- a/apps/cdk/src/stacks/backend.ts
+++ b/apps/cdk/src/stacks/backend.ts
@@ -50,7 +50,7 @@ export class BackendStack extends Stack {
         });
 
         const handler = new lambda.Function(this, 'lambda', {
-            runtime: lambda.Runtime.NODEJS_18_X,
+            runtime: lambda.Runtime.NODEJS_LATEST,
             code: lambda.Code.fromAsset('../backend/dist'),
             handler: 'lambda.handler',
             timeout: Duration.seconds(20),

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "packageManager": "pnpm@9.11.0",
     "engines": {
         "pnpm": "^9.0.0",
-        "node": ">=16"
+        "node": ">=22"
     }
 }


### PR DESCRIPTION
## Summary
- What it says on the tin.
- Also removes the node version check in the `cdk` sub-repo.

## Test Plan
- See if prod breaks (because actions need to be merged to actually work).