### PR TITLE
Redeploy every 15 minutes

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -8,6 +8,12 @@ on:
             - main
 
     workflow_dispatch:
+    
+    # Re-deploy everyr 15 minutes because *something* is breaking, and re-deploying
+    # seems to fix it remporarily. This is a temporary fix during enrollment.
+    schedule:
+        - cron: '*/15 * * * *'
+        
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Deploy every 15 minutes to alleviate an unknown issue that is fixed by redeployment.
- This is a temporary fix so the page stays up during enrollment.
