### PR TITLE
fix: catch invalid username

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -280,17 +280,10 @@ export const loadSchedule = async (providerId: string, rememberMe: boolean, acco
                     providerId,
                 });
 
-                if (account == null) {
-                    openSnackbar('error', `Couldn't find account for username "${providerId}".`);
-                    return;
-                }
-
                 const userDataResponse = await trpc.userData.getUserData.query({ userId: account.userId });
                 const scheduleSaveState = userDataResponse?.userData ?? userDataResponse;
 
-                if (scheduleSaveState == null) {
-                    openSnackbar('error', `Couldn't find schedules for username "${providerId}".`);
-                } else if (await AppStore.loadSchedule(scheduleSaveState)) {
+                if (await AppStore.loadSchedule(scheduleSaveState)) {
                     openSnackbar('success', `Schedule loaded.`);
                 } else {
                     AppStore.loadSkeletonSchedule(scheduleSaveState);
@@ -301,11 +294,14 @@ export const loadSchedule = async (providerId: string, rememberMe: boolean, acco
                     );
                 }
             } catch (e) {
-                console.error(e);
-                openSnackbar(
-                    'error',
-                    `Failed to load schedules. If this continues to happen, please submit a feedback form.`
-                );
+                if (e instanceof Error) {
+                    openSnackbar('error', e.message);
+                } else {
+                    openSnackbar(
+                        'error',
+                        '`Failed to load schedules. If this continues to happen, please submit a feedback form.`'
+                    );
+                }
             }
         }
     }

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -6,6 +6,7 @@ import type {
     User,
     WebsocSection,
 } from '@packages/antalmanac-types';
+import { TRPCClientError } from '@trpc/client';
 import { TRPCError } from '@trpc/server';
 import { VariantType } from 'notistack';
 
@@ -294,14 +295,16 @@ export const loadSchedule = async (providerId: string, rememberMe: boolean, acco
                     );
                 }
             } catch (e) {
-                if (e instanceof Error) {
-                    openSnackbar('error', e.message);
-                } else {
-                    openSnackbar(
-                        'error',
-                        '`Failed to load schedules. If this continues to happen, please submit a feedback form.`'
-                    );
+                if (e instanceof TRPCClientError) {
+                    if (e.data.httpStatus === 404) {
+                        openSnackbar('error', e.message);
+                    }
+                    return;
                 }
+                openSnackbar(
+                    'error',
+                    '`Failed to load schedules. If this continues to happen, please submit a feedback form.`'
+                );
             }
         }
     }

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -280,6 +280,11 @@ export const loadSchedule = async (providerId: string, rememberMe: boolean, acco
                     providerId,
                 });
 
+                if (account == null) {
+                    openSnackbar('error', `Couldn't find account for username "${providerId}".`);
+                    return;
+                }
+
                 const userDataResponse = await trpc.userData.getUserData.query({ userId: account.userId });
                 const scheduleSaveState = userDataResponse?.userData ?? userDataResponse;
 

--- a/apps/backend/src/routers/userData.ts
+++ b/apps/backend/src/routers/userData.ts
@@ -89,13 +89,27 @@ const userDataRouter = router({
     }),
 
     getGuestAccountAndUserByName: procedure.input(z.object({ name: z.string() })).query(async ({ input }) => {
-        return RDS.getGuestAccountAndUserByName(db, input.name);
+        const result = await RDS.getGuestAccountAndUserByName(db, input.name);
+        if (!result) {
+            throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: 'User not found',
+            });
+        }
+        return result;
     }),
 
     getAccountByProviderId: procedure
         .input(z.object({ accountType: z.enum(['GOOGLE', 'GUEST']), providerId: z.string() }))
         .query(async ({ input }) => {
-            return RDS.getAccountByProviderId(db, input.accountType, input.providerId);
+            const account = await RDS.getAccountByProviderId(db, input.accountType, input.providerId);
+            if (!account) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: `Couldn't find schedules for username "${input.providerId}".`,
+                });
+            }
+            return account;
         }),
     /**
      * Retrieves Google authentication URL for login/sign up.


### PR DESCRIPTION
## Summary
When fetching the account associated with the username returns null. Specify the error has to do with the username not existing.

![image](https://github.com/user-attachments/assets/0e6ab4b0-5226-4f85-953d-0d1e72449da6)


## Test Plan
- Type in a username that doesn't exist -> `Couldn't find [...]" 
-
## Issues
Hold up haven't tested. I'm at 7 grams rn

Closes #1246

<!-- [Optional]
## Future Followup
-->