### PR TITLE
Temporarily disable PWA banner

### DIFF
--- a/apps/antalmanac/src/components/InstallPWABanner.tsx
+++ b/apps/antalmanac/src/components/InstallPWABanner.tsx
@@ -59,6 +59,8 @@ function InstallPWABanner() {
 
     const displayPWABanner = bannerVisibility && !dismissedRecently && canInstall;
 
+    return null;
+
     return (
         <Box
             sx={{


### PR DESCRIPTION
## Summary
Temporarily disables PWA banner from rendering until more effective implementation has been figured out

## Test Plan
- Ensure PWA banner doesn't appear (ideally in a new browser)

## Issues

Closes #1182

<!-- [Optional]
## Future Followup
-->
