### PR TITLE
feat: reduce cache lifetime

### DIFF
--- a/apps/antalmanac/src/lib/websoc.ts
+++ b/apps/antalmanac/src/lib/websoc.ts
@@ -22,8 +22,8 @@ class _WebSOC {
     async query(params: Record<string, string>) {
         const paramsString = JSON.stringify(params);
 
-        // hit cache if data is less than 15 minutes old
-        if (this.cache[paramsString]?.timestamp > Date.now() - 15 * 60 * 1000) {
+        // hit cache if data is less than 5 minutes old
+        if (this.cache[paramsString]?.timestamp > Date.now() - 5 * 60 * 1000) {
             return this.cache[paramsString];
         }
 


### PR DESCRIPTION
## Summary
1. Drops AA's client side Websoc cache to 5 minutes, more closely matching AAPI's ~5 minute scraping cadence

## Test Plan
1. Make a query
2. Make the same query; this should be instant (cached)
3. Wait at least 5 minutes but no more than 15 minutes
4. Query should not be cached

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
