### PR TITLE
fix: spontaneous user logout on refresh

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -13,7 +13,7 @@ import { SnackbarOrigin, VariantType } from 'notistack';
 import analyticsEnum, { logAnalytics, courseNumAsDecimal } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
 import { warnMultipleTerms } from '$lib/helpers';
-import { setLocalStorageUserId, setLocalStorageDataCache, removeLocalStorageSessionId } from '$lib/localStorage';
+import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
@@ -342,7 +342,6 @@ export const loadScheduleWithSessionToken = async () => {
     } catch (e) {
         console.error(e);
         openSnackbar('error', `Failed to load schedules. If this continues to happen, please submit a feedback form.`);
-        removeLocalStorageSessionId();
         return false;
     }
 };


### PR DESCRIPTION
## Summary
It seems like when you spam Refresh the `loadScheduleWithSessionToken` catches an error that removes the session token from local storage

## Reproduce on prod 
1. Login with Google account with some data
2. Quickly spam refresh on the webpage before it can load 
3. After several refreshes the page your account should be logged out and you'll have to log back in 
4. (Additional note): Inspect Page -> in `Console` type: `localStorage` and the `sessionID` should be missing 

## Test Plan
1. Follow the same steps to reproduce the error but your account should remained logged in

## Issues

Closes #1262

<!-- [Optional]
## Future Followup
-->
