### PR TITLE
fix: Load schedule error propogation

### DIFF
--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -355,7 +355,8 @@ class AppStore extends EventEmitter {
     }
 
     async loadSchedule(savedSchedule: ScheduleSaveState) {
-        if (!(await this.loadScheduleFromSaveState(savedSchedule))) {
+        const loadSuccess = await this.loadScheduleFromSaveState(savedSchedule);
+        if (!loadSuccess) {
             return false;
         }
         this.unsavedChanges = false;

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -348,13 +348,16 @@ class AppStore extends EventEmitter {
     private async loadScheduleFromSaveState(savedSchedule: ScheduleSaveState) {
         try {
             await this.schedule.fromScheduleSaveState(savedSchedule);
+            return true;
         } catch {
             return false;
         }
     }
 
     async loadSchedule(savedSchedule: ScheduleSaveState) {
-        await this.loadScheduleFromSaveState(savedSchedule);
+        if (!(await this.loadScheduleFromSaveState(savedSchedule))) {
+            return false;
+        }
         this.unsavedChanges = false;
 
         /**


### PR DESCRIPTION
## Summary
Display an error to the user when a schedule fails to load

This is a hypothosized fix for empty schedules being loaded. Currently, when `fromScheduleSaveState` throws an error nothing happens and `loadSchedule` returns `true` 

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
