### PR TITLE
feat: outage page

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -10,11 +10,18 @@ import { undoDelete } from './actions/AppStoreActions';
 import AppQueryProvider from './providers/Query';
 import AppThemeProvider from './providers/Theme';
 import AppThemev5Provider from './providers/Themev5';
-import { ErrorPage } from './routes/ErrorPage';
-import Feedback from './routes/Feedback';
-import Home from './routes/Home';
 
-const BrowserRouter = createBrowserRouter([
+import { ErrorPage } from '$routes/ErrorPage';
+import Feedback from '$routes/Feedback';
+import Home from '$routes/Home';
+import { OutagePage } from '$routes/OutagePage';
+
+/**
+ * Do not edit this unless you know what you're doing.
+ */
+const OUTAGE = false;
+
+const BROWSER_ROUTER = createBrowserRouter([
     {
         path: '/',
         element: <Home />,
@@ -35,6 +42,20 @@ const BrowserRouter = createBrowserRouter([
         element: <Navigate to="/" replace />,
     },
 ]);
+
+const OUTAGE_ROUTER = createBrowserRouter([
+    {
+        path: '/outage',
+        element: <OutagePage />,
+        errorElement: <ErrorPage />,
+    },
+    {
+        path: '*',
+        element: <Navigate to="/outage" replace />,
+    },
+]);
+
+const ROUTER = OUTAGE ? OUTAGE_ROUTER : BROWSER_ROUTER;
 
 /**
  * Renders the single page application.
@@ -57,18 +78,15 @@ export default function App() {
                         steps={[] /** Will be populated by Tutorial component */}
                         padding={5}
                         styles={{
-                            maskArea: (base, _) => ({
-                                // The highlighted area
+                            maskArea: (base) => ({
                                 ...base,
                                 rx: 5,
                             }),
-                            maskWrapper: (base, _) => ({
-                                // The background/overlay
+                            maskWrapper: (base) => ({
                                 ...base,
                                 color: 'rgba(0, 0, 0, 0.3)',
                             }),
-                            popover: (base, _) => ({
-                                // The text box
+                            popover: (base) => ({
                                 ...base,
                                 background: '#fff',
                                 color: 'black',
@@ -79,7 +97,7 @@ export default function App() {
                         }}
                     >
                         <SnackbarProvider>
-                            <RouterProvider router={BrowserRouter} />
+                            <RouterProvider router={ROUTER} />
                         </SnackbarProvider>
                     </TourProvider>
                 </AppThemev5Provider>

--- a/apps/antalmanac/src/routes/OutagePage.tsx
+++ b/apps/antalmanac/src/routes/OutagePage.tsx
@@ -22,7 +22,7 @@ export const OutagePage = () => {
                 <Stack spacing={2}>
                     <Typography variant="h5" component="p" sx={{ textWrap: 'balance' }}>
                         We apologize for the inconvenience and are working to get AntAlmanac back on online. Check out
-                        the <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">ICSSC Projects server</Link> for updates.
+                        the <Link to="https://discord.gg/KqJq8huuBB">ICSSC Projects server</Link> for updates.
                     </Typography>
                 </Stack>
             </Stack>

--- a/apps/antalmanac/src/routes/OutagePage.tsx
+++ b/apps/antalmanac/src/routes/OutagePage.tsx
@@ -1,0 +1,31 @@
+import { Box, Typography, Stack } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+export const OutagePage = () => {
+    return (
+        <Box sx={{ height: '100dvh', overflowY: 'auto' }}>
+            <Stack
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    maxWidth: 800,
+                    minHeight: '100dvh',
+                    margin: 'auto',
+                    padding: 2,
+                    gap: 2,
+                }}
+            >
+                <Typography variant="h3" component="h1" sx={{ textWrap: 'balance' }}>
+                    AntAlmanac is currently down for maintenance.
+                </Typography>
+                <Stack spacing={2}>
+                    <Typography variant="h5" component="p" sx={{ textWrap: 'balance' }}>
+                        We apologize for the inconvenience and are working to get AntAlmanac back on online. Check out
+                        the <Link to="https://forms.gle/k81f2aNdpdQYeKK8A">ICSSC Projects server</Link> for updates.
+                    </Typography>
+                </Stack>
+            </Stack>
+        </Box>
+    );
+};


### PR DESCRIPTION
## Summary
1. Adds an outage page which can be manually triggered by flipping a boolean in `App.tsx`

<img width="1728" alt="Screenshot 2025-03-09 at 10 44 36 PM" src="https://github.com/user-attachments/assets/a209f64c-371c-486c-b782-35396a5cb5b2" />

## Test Plan
1. Navigating to `/outage` should, by default, do nothing.
2. If you manually change the boolean flag locally, then all routes should display the Outage page

## Issues
Closes #

<!-- [Optional]
## Future Followup
-->
