### PR TITLE
Add redo functionality alongside undo

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -15,7 +15,7 @@ import AppStore from '$stores/AppStore';
 const MAX_UNSAVED_ACTIONS = 1000;
 
 export interface UndoAction {
-    type: 'undoAction';
+    type: 'undoAction' | 'redoAction';
 }
 
 export interface AddCourseAction {

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -14,7 +14,7 @@ import AppStore from '$stores/AppStore';
 
 const MAX_UNSAVED_ACTIONS = 1000;
 
-export interface UndoAction {
+export interface UndoRedoAction {
     type: 'undoAction' | 'redoAction';
 }
 
@@ -108,7 +108,7 @@ export type ActionType =
     | CopyScheduleAction
     | ReorderScheduleAction
     | ChangeCourseColorAction
-    | UndoAction;
+    | UndoRedoAction;
 
 function parseUnsavedActionsString(unsavedActionsString: string): ActionType[] {
     try {

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -243,6 +243,12 @@ export const undoDelete = (event: KeyboardEvent | null) => {
     }
 };
 
+export const redoDelete = (event: KeyboardEvent | null) => {
+    if (event == null || (event.keyCode === 89 && (event.ctrlKey || event.metaKey))) {
+        AppStore.redoAction();
+    }
+};
+
 export const changeCurrentSchedule = (newScheduleIndex: number) => {
     AppStore.changeCurrentSchedule(newScheduleIndex);
 };

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -1,12 +1,13 @@
 import {
     Undo as UndoIcon,
+    Redo as RedoIcon,
     Description as DescriptionIcon,
     DescriptionOutlined as DescriptionOutlinedIcon,
 } from '@mui/icons-material';
 import { useTheme, useMediaQuery, Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
 import { useState, useCallback, useEffect, memo } from 'react';
 
-import { undoDelete } from '$actions/AppStoreActions';
+import { undoDelete, redoDelete } from '$actions/AppStoreActions';
 import CustomEventDialog from '$components/Calendar/Toolbar/CustomEventDialog';
 import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
 import { ClearScheduleButton } from '$components/buttons/Clear';
@@ -119,8 +120,8 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                 </Tooltip>
 
                 <Tooltip title="Redo last action">
-                    <IconButton onClick={handleUndo} size="medium" disabled={skeletonMode}>
-                        <UndoIcon fontSize="small" />
+                    <IconButton onClick={() => redoDelete(null)} size="medium" disabled={skeletonMode}>
+                        <RedoIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
 

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -118,6 +118,12 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                     </IconButton>
                 </Tooltip>
 
+                <Tooltip title="Redo last action">
+                    <IconButton onClick={handleUndo} size="medium" disabled={skeletonMode}>
+                        <UndoIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+
                 <ClearScheduleButton size="medium" fontSize="small" skeletonMode={skeletonMode} />
 
                 <CustomEventDialog key="custom" scheduleNames={AppStore.getScheduleNames()} />

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -24,6 +24,14 @@ function handleUndo() {
     undoDelete(null);
 }
 
+function handleRedo() {
+    logAnalytics({
+        category: analyticsEnum.calendar.title,
+        action: analyticsEnum.calendar.actions.REDO,
+    });
+    redoDelete(null);
+}
+
 export interface CalendarPaneToolbarProps {
     scheduleNames: string[];
     currentScheduleIndex: number;
@@ -120,7 +128,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                 </Tooltip>
 
                 <Tooltip title="Redo last action">
-                    <IconButton onClick={() => redoDelete(null)} size="medium" disabled={skeletonMode}>
+                    <IconButton onClick={handleRedo} size="medium" disabled={skeletonMode}>
                         <RedoIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>

--- a/apps/antalmanac/src/lib/analytics/analytics.ts
+++ b/apps/antalmanac/src/lib/analytics/analytics.ts
@@ -19,6 +19,7 @@ const analyticsEnum = {
             DISPLAY_FINALS: 'Display Finals',
             CHANGE_SCHEDULE: 'Change Schedule',
             UNDO: 'Undo',
+            REDO: 'Redo',
             DOWNLOAD: 'Download Schedule',
         },
     },

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -237,6 +237,10 @@ class AppStore extends EventEmitter {
     redoAction() {
         this.schedule.redoState();
         this.unsavedChanges = true;
+        const action: UndoAction = {
+            type: 'redoAction',
+        };
+        actionTypesStore.autoSaveSchedule(action);
         this.emit('addedCoursesChange');
         this.emit('customEventsChange');
         this.emit('colorChange', false);

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -226,12 +226,7 @@ class AppStore extends EventEmitter {
             type: 'undoAction',
         };
         actionTypesStore.autoSaveSchedule(action);
-        this.emit('addedCoursesChange');
-        this.emit('customEventsChange');
-        this.emit('colorChange', false);
-        this.emit('scheduleNamesChange');
-        this.emit('currentScheduleIndexChange');
-        this.emit('scheduleNotesChange');
+        this.emitUndoRedoEvents();
     }
 
     redoAction() {
@@ -241,12 +236,7 @@ class AppStore extends EventEmitter {
             type: 'redoAction',
         };
         actionTypesStore.autoSaveSchedule(action);
-        this.emit('addedCoursesChange');
-        this.emit('customEventsChange');
-        this.emit('colorChange', false);
-        this.emit('scheduleNamesChange');
-        this.emit('currentScheduleIndexChange');
-        this.emit('scheduleNotesChange');
+        this.emitUndoRedoEvents();
     }
 
     addCustomEvent(customEvent: RepeatingCustomEvent, scheduleIndices: number[]) {
@@ -483,6 +473,15 @@ class AppStore extends EventEmitter {
         new Set([term, ...this.schedule.getCurrentCourses().map((course) => course.term)]);
 
     getPreviousStates = () => this.schedule.getPreviousStates();
+
+    emitUndoRedoEvents() {
+        this.emit('addedCoursesChange');
+        this.emit('customEventsChange');
+        this.emit('colorChange', false);
+        this.emit('scheduleNamesChange');
+        this.emit('currentScheduleIndexChange');
+        this.emit('scheduleNotesChange');
+    }
 }
 
 const store = new AppStore();

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -234,6 +234,17 @@ class AppStore extends EventEmitter {
         this.emit('scheduleNotesChange');
     }
 
+    redoAction() {
+        this.schedule.redoState();
+        this.unsavedChanges = true;
+        this.emit('addedCoursesChange');
+        this.emit('customEventsChange');
+        this.emit('colorChange', false);
+        this.emit('scheduleNamesChange');
+        this.emit('currentScheduleIndexChange');
+        this.emit('scheduleNotesChange');
+    }
+
     addCustomEvent(customEvent: RepeatingCustomEvent, scheduleIndices: number[]) {
         this.schedule.addCustomEvent(customEvent, scheduleIndices);
         this.unsavedChanges = true;

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -17,7 +17,7 @@ import type {
     DeleteScheduleAction,
     ReorderScheduleAction,
     ChangeCourseColorAction,
-    UndoAction,
+    UndoRedoAction,
     AddScheduleAction,
 } from '$actions/ActionTypesStore';
 import { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
@@ -222,7 +222,7 @@ class AppStore extends EventEmitter {
     undoAction() {
         this.schedule.revertState();
         this.unsavedChanges = true;
-        const action: UndoAction = {
+        const action: UndoRedoAction = {
             type: 'undoAction',
         };
         actionTypesStore.autoSaveSchedule(action);
@@ -237,7 +237,7 @@ class AppStore extends EventEmitter {
     redoAction() {
         this.schedule.redoState();
         this.unsavedChanges = true;
-        const action: UndoAction = {
+        const action: UndoRedoAction = {
             type: 'redoAction',
         };
         actionTypesStore.autoSaveSchedule(action);

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -505,11 +505,8 @@ export class Schedules {
         const state = this.previousStates.pop();
         if (state !== undefined) {
             //saving current state into futureStates for redo
-            const clonedState = structuredClone({
-                schedules: this.schedules,
-                scheduleIndex: this.currentScheduleIndex,
-            });
-            this.futureStates.push(clonedState);
+            const clonedSchedules = JSON.parse(JSON.stringify(this.schedules)) as Schedule[];
+            this.futureStates.push({ schedules: clonedSchedules, scheduleIndex: this.currentScheduleIndex });
             //reverting to previous state
             this.schedules = state.schedules;
             this.currentScheduleIndex = state.scheduleIndex;
@@ -524,11 +521,8 @@ export class Schedules {
         const state = this.futureStates.pop();
         if (state !== undefined) {
             //saving current state into previousStates for undo
-            const clonedState = structuredClone({
-                schedules: this.schedules,
-                scheduleIndex: this.currentScheduleIndex,
-            });
-            this.previousStates.push(clonedState);
+            const clonedSchedules = JSON.parse(JSON.stringify(this.schedules)) as Schedule[];
+            this.previousStates.push({ schedules: clonedSchedules, scheduleIndex: this.currentScheduleIndex });
             //restoring the future state
             this.schedules = state.schedules;
             this.currentScheduleIndex = state.scheduleIndex;


### PR DESCRIPTION
## Summary
This PR implements redo button/functionality to go alongside with the undo button in the calendar scheduler. Redo allows reapplying undone actions using a ```futureStates``` stack.

## Test Plan
* Multiple courses added and removed from the calendar
* Used Undo and courses were deleted from the course list
* Used Redo and courses were showing again as expected

## Video Demo
https://github.com/user-attachments/assets/651cfe76-b5f7-49f4-b635-d51a89c156a9

## Issues
Closes #1152 

## Future Followup
Add Ctrl+Y functionality to redo
