### PR TITLE
Styling: Schedule item colors

### DIFF
--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,6 +1,7 @@
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, Tooltip } from '@mui/material';
 import {
+    red,
     blue,
     amber,
     yellow,
@@ -122,6 +123,7 @@ class ColorPicker extends PureComponent<ColorPickerProps> {
                         color={this.state.color}
                         onChange={this.handleColorChange}
                         presetColors={[
+                            red[300],
                             blue[300],
                             amber[300],
                             yellow[300],
@@ -136,7 +138,6 @@ class ColorPicker extends PureComponent<ColorPickerProps> {
                             green[900],
                             grey[800],
                             grey[400],
-                            grey[100],
                             grey[50],
                         ]}
                     />

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,20 +1,5 @@
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, PopoverProps, Tooltip } from '@mui/material';
-import {
-    red,
-    blue,
-    amber,
-    yellow,
-    green,
-    teal,
-    cyan,
-    lightBlue,
-    indigo,
-    purple,
-    pink,
-    brown,
-    grey,
-} from '@mui/material/colors';
 import { PostHog, usePostHog } from 'posthog-js/react';
 import { memo, useEffect, useState } from 'react';
 import { SketchPicker } from 'react-color';
@@ -22,6 +7,7 @@ import { SketchPicker } from 'react-color';
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
 import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import AppStore from '$stores/AppStore';
+import { colorPickerPresetColors } from '$stores/scheduleHelpers';
 
 interface ColorPickerProps {
     color: string;
@@ -116,28 +102,7 @@ const ColorPicker = memo(function ColorPicker({
                     horizontal: 'left',
                 }}
             >
-                <SketchPicker
-                    color={currColor}
-                    onChange={handleColorChange}
-                    presetColors={[
-                        red[300],
-                        blue[300],
-                        amber[300],
-                        yellow[300],
-                        green[300],
-                        teal[300],
-                        cyan[300],
-                        lightBlue[300],
-                        indigo[300],
-                        purple[300],
-                        pink[300],
-                        brown[500],
-                        green[900],
-                        grey[800],
-                        grey[400],
-                        grey[50],
-                    ]}
-                />
+                <SketchPicker color={currColor} onChange={handleColorChange} presetColors={colorPickerPresetColors} />
             </Popover>
         </>
     );

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -143,8 +143,4 @@ const ColorPicker = memo(function ColorPicker({
     );
 });
 
-/*
-
-
-*/
 export default ColorPicker;

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,5 +1,19 @@
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, Tooltip } from '@mui/material';
+import {
+    blue,
+    amber,
+    yellow,
+    green,
+    teal,
+    cyan,
+    lightBlue,
+    indigo,
+    purple,
+    pink,
+    brown,
+    grey,
+} from '@mui/material/colors';
 import { PureComponent } from 'react';
 import { SketchPicker } from 'react-color';
 
@@ -104,11 +118,36 @@ class ColorPicker extends PureComponent<ColorPickerProps> {
                         horizontal: 'left',
                     }}
                 >
-                    <SketchPicker color={this.state.color} onChange={this.handleColorChange} />
+                    <SketchPicker
+                        color={this.state.color}
+                        onChange={this.handleColorChange}
+                        presetColors={[
+                            blue[300],
+                            amber[300],
+                            yellow[300],
+                            green[300],
+                            teal[300],
+                            cyan[300],
+                            lightBlue[300],
+                            indigo[300],
+                            purple[300],
+                            pink[300],
+                            brown[500],
+                            green[900],
+                            grey[800],
+                            grey[400],
+                            grey[100],
+                            grey[50],
+                        ]}
+                    />
                 </Popover>
             </>
         );
     }
 }
 
+/*
+
+
+*/
 export default ColorPicker;

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -141,7 +141,7 @@ function generateCloseColor(originalColor: string, usedColors: Set<string>, vari
     ) {
         color = {
             ...color,
-            l: Math.max(0, Math.round(((color.l - delta) * 100) % 100) / 100), // Subtract delta and ensure lightness doesn't go below 0
+            l: Math.round(((color.l + delta) * 100) % 100) / 100,
         };
     }
 

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -7,7 +7,7 @@ export interface HSLColor {
     l: number;
 }
 
-const defaultColors = [blue[500], pink[500], purple[500], green[500], amber[500], deepPurple[500], deepOrange[500]];
+const defaultColors = [blue[300], pink[300], purple[300], green[300], amber[300], deepPurple[300], deepOrange[300]];
 
 /**
  * Converts a hex color to HSL
@@ -141,7 +141,7 @@ function generateCloseColor(originalColor: string, usedColors: Set<string>, vari
     ) {
         color = {
             ...color,
-            l: Math.round(((color.l + delta) * 100) % 100) / 100,
+            l: Math.max(0, Math.round(((color.l - delta) * 100) % 100) / 100), // Subtract delta and ensure lightness doesn't go below 0
         };
     }
 

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -1,4 +1,19 @@
-import { amber, blue, deepOrange, deepPurple, green, pink, purple } from '@mui/material/colors';
+import {
+    amber,
+    blue,
+    cyan,
+    deepOrange,
+    deepPurple,
+    green,
+    grey,
+    indigo,
+    lightBlue,
+    pink,
+    purple,
+    red,
+    teal,
+    yellow,
+} from '@mui/material/colors';
 import { ScheduleCourse } from '@packages/antalmanac-types';
 
 export interface HSLColor {
@@ -9,6 +24,24 @@ export interface HSLColor {
 
 const defaultColors = [blue[300], pink[300], purple[300], green[300], amber[300], deepPurple[300], deepOrange[300]];
 
+export const colorPickerPresetColors = [
+    red[300],
+    blue[300],
+    deepOrange[300],
+    amber[300],
+    yellow[300],
+    green[300],
+    teal[300],
+    cyan[300],
+    lightBlue[300],
+    indigo[300],
+    deepPurple[300],
+    pink[300],
+    green[900],
+    grey[800],
+    grey[400],
+    grey[50],
+];
 /**
  * Converts a hex color to HSL
  * Assumes the hex color is in the format #RRGGBB
@@ -127,7 +160,7 @@ function colorIsContained(color: HSLColor, usedColors: Iterable<HSLColor>, delta
  *
  * @return Unused hex color that is close to the original color ("#RRGGBB").
  */
-function generateCloseColor(originalColor: string, usedColors: Set<string>, variation = 0.1): string {
+function generateCloseColor(originalColor: string, usedColors: Set<string>, variation = 0.05): string {
     const usedColorsHSL = [...usedColors].map(HexToHSL);
 
     // Generate a color that is slightly different from the original color and that is not already used

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -1,5 +1,6 @@
 import {
     amber,
+    brown,
     blue,
     cyan,
     deepOrange,
@@ -22,24 +23,24 @@ export interface HSLColor {
     l: number;
 }
 
-const defaultColors = [blue[300], pink[300], purple[300], green[300], amber[300], deepPurple[300], deepOrange[300]];
+const defaultColors = [blue[200], pink[200], purple[200], green[200], amber[200], deepPurple[200], deepOrange[200]];
 
 export const colorPickerPresetColors = [
-    red[300],
-    blue[300],
-    deepOrange[300],
-    amber[300],
-    yellow[300],
+    brown[200],
+    red[200],
+    deepOrange[200],
+    amber[200],
+    yellow[200],
+    green[200],
+    teal[200],
+    cyan[100],
+    lightBlue[200],
+    indigo[200],
+    deepPurple[200],
+    pink[200],
     green[300],
-    teal[300],
-    cyan[300],
-    lightBlue[300],
-    indigo[300],
-    deepPurple[300],
-    pink[300],
-    green[900],
-    grey[800],
-    grey[400],
+    grey[600],
+    grey[300],
     grey[50],
 ];
 /**
@@ -160,7 +161,7 @@ function colorIsContained(color: HSLColor, usedColors: Iterable<HSLColor>, delta
  *
  * @return Unused hex color that is close to the original color ("#RRGGBB").
  */
-function generateCloseColor(originalColor: string, usedColors: Set<string>, variation = 0.05): string {
+function generateCloseColor(originalColor: string, usedColors: Set<string>, variation = 0.1): string {
     const usedColorsHSL = [...usedColors].map(HexToHSL);
 
     // Generate a color that is slightly different from the original color and that is not already used


### PR DESCRIPTION
## Summary
A common critique of AA is it's styling. I've seen a handful of user schedules, and many of them tend to gravitate towards these lighter shades. Additionally, the color picker options seem disjoint from the default colors that we assign to schedule items. There's probably some psychology with "contemporary" colors and how we percieve "quality" or something... 

#### Old
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1ca2a8e5-0010-4162-ba1a-838f68aa3c81" />
<img width="215" alt="image" src="https://github.com/user-attachments/assets/1a9442fb-48b4-49e4-a2ce-bd40a914d4fc" />

#### New 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/eb296af4-fe43-4912-8802-0ec203df8729" />
<img width="215" alt="image" src="https://github.com/user-attachments/assets/69d23280-7224-4c7d-8f37-e75cb48a0086" />
I kinda just did this for fun

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
