### PR TITLE
AANTS Workflows

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -118,8 +118,8 @@ jobs:
             - name: Run database migrations
               run: pnpm --filter "antalmanac-backend" migrate
 
-            - name: Build backend
-              run: pnpm --filter "antalmanac-backend" build
+            - name: Build all
+              run: pnpm build
               env:
                   ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -171,8 +171,8 @@ jobs:
                   url: ${{ needs.get_staging_configuration.outputs.backend_environment_url }}
                   status: in_progress
 
-            - name: Build backend
-              run: pnpm --filter "antalmanac-backend" build
+            - name: Build all
+              run: pnpm build
               env:
                   ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -57,11 +57,11 @@ jobs:
 
         outputs:
             # A staging backend should only be deployed if either the backend or CDK changed.
-            should-deploy-backend: ${{ steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' }}
+            should-deploy-backend: ${{ steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true' }}
 
             # If a staging backend is deployed, then the frontend should use its URL.
             # Otherwise use the default development API endpoint.
-            antalmanac-api-endpoint: ${{ ((steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true') && format('staging-{0}', github.event.pull_request.number)) || 'dev' }}
+            antalmanac-api-endpoint: ${{ ((steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true') && format('staging-{0}', github.event.pull_request.number)) || 'dev' }}
 
             frontend_environment: frontend-staging-${{ github.event.pull_request.number }}
             frontend_environment_url: https://staging-${{ github.event.pull_request.number }}.antalmanac.com
@@ -77,6 +77,8 @@ jobs:
               uses: dorny/paths-filter@v2
               with:
                   filters: |
+                      aants:
+                        - 'apps/aants/**'
                       backend:
                         - 'apps/backend/**'
                       cdk:


### PR DESCRIPTION
## Summary
- Update workflows to support AANTS.

### Changes
- Re-deploy backend (including AANTS) when `apps/aants/**` is changed.
- Change backend build step to build all parts of the app.
    - Technically, we're unnecessarily building the frontend as well, but this makes it simpler, and it doesn't take that long anyway.

## Test Plan
- Merge into `main`, then redeploy the AANTS PR.
    - This is the only way to test because only the workflow on `main` is run.

## Issues
- Part of #761 
