### PR TITLE
Add ANTEATER_API_KEY to backend vars parsing

### DIFF
--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -24,10 +24,16 @@ export const mapboxEnvSchema = z.object({
 });
 
 /**
+ * Environment variables required by the backend to connect to the Anteater API.
+ */
+export const aapiEnvSchema = z.object({
+    ANTEATER_API_KEY: z.string(),
+});
+
+/**
  * Environment variables required by the backend during runtime.
  */
-export const backendEnvSchema = [
-    rdsEnvSchema, mapboxEnvSchema, googleOAuthEnvSchema
-].reduce(
-    (acc, schema) => acc.merge(schema), z.object({STAGE: z.string()})
-);
+export const backendEnvSchema = googleOAuthEnvSchema
+    .merge(rdsEnvSchema)
+    .merge(mapboxEnvSchema)
+    .merge(aapiEnvSchema);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -14,8 +14,23 @@ const MAPBOX_API_URL = 'https://api.mapbox.com';
 
 const PORT = 3000;
 
+function getAndCheckEnv() {
+    const env = backendEnvSchema.parse(process.env);
+
+    if (!env.ANTEATER_API_KEY) {
+        console.error('ANTEATER_API_KEY is not set');
+    }
+
+    if (!env.GOOGLE_CLIENT_SECRET) {
+        console.error('MAPBOX_ACCESS_TOKEN is not set');
+    }
+
+    return env;
+}
+
 export async function start(corsEnabled = false) {
-    const env = backendEnvSchema.parse(process.env)
+    const env = getAndCheckEnv();
+
     const app = express();
     app.use(cors(corsEnabled ? corsOptions : undefined));
     app.use(express.json());


### PR DESCRIPTION
## Summary
- ANTEATER_API_KEY was omitted from the Zod environment variables parsing.
    - I think the problem was that AAPI key change happened before the start of auth, and its inclusion was lost during merging.
    - Perhaps I should've caught that during review, but I glossed over it because I was the one that wrote it.
- This adds it back, along with reformatting the Zod declaration to be clearer.

## Test Plan
- See that the environment variable shows up in the staging lambda.
- Deploy to prod and see the same in prod.

Closes (partially) #1260

## Future Follow-Up
- Right now, the backend parses environment variables when it starts, but then the variables are still pulled from `process.env`. That bypasses type-checking, which partly explains why we didn't see this omission earlier.
