### PR TITLE
fix: double push schedules

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -218,7 +218,6 @@ const handleScheduleImport = async (username: string, skipImportedCheck = false)
     const currentSchedules = AppStore.schedule.getScheduleAsSaveState();
 
     if (scheduleSaveState.schedules) {
-        currentSchedules.schedules.push(...scheduleSaveState.schedules);
         mergeShortCourseSchedules(currentSchedules.schedules, scheduleSaveState.schedules, '(import)-');
         currentSchedules.scheduleIndex = currentSchedules.schedules.length - 1;
 


### PR DESCRIPTION
## Summary
Currently importing a schedule merges existing and importing schedules and then performs a second merge, adding the (import) prefix to the schedule names. This removes the initial merge.

## Test Plan

## Issues

Closes #1244 

<!-- [Optional]
## Future Followup
-->
