### PR TITLE
Refactor detecting new user login

### DIFF
--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -18,7 +18,7 @@ import {
     Tooltip,
 } from '@mui/material';
 import { CourseInfo } from '@packages/antalmanac-types';
-import { ChangeEvent, useCallback, useEffect, useState, useRef } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -32,13 +32,14 @@ import { AlertDialog } from '$components/AlertDialog';
 import { TermSelector } from '$components/RightPane/CoursePane/SearchForm/TermSelector';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import {
     getLocalStorageDataCache,
     getLocalStorageOnFirstSignin,
-    setLocalStorageOnFirstSignin,
+    getLocalStorageUserId,
+    removeLocalStorageOnFirstSignin,
+    removeLocalStorageUserId,
 } from '$lib/localStorage';
 import { WebSOC } from '$lib/websoc';
 import { ZotcourseResponse, queryZotcourse } from '$lib/zotcourse';
@@ -65,10 +66,8 @@ export function Import() {
 
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
 
-    const { session, sessionIsValid } = useSessionStore();
+    const { sessionIsValid } = useSessionStore();
     const { openImportDialog, setOpenImportDialog } = scheduleComponentsToggleStore();
-
-    const firstTimeUserFlag = useRef(true);
 
     const { isDark } = useThemeStore();
 
@@ -232,18 +231,16 @@ export function Import() {
     }, []);
 
     const handleFirstTimeSignin = useCallback(async () => {
-        const { users, accounts } = await trpc.userData.getUserAndAccountBySessionToken.query({ token: session ?? '' });
-
-        if (!users.currentScheduleId && accounts.accountType === 'GOOGLE') {
-            if (getLocalStorageOnFirstSignin() === null || getLocalStorageOnFirstSignin() !== users.email) {
-                setLocalStorageOnFirstSignin(users.email);
-                handleOpen();
-                setImportSource(ImportSource.AA_USERNAME_IMPORT);
-            } else {
-                firstTimeUserFlag.current = false;
-            }
+        const newUserFlag = getLocalStorageOnFirstSignin() ?? '';
+        if (newUserFlag !== '') {
+            const savedUserId = getLocalStorageUserId();
+            if (savedUserId) setAAUsername(savedUserId);
+            handleOpen();
+            removeLocalStorageOnFirstSignin();
+            removeLocalStorageUserId();
+            setImportSource(ImportSource.AA_USERNAME_IMPORT);
         }
-    }, [session, handleOpen]);
+    }, [handleOpen]);
 
     useEffect(() => {
         const handleSkeletonModeChange = () => {

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -14,6 +14,7 @@ import {
     removeLocalStorageDataCache,
     removeLocalStorageFromLoading,
     setLocalStorageSessionId,
+    setLocalStorageOnFirstSignin,
 } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';
 import { useSessionStore } from '$stores/SessionStore';
@@ -30,7 +31,7 @@ export function AuthPage() {
                 return;
             }
 
-            const { sessionToken, userId, providerId } = await trpc.userData.handleGoogleCallback.mutate({
+            const { sessionToken, userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
                 code: code,
                 token: session ?? '',
             });
@@ -38,7 +39,12 @@ export function AuthPage() {
             const fromLoading = getLocalStorageFromLoading() ?? '';
             const savedUserId = getLocalStorageUserId() ?? '';
             const savedData = getLocalStorageDataCache() ?? '';
-            removeLocalStorageUserId();
+
+            if (newUser) {
+                setLocalStorageOnFirstSignin('true');
+            } else {
+                removeLocalStorageUserId();
+            }
 
             if (!(sessionToken && providerId)) {
                 window.location.href = '/';

--- a/apps/backend/src/lib/rds.ts
+++ b/apps/backend/src/lib/rds.ts
@@ -159,10 +159,10 @@ export class RDS {
                 .returning()
                 .then((res) => res[0]);
 
-            return account;
+            return { ...account, newUser: true };
         }
 
-        return existingAccount;
+        return { ...existingAccount, newUser: false };
     }
 
     /**

--- a/apps/backend/src/routers/userData.ts
+++ b/apps/backend/src/routers/userData.ts
@@ -161,10 +161,15 @@ const userDataRouter = router({
 
         if (userId.length > 0) {
             const session = await RDS.upsertSession(db, userId, input.token);
-            return { sessionToken: session?.refreshToken, userId: userId, providerId: payload.sub };
+            return {
+                sessionToken: session?.refreshToken,
+                userId: userId,
+                providerId: payload.sub,
+                newUser: account.newUser,
+            };
         }
 
-        return { sessionToken: null, userId: null, providerId: null };
+        return { sessionToken: null, userId: null, providerId: null, newUser: account.newUser };
     }),
     /**
      * Logs in or signs up existing user


### PR DESCRIPTION
## Summary
The implementation for detecting a new AntAlmanac user was pretty messy for auth v1 and was not changed for v2.

I'm not sure if this PR is necessary as all users likely have already created their accounts. However, auto prompting new users with this dialog could open an opportunity for #1186. Since users can import a ZotCourse ID we could use that to display manual search.  

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/326012a6-40be-4a4c-b06a-12b5894dbebd" />

## Test Plan

## Issues

Closes #1240

<!-- [Optional]
## Future Followup
-->
