### PR TITLE
Allow dev mirror deployment (temp fix)

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -160,6 +160,8 @@ jobs:
               run: pnpm --filter "antalmanac-cdk" backend-development deploy
               env:
                   NODE_ENV: development
+                  DB_URL: ${{ secrets.PROD_DB_URL }}
+                  
                   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
                   GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
                   GOOGLE_REDIRECT_URI: https://antalmanac.com/auth

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -160,3 +160,6 @@ jobs:
               run: pnpm --filter "antalmanac-cdk" backend-development deploy
               env:
                   NODE_ENV: development
+                  GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+                  GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+                  GOOGLE_REDIRECT_URI: https://antalmanac.com/auth

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -57,11 +57,15 @@ jobs:
 
         outputs:
             # A staging backend should only be deployed if either the backend or CDK changed.
-            should-deploy-backend: ${{ steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true' }}
+            # should-deploy-backend: ${{ steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true' }}
 
             # If a staging backend is deployed, then the frontend should use its URL.
             # Otherwise use the default development API endpoint.
-            antalmanac-api-endpoint: ${{ ((steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true') && format('staging-{0}', github.event.pull_request.number)) || 'dev' }}
+            # antalmanac-api-endpoint: ${{ ((steps.changed.outputs.backend == 'true' ||  steps.changed.outputs.cdk == 'true' || steps.changed.outputs.aants=='true') && format('staging-{0}', github.event.pull_request.number)) || 'dev' }}
+            
+            # Temporarily always deploy the backend.
+            should-deploy-backend: 'true'
+            antalmanac-api-endpoint: ${{ ( format('staging-{0}', github.event.pull_request.number))}}
 
             frontend_environment: frontend-staging-${{ github.event.pull_request.number }}
             frontend_environment_url: https://staging-${{ github.event.pull_request.number }}.antalmanac.com

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 
    If none of those work for any reason, you can defer to your Operating System's
    package manager or [the downloads from the official website](https://nodejs.org/en/download).
-   We will be using the latest LTS version, 20.10.0, lts/iron.
 
 2. Install `pnpm`. This is our package manager of choice for this project.
    It's responsible for installing, uninstalling, and keeping track of the app's dependencies.
@@ -110,6 +109,7 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 
 3. Start the development server for the frontend.
   `pnpm start:aa` or `cd apps/antalmanac && pnpm dev`
+  - Note that signing in with Google does not work for local development. We are actively working on a fix.
 
 4. View the local website at http://localhost:5173.
    As you make changes to the React application, those changes will be automatically reflected on the local website.


### PR DESCRIPTION
## Summary
- The dev mirror has been broken because it was missing the Google Auth credentials. 
- This is a non-trivial problem because the redirect needs to change depending where the frontend is running.
- The fix for now is to deploy with the production redirect.
  - Auth won't work when running `pnpm run start:aa`.
- This PR also makes the backend deploy for every PR, ensuring that staging works.
  - As long as the staging URL is added to the GCP Console.

## Test Plan

## Issues

Part of  #1272 

## Future Followup
- Make the dev mirror generate new oAuth clients for staging instances.
