### PR TITLE
feat: show waitlist capacity

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentColumnHeader.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentColumnHeader.tsx
@@ -1,0 +1,32 @@
+import { Help } from '@material-ui/icons';
+import { Box, Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material';
+
+interface EnrollmentColumnHeaderProps {
+    label: string;
+}
+
+export function EnrollmentColumnHeader(props: EnrollmentColumnHeaderProps) {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+    return (
+        <Box display="flex">
+            {props.label}
+            {!isMobile && (
+                <Tooltip
+                    title={
+                        <Typography>
+                            Enrolled/Capacity
+                            <br />
+                            Waitlist/Capacity
+                            <br />
+                            New-Only Reserved
+                        </Typography>
+                    }
+                >
+                    <Help fontSize="small" />
+                </Tooltip>
+            )}
+        </Box>
+    );
+}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,16 +1,5 @@
-import {
-    Box,
-    Paper,
-    Table,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Tooltip,
-    Typography,
-    useMediaQuery,
-} from '@material-ui/core';
-import { Assessment, Help, RateReview, ShowChart as ShowChartIcon } from '@material-ui/icons';
+import { Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery } from '@material-ui/core';
+import { Assessment, RateReview, ShowChart as ShowChartIcon } from '@material-ui/icons';
 import { useMemo } from 'react';
 
 import { EnrollmentHistoryPopup } from './EnrollmentHistoryPopup';
@@ -20,6 +9,7 @@ import { SectionTableProps } from './SectionTable.types';
 import { CourseInfoBar } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoBar';
 import { CourseInfoButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoButton';
 import { CourseInfoSearchButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton';
+import { EnrollmentColumnHeader } from '$components/RightPane/SectionTable/EnrollmentColumnHeader';
 import { SectionTableBody } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBody';
 import analyticsEnum from '$lib/analytics';
 import { MOBILE_BREAKPOINT } from '$src/globals';
@@ -76,35 +66,6 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
     },
 };
 const tableHeaderColumnEntries = Object.entries(tableHeaderColumns);
-
-interface EnrollmentColumnHeaderProps {
-    label: string;
-}
-
-function EnrollmentColumnHeader(props: EnrollmentColumnHeaderProps) {
-    const isMobileScreen = useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT})`);
-
-    return (
-        <Box display="flex">
-            {props.label}
-            {!isMobileScreen && (
-                <Tooltip
-                    title={
-                        <Typography>
-                            Enrolled/Capacity
-                            <br />
-                            Waitlist
-                            <br />
-                            New-Only Reserved
-                        </Typography>
-                    }
-                >
-                    <Help fontSize="small" />
-                </Tooltip>
-            )}
-        </Box>
-    );
-}
 
 function SectionTable(props: SectionTableProps) {
     const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory } = props;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
@@ -12,6 +12,8 @@ interface EnrollmentCellProps {
      */
     numOnWaitlist: string;
 
+    numWaitlistCap: string;
+
     /**
      * This is a string because numOnWaitlist is a string. I haven't seen this be "n/a" but it seems possible and I don't want it to break if that happens.
      */
@@ -22,6 +24,7 @@ export const EnrollmentCell = ({
     numCurrentlyEnrolled,
     maxCapacity,
     numOnWaitlist,
+    numWaitlistCap,
     numNewOnlyReserved,
 }: EnrollmentCellProps) => {
     return (
@@ -32,7 +35,11 @@ export const EnrollmentCell = ({
                         {numCurrentlyEnrolled.totalEnrolled} / {maxCapacity}
                     </strong>
                 </Box>
-                {numOnWaitlist !== '' && <Box>WL: {numOnWaitlist}</Box>}
+                {numOnWaitlist !== '' && (
+                    <Box>
+                        WL: {numOnWaitlist} / {numWaitlistCap}
+                    </Box>
+                )}
                 {numNewOnlyReserved !== '' && <Box>NOR: {numNewOnlyReserved}</Box>}
             </Box>
         </TableBodyCellContainer>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
@@ -5,7 +5,7 @@ import { TableBodyCellContainer } from '$components/RightPane/SectionTable/Secti
 
 interface EnrollmentCellProps {
     numCurrentlyEnrolled: WebsocSectionEnrollment;
-    maxCapacity: number;
+    maxCapacity: string;
 
     /**
      * This is a string because sometimes it's "n/a"


### PR DESCRIPTION
## Summary
1. WebSOC and the API tell us the waitlist capacity on a section, this PR now surfaces it to the user

<img width="950" alt="Screenshot 2025-02-27 at 12 21 24 PM" src="https://github.com/user-attachments/assets/53e3e3f7-1455-4dcd-af4d-35d5151b8fd1" />

## Test Plan
1. Look at it yippee!

## Issues

Closes #1173

<!-- [Optional]
## Future Followup
-->
