### PR TITLE
feat: decrease save times

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/DeleteScheduleButton.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/DeleteScheduleButton.tsx
@@ -1,5 +1,5 @@
 import { Clear as ClearIcon } from '@mui/icons-material';
-import { Box, IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import { useCallback, useState } from 'react';
 
 import DeleteScheduleDialog from '$components/dialogs/DeleteSchedule';
@@ -22,8 +22,8 @@ export function DeleteScheduleButton({ index, disabled }: DeleteScheduleButtonPr
     }, []);
 
     return (
-        <Box>
-            <Tooltip title="Delete Schedule">
+        <>
+            <Tooltip title="Delete Schedule" disableInteractive>
                 <span>
                     <IconButton
                         onClick={handleOpen}
@@ -35,6 +35,6 @@ export function DeleteScheduleButton({ index, disabled }: DeleteScheduleButtonPr
                 </span>
             </Tooltip>
             <DeleteScheduleDialog fullWidth open={open} index={index} onClose={handleClose} />
-        </Box>
+        </>
     );
 }

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/RenameScheduleButton.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/RenameScheduleButton.tsx
@@ -1,5 +1,5 @@
 import { Edit as EditIcon } from '@mui/icons-material';
-import { Box, IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import { useCallback, useState } from 'react';
 
 import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
@@ -21,8 +21,8 @@ export function RenameScheduleButton({ index, disabled }: RenameScheduleButtonPr
     }, []);
 
     return (
-        <Box>
-            <Tooltip title="Rename Schedule">
+        <>
+            <Tooltip title="Rename Schedule" disableInteractive>
                 <span>
                     <IconButton onClick={handleOpen} size="small" disabled={disabled}>
                         <EditIcon />
@@ -30,6 +30,6 @@ export function RenameScheduleButton({ index, disabled }: RenameScheduleButtonPr
                 </span>
             </Tooltip>
             <RenameScheduleDialog fullWidth open={open} index={index} onClose={handleClose} />
-        </Box>
+        </>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
@@ -154,7 +154,7 @@ export function ScheduleAddCell(props: ActionProps) {
             }}
         >
             {scheduleConflict ? (
-                <Tooltip title="This course overlaps with another event in your calendar!" arrow>
+                <Tooltip title="This course overlaps with another event in your calendar!" arrow disableInteractive>
                     <IconButton onClick={() => closeAndAddCourse(AppStore.getCurrentScheduleIndex())}>
                         <Add fontSize="small" />
                     </IconButton>

--- a/apps/antalmanac/src/components/buttons/Copy.tsx
+++ b/apps/antalmanac/src/components/buttons/Copy.tsx
@@ -23,7 +23,7 @@ export function CopyScheduleButton({ index, disabled, buttonSx }: CopyScheduleBu
 
     return (
         <>
-            <Tooltip title="Copy Schedule">
+            <Tooltip title="Copy Schedule" disableInteractive>
                 <span>
                     <IconButton sx={buttonSx} onClick={handleOpen} size="small" disabled={disabled}>
                         <ContentCopy />

--- a/apps/backend/src/lib/rds.ts
+++ b/apps/backend/src/lib/rds.ts
@@ -2,9 +2,16 @@ import { ShortCourse, ShortCourseSchedule, User, RepeatingCustomEvent } from '@p
 
 import { and, eq } from 'drizzle-orm';
 import type { Database } from '$db/index';
-import { 
-    schedules, users, accounts, coursesInSchedule, customEvents, 
-    AccountType, Schedule, CourseInSchedule, CustomEvent
+import {
+    schedules,
+    users,
+    accounts,
+    coursesInSchedule,
+    customEvents,
+    AccountType,
+    Schedule,
+    CourseInSchedule,
+    CustomEvent,
 } from '$db/schema';
 
 type DatabaseOrTransaction = Omit<Database, '$client'>;
@@ -58,11 +65,14 @@ export class RDS {
     /**
      * Creates a new schedule if one with its name doesn't already exist
      * and replaces its courses and custom events with the ones provided.
-     * 
+     *
      * @returns The ID of the new/existing schedule
      */
     static async upsertScheduleAndContents(
-        db: DatabaseOrTransaction, userId: string, schedule: ShortCourseSchedule, index: number
+        db: DatabaseOrTransaction,
+        userId: string,
+        schedule: ShortCourseSchedule,
+        index: number
     ) {
         // Add schedule
         const dbSchedule = {
@@ -74,12 +84,7 @@ export class RDS {
         };
 
         const scheduleResult = await db
-            .transaction((tx) =>
-                tx
-                    .insert(schedules)
-                    .values(dbSchedule)
-                    .returning({ id: schedules.id })
-            )
+            .transaction((tx) => tx.insert(schedules).values(dbSchedule).returning({ id: schedules.id }))
             .catch((error) => {
                 throw new Error(`Failed to insert schedule for ${userId} (${schedule.scheduleName}): ${error}`);
             });
@@ -149,15 +154,15 @@ export class RDS {
 
     /** Deletes and recreates all of the user's schedules and contents */
     private static async upsertSchedulesAndContents(
-        db: DatabaseOrTransaction, userId: string, scheduleArray: ShortCourseSchedule[]
+        db: DatabaseOrTransaction,
+        userId: string,
+        scheduleArray: ShortCourseSchedule[]
     ): Promise<string[]> {
         // Drop all schedules, which will cascade to courses and custom events
         await db.delete(schedules).where(eq(schedules.userId, userId));
 
         return Promise.all(
-            scheduleArray.map(
-                (schedule, index) => this.upsertScheduleAndContents(db, userId, schedule, index)
-            )
+            scheduleArray.map((schedule, index) => this.upsertScheduleAndContents(db, userId, schedule, index))
         );
     }
 
@@ -221,9 +226,7 @@ export class RDS {
         await db.transaction(async (tx) => await tx.insert(customEvents).values(dbCustomEvents));
     }
 
-    static async getGuestUserData(
-        db: DatabaseOrTransaction, guestId: string
-    ): Promise<User | null> {
+    static async getGuestUserData(db: DatabaseOrTransaction, guestId: string): Promise<User | null> {
         const userAndAccount = await RDS.getUserAndAccount(db, 'GUEST', guestId);
         if (!userAndAccount) {
             return null;
@@ -235,7 +238,7 @@ export class RDS {
             .select()
             .from(schedules)
             .where(eq(schedules.userId, userId))
-            .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId))
+            .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId));
 
         const customEventResults = await db
             .select()
@@ -245,7 +248,7 @@ export class RDS {
 
         const userSchedules = RDS.aggregateUserData(sectionResults, customEventResults);
 
-        const scheduleIndex = userAndAccount.user.currentScheduleId 
+        const scheduleIndex = userAndAccount.user.currentScheduleId
             ? userSchedules.findIndex((schedule) => schedule.id === userAndAccount.user.currentScheduleId)
             : userSchedules.length;
 
@@ -255,11 +258,13 @@ export class RDS {
                 schedules: userSchedules,
                 scheduleIndex,
             },
-        }
+        };
     }
 
     private static async getUserAndAccount(
-        db: DatabaseOrTransaction, accountType: AccountType, providerAccountId: string
+        db: DatabaseOrTransaction,
+        accountType: AccountType,
+        providerAccountId: string
     ) {
         const res = await db
             .select()
@@ -279,11 +284,11 @@ export class RDS {
      * Aggregates the user's schedule data from the results of two queries.
      */
     private static aggregateUserData(
-        sectionResults: {schedules: Schedule, coursesInSchedule: CourseInSchedule | null}[],
-        customEventResults: {schedules: Schedule, customEvents: CustomEvent | null}[]
-    ): (ShortCourseSchedule & { id: string, index: number })[] {
+        sectionResults: { schedules: Schedule; coursesInSchedule: CourseInSchedule | null }[],
+        customEventResults: { schedules: Schedule; customEvents: CustomEvent | null }[]
+    ): (ShortCourseSchedule & { id: string; index: number })[] {
         // Map from schedule ID to schedule data
-        const schedulesMapping: Record<string, ShortCourseSchedule & { id: string, index: number }> = {};
+        const schedulesMapping: Record<string, ShortCourseSchedule & { id: string; index: number }> = {};
 
         // Add courses to schedules
         sectionResults.forEach(({ schedules: schedule, coursesInSchedule: course }) => {


### PR DESCRIPTION
## Summary
The migration from Dynamo to RDS (#993, #1064) resulted in significant performance degradation for saving schedules. Users with (reasonably) large schedules across multiple quarters began experiencing save times of >15 seconds, which timed out our lambdas and required a hotfix patch (#1115).

This PR removes redundant database operations and nested transactions which significantly increased time required to save a schedule.

On a user with 17 schedules, 11 of which have 16 elements (courses+custom events) (and the rest have a regular amount ~8), this PR brings save times down to ~5.75 seconds. On live, this operation takes ~16 seconds. That's an improvement of 64% 🤯. 

On even more extreme testing with 15 large schedules that each have 26 elements, plus 6 normal schedules, save times reach ~22 seconds on live. This PR achieves ~10 seconds, at a ~55% improvement.

## Test Plan
On staging, create and populate a schedule with a bunch of courses. Duplicate that schedule a few times (12 or so should be reasonable).

1. Save the user and look at how long it took. This can be checked via the Network time in Chrome Dev Tools, look for a call to `users.saveUserData` and look at its timing tab.
2. Make edits to a schedule, save, and reload. Changes should be persisted. There also shouldn't be any "dangling" courses or schedules in the database. Checking this would require access to the DB, so please contact myself or @MinhxNguyen7 or @adcockdalton for access.
3. Try your best to stress test this! Change schedule names. Save it to another username. Move the order around.

> [!NOTE]
> Attempting to test this feature on a local DB will likely not be very effective. The most accurate results will be on the staging instance.

## Issues
Closes #1114

## Future Followup
The `RDS` class is a mess. Methods are misnamed (e.g. `upsert` when there's only an `insert`), the class is seemingly not necessary beyond being functioning as an index for methods, etc. 

See: #1158