### PR TITLE
Day Filtering in Advanced Search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -241,6 +241,7 @@ export default function CourseRenderPane(props: { id?: number }) {
             room: formData.room,
             division: formData.division,
             excludeRestrictionCodes: formData.excludeRestrictionCodes.split('').join(','), // comma delimited string (e.g. ABC -> A,B,C)
+            days: formData.days.split(/(?=[A-Z])/).join(','), // split on capital letters (e.g. MTuF -> M,Tu,F)
         };
 
         const gradesQueryParams = {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -2,7 +2,11 @@ import { TextField, Box, FormControl, InputLabel, Select, Switch, FormControlLab
 import { MenuItem } from '@mui/material';
 import { useState, useEffect, useCallback } from 'react';
 
-import { EXCLUDE_RESTRICTION_CODES_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants';
+import {
+    EXCLUDE_RESTRICTION_CODES_OPTIONS,
+    DAYS_OPTIONS,
+    DAY_ORDER,
+} from '$components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 
 export function AdvancedSearchTextFields() {
@@ -17,6 +21,11 @@ export function AdvancedSearchTextFields() {
     const [excludeRestrictionCodes, setExcludeRestrictionCodes] = useState(
         RightPaneStore.getFormData().excludeRestrictionCodes
     );
+    const [days, setDays] = useState(() => {
+        const daysString = RightPaneStore.getFormData().days;
+        const daysArray = daysString ? daysString.split(/(?=[A-Z])/) : [];
+        return daysArray.sort((a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b));
+    });
 
     const resetField = useCallback(() => {
         const formData = RightPaneStore.getFormData();
@@ -29,6 +38,7 @@ export function AdvancedSearchTextFields() {
         setRoom(formData.room);
         setDivision(formData.division);
         setExcludeRestrictionCodes(formData.excludeRestrictionCodes);
+        setDays([]);
     }, []);
 
     useEffect(() => {
@@ -97,6 +107,16 @@ export function AdvancedSearchTextFields() {
                     case 'excludeRestrictionCodes':
                         setExcludeRestrictionCodes(stringValue);
                         break;
+                    case 'days': {
+                        const daysArray = Array.isArray(value) ? value : [value];
+                        const orderedDaysArray = daysArray.sort((a, b) => {
+                            return DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b);
+                        });
+
+                        setDays(orderedDaysArray);
+                        RightPaneStore.updateFormValue('days', orderedDaysArray.join(''));
+                        break;
+                    }
                     default:
                         break;
                 }
@@ -269,6 +289,37 @@ export function AdvancedSearchTextFields() {
                     renderValue={(selected) => (selected as string[]).join(', ')}
                 >
                     {EXCLUDE_RESTRICTION_CODES_OPTIONS.map((option) => (
+                        <MenuItem
+                            key={option.value}
+                            value={option.value}
+                            style={{
+                                maxWidth: 240,
+                            }}
+                        >
+                            <span
+                                style={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {option.label}
+                            </span>
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+
+            <FormControl style={{ minWidth: 150 }}>
+                <InputLabel id="days-label">Days</InputLabel>
+                <Select
+                    multiple
+                    labelId="days-label"
+                    value={days}
+                    onChange={handleChange('days')}
+                    renderValue={(selected) => (selected as string[]).join(', ')}
+                >
+                    {DAYS_OPTIONS.map((option) => (
                         <MenuItem
                             key={option.value}
                             value={option.value}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -309,8 +309,8 @@ export function AdvancedSearchTextFields() {
                     renderValue={(selected) =>
                         (selected as string[])
                             .sort((a, b) => {
-                                const orderA = DAYS_OPTIONS.find((day) => day.value === a)?.order ?? Infinity;
-                                const orderB = DAYS_OPTIONS.find((day) => day.value === b)?.order ?? Infinity;
+                                const orderA = DAYS_OPTIONS.findIndex((day) => day.value === a);
+                                const orderB = DAYS_OPTIONS.findIndex((day) => day.value === b);
                                 return orderA - orderB;
                             })
                             .join(', ')

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect, useCallback } from 'react';
 import {
     EXCLUDE_RESTRICTION_CODES_OPTIONS,
     DAYS_OPTIONS,
-    DAY_ORDER,
 } from '$components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 
@@ -21,11 +20,7 @@ export function AdvancedSearchTextFields() {
     const [excludeRestrictionCodes, setExcludeRestrictionCodes] = useState(
         RightPaneStore.getFormData().excludeRestrictionCodes
     );
-    const [days, setDays] = useState(() => {
-        const daysString = RightPaneStore.getFormData().days;
-        const daysArray = daysString ? daysString.split(/(?=[A-Z])/) : [];
-        return daysArray.sort((a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b));
-    });
+    const [days, setDays] = useState(RightPaneStore.getFormData().days);
 
     const resetField = useCallback(() => {
         const formData = RightPaneStore.getFormData();
@@ -38,7 +33,7 @@ export function AdvancedSearchTextFields() {
         setRoom(formData.room);
         setDivision(formData.division);
         setExcludeRestrictionCodes(formData.excludeRestrictionCodes);
-        setDays([]);
+        setDays(formData.days);
     }, []);
 
     useEffect(() => {
@@ -108,13 +103,7 @@ export function AdvancedSearchTextFields() {
                         setExcludeRestrictionCodes(stringValue);
                         break;
                     case 'days': {
-                        const daysArray = Array.isArray(value) ? value : [value];
-                        const orderedDaysArray = daysArray.sort((a, b) => {
-                            return DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b);
-                        });
-
-                        setDays(orderedDaysArray);
-                        RightPaneStore.updateFormValue('days', orderedDaysArray.join(''));
+                        setDays(stringValue);
                         break;
                     }
                     default:
@@ -315,9 +304,17 @@ export function AdvancedSearchTextFields() {
                 <Select
                     multiple
                     labelId="days-label"
-                    value={days}
+                    value={days ? days.split(/(?=[A-Z])/) : []}
                     onChange={handleChange('days')}
-                    renderValue={(selected) => (selected as string[]).join(', ')}
+                    renderValue={(selected) =>
+                        (selected as string[])
+                            .sort((a, b) => {
+                                const orderA = DAYS_OPTIONS.find((day) => day.value === a)?.order ?? Infinity;
+                                const orderB = DAYS_OPTIONS.find((day) => day.value === b)?.order ?? Infinity;
+                                return orderA - orderB;
+                            })
+                            .join(', ')
+                    }
                 >
                     {DAYS_OPTIONS.map((option) => (
                         <MenuItem

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
@@ -20,11 +20,11 @@ export const EXCLUDE_RESTRICTION_CODES_OPTIONS = [
 ];
 
 export const DAYS_OPTIONS = [
-    { value: 'Su', label: 'Su: Sunday', order: 0 },
-    { value: 'M', label: 'M: Monday', order: 1 },
-    { value: 'Tu', label: 'Tu: Tuesday', order: 2 },
-    { value: 'W', label: 'W: Wednesday', order: 3 },
-    { value: 'Th', label: 'Th: Thursday', order: 4 },
-    { value: 'F', label: 'F: Friday', order: 5 },
-    { value: 'Sa', label: 'Sa: Saturday', order: 6 },
+    { value: 'Su', label: 'Su: Sunday' },
+    { value: 'M', label: 'M: Monday' },
+    { value: 'Tu', label: 'Tu: Tuesday' },
+    { value: 'W', label: 'W: Wednesday' },
+    { value: 'Th', label: 'Th: Thursday' },
+    { value: 'F', label: 'F: Friday' },
+    { value: 'Sa', label: 'Sa: Saturday' },
 ];

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
@@ -18,3 +18,13 @@ export const EXCLUDE_RESTRICTION_CODES_OPTIONS = [
     { value: 'S', label: 'S: Satisfactory/Unsatisfactory only' },
     { value: 'X', label: 'X: Separate authorization codes required to add, drop, or change enrollment' },
 ];
+
+export const DAYS_OPTIONS = [
+    { value: 'M', label: 'M: Monday' },
+    { value: 'Tu', label: 'Tu: Tuesday' },
+    { value: 'W', label: 'W: Wednesday' },
+    { value: 'Th', label: 'Th: Thursday' },
+    { value: 'F', label: 'F: Friday' },
+];
+
+export const DAY_ORDER = ['M', 'Tu', 'W', 'Th', 'F', 'Sa', 'Su'];

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/constants.ts
@@ -20,11 +20,11 @@ export const EXCLUDE_RESTRICTION_CODES_OPTIONS = [
 ];
 
 export const DAYS_OPTIONS = [
-    { value: 'M', label: 'M: Monday' },
-    { value: 'Tu', label: 'Tu: Tuesday' },
-    { value: 'W', label: 'W: Wednesday' },
-    { value: 'Th', label: 'Th: Thursday' },
-    { value: 'F', label: 'F: Friday' },
+    { value: 'Su', label: 'Su: Sunday', order: 0 },
+    { value: 'M', label: 'M: Monday', order: 1 },
+    { value: 'Tu', label: 'Tu: Tuesday', order: 2 },
+    { value: 'W', label: 'W: Wednesday', order: 3 },
+    { value: 'Th', label: 'Th: Thursday', order: 4 },
+    { value: 'F', label: 'F: Friday', order: 5 },
+    { value: 'Sa', label: 'Sa: Saturday', order: 6 },
 ];
-
-export const DAY_ORDER = ['M', 'Tu', 'W', 'Th', 'F', 'Sa', 'Su'];

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -18,6 +18,7 @@ const defaultFormValues: Record<string, string> = {
     room: '',
     division: '',
     excludeRestrictionCodes: '',
+    days: '',
 };
 
 export interface BuildingFocusInfo {
@@ -58,6 +59,7 @@ class RightPaneStore extends EventEmitter {
 
         formFields.forEach((field) => {
             const paramValue = search.get(field) || search.get(field.toUpperCase());
+
             if (paramValue !== null) {
                 this.formData[field] = paramValue;
             }


### PR DESCRIPTION
## Summary
Added filtering by days for classes in advanced search
![Screen Recording 2025-04-01 at 12 06 59 AM](https://github.com/user-attachments/assets/8f3cc287-18ee-41f5-810c-dac35c90ee7d)


## Test Plan

- [x] Make sure it works for one day selected
- [x] Make sure it works when multiple days are selected (TuTh or MWF or MTuF)
- [x] Make sure it works when no days are selected

## Issues

Closes #1190

<!-- [Optional]
## Future Followup
-->
