### PR TITLE
fix: enrollment history graph off-by-one

### DIFF
--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -91,7 +91,7 @@ export class DepartmentEnrollmentHistory {
             for (const [i, dateString] of enrollmentHistory.dates.entries()) {
                 const [day = '', month = '', year = ''] = dateString.split('-');
                 const date = new Date(Number(day), Number(month), Number(year));
-                const formattedDate = `${date.getMonth()}/${date.getDate() - 1}/${date.getFullYear()}`;
+                const formattedDate = `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 
                 enrollmentDays.push({
                     date: formattedDate,


### PR DESCRIPTION
## Summary

Fix off-by-one bugs when parsing AAPI enrollment history response.
Months as returned by `Date` are zero-based, and dates (days of the month) are one-based. Simple fix.

## Test Plan
Try some more cases.

Here's the screenshot from the issue: 
![image](https://github.com/user-attachments/assets/70bfb254-e299-4296-81e9-c669e91d41ae)

## Issues

Closes #1180.

