### PR TITLE
fix: Google login from prod

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -363,7 +363,7 @@ const cacheSchedule = () => {
 
 export const loginUser = async () => {
     try {
-        const authUrl = await trpc.userData.getGoogleAuthUrl.query();
+        const authUrl = await trpc.userData.getGoogleAuthUrl.query({ redirectOrigin: window.location.origin });
         if (authUrl) {
             cacheSchedule();
             window.location.href = authUrl;

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -34,6 +34,7 @@ export function AuthPage() {
             const { sessionToken, userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
                 code: code,
                 token: session ?? '',
+                redirectOrigin: window.location.origin,
             });
 
             const fromLoading = getLocalStorageFromLoading() ?? '';
@@ -72,7 +73,7 @@ export function AuthPage() {
 
             // handle unsaved changes
             if (savedData !== '') {
-                const userData = await trpc.userData.getUserData.query({ userId: userId });
+                const userData = await trpc.userData.getUserData.query({ userId: userId ?? '' });
                 const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
 
                 if (savedUserId !== '') {

--- a/apps/backend/src/lib/googleOAuth.ts
+++ b/apps/backend/src/lib/googleOAuth.ts
@@ -33,11 +33,9 @@ export class GoogleOAuth2ClientsManager {
      * @returns OAuth2Client configured for the given redirect origin
      */
     getClient(redirectOrigin: string): OAuth2Client {
+        // If the STAGE is prod then we will use the value stored from GOOGLE_REDIRECT_URI (i.e. https://antalmanac.com/auth)
         if (!this.allowDynamicRedirects && redirectOrigin !== this.redirectOrigin) {
-            throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message: 'Dynamic redirects are not allowed',
-            });
+            return new OAuth2Client(this.clientId, this.clientSecret, this.redirectOrigin);
         }
 
         try {

--- a/apps/backend/src/lib/googleOAuth.ts
+++ b/apps/backend/src/lib/googleOAuth.ts
@@ -1,0 +1,59 @@
+import { URL } from 'url';
+import { OAuth2Client } from 'google-auth-library';
+import { backendEnvSchema } from 'src/env';
+import { TRPCError } from '@trpc/server';
+
+export class GoogleOAuth2ClientsManager {
+    /**
+     * Map of redirect origins to OAuth2Clients.
+     */
+    private clients: Map<string, OAuth2Client> = new Map();
+    private readonly clientId: string;
+    private readonly clientSecret: string;
+    private readonly allowDynamicRedirects: boolean;
+    private readonly redirectOrigin: string;
+
+    constructor(_clientId: string, _clientSecret: string) {
+        this.clientId = _clientId;
+        this.clientSecret = _clientSecret;
+
+        const { STAGE, GOOGLE_REDIRECT_URI } = backendEnvSchema.parse(process.env);
+        this.allowDynamicRedirects = STAGE !== 'prod';
+        this.redirectOrigin = GOOGLE_REDIRECT_URI;
+    }
+
+    getClient(redirectOrigin: string): OAuth2Client {
+        if (!this.allowDynamicRedirects && redirectOrigin !== this.redirectOrigin) {
+            throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message: 'Dynamic redirects are not allowed',
+            });
+        }
+
+        try {
+            const client = this.clients.get(redirectOrigin);
+            if (!client) {
+                throw new Error('Client not found');
+            }
+            return client;
+        } catch (error) {
+            const urlParsed = new URL(redirectOrigin);
+            const hasNoPath = urlParsed.pathname === '/';
+            const isLocalhost = urlParsed.hostname === 'localhost' || urlParsed.hostname === '127.0.0.1';
+            const isAntAlmanac = urlParsed.hostname.endsWith('antalmanac.com');
+
+            const isValidRedirectUri = (isLocalhost || isAntAlmanac) && hasNoPath;
+
+            if (!this.clients.has(redirectOrigin) && isValidRedirectUri) {
+                const client = new OAuth2Client(this.clientId, this.clientSecret, redirectOrigin + '/auth');
+                this.clients.set(redirectOrigin, client);
+                return client;
+            } else {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'Invalid redirect origin ' + redirectOrigin,
+                });
+            }
+        }
+    }
+}

--- a/apps/backend/src/lib/googleOAuth.ts
+++ b/apps/backend/src/lib/googleOAuth.ts
@@ -3,6 +3,10 @@ import { OAuth2Client } from 'google-auth-library';
 import { backendEnvSchema } from 'src/env';
 import { TRPCError } from '@trpc/server';
 
+/**
+ * Manages Google OAuth2 clients for different redirect origins.
+ * Handles client creation and validation of redirect URIs based on environment.
+ */
 export class GoogleOAuth2ClientsManager {
     /**
      * Map of redirect origins to OAuth2Clients.
@@ -22,6 +26,12 @@ export class GoogleOAuth2ClientsManager {
         this.redirectOrigin = GOOGLE_REDIRECT_URI;
     }
 
+    /**
+     * Gets or creates an OAuth2Client for the given redirect origin.
+     *
+     * @param redirectOrigin - The origin URL to create/get a client for
+     * @returns OAuth2Client configured for the given redirect origin
+     */
     getClient(redirectOrigin: string): OAuth2Client {
         if (!this.allowDynamicRedirects && redirectOrigin !== this.redirectOrigin) {
             throw new TRPCError({

--- a/apps/backend/src/routers/userData.ts
+++ b/apps/backend/src/routers/userData.ts
@@ -1,20 +1,20 @@
 import { UserSchema } from '@packages/antalmanac-types';
 import { TRPCError } from '@trpc/server';
 import { type } from 'arktype';
-import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
 
 import { db } from 'src/db';
 import { googleOAuthEnvSchema } from 'src/env';
 import { mangleDuplicateScheduleNames } from 'src/lib/formatting';
 import { RDS } from 'src/lib/rds';
+import { GoogleOAuth2ClientsManager } from 'src/lib/googleOAuth';
 import { procedure, router } from '../trpc';
 
-const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI } = googleOAuthEnvSchema.parse(process.env);
+const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } = googleOAuthEnvSchema.parse(process.env);
 
 const userInputSchema = type([{ userId: 'string' }, '|', { googleId: 'string' }]);
 
-const oauth2Client = new OAuth2Client(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI);
+const oauth2ClientsManager = new GoogleOAuth2ClientsManager(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET);
 
 const saveInputSchema = type({
     /**
@@ -34,6 +34,7 @@ const saveInputSchema = type({
 const saveGoogleSchema = type({
     code: 'string',
     token: 'string',
+    redirectOrigin: 'string',
 });
 
 const userDataRouter = router({
@@ -115,8 +116,8 @@ const userDataRouter = router({
      * Retrieves Google authentication URL for login/sign up.
      * Retrieves Google auth url to login/sign up
      */
-    getGoogleAuthUrl: procedure.query(async () => {
-        const url = oauth2Client.generateAuthUrl({
+    getGoogleAuthUrl: procedure.input(z.object({ redirectOrigin: z.string() })).query(async ({ input }) => {
+        const url = oauth2ClientsManager.getClient(input.redirectOrigin).generateAuthUrl({
             access_type: 'offline',
             scope: ['profile', 'email'],
         });
@@ -126,6 +127,7 @@ const userDataRouter = router({
      * Logs in or signs up a user and creates user's session
      */
     handleGoogleCallback: procedure.input(saveGoogleSchema.assert).mutation(async ({ input }) => {
+        const oauth2Client = oauth2ClientsManager.getClient(input.redirectOrigin);
         const { tokens } = await oauth2Client.getToken({ code: input.code });
         if (!tokens || !tokens.id_token) {
             throw new TRPCError({


### PR DESCRIPTION
## Summary
The new dev mirror breaks auth on prod but works on staging and locally.  

When the `.env` `STAGE=prod` the `GoogleOAuth2ClientsManager` throws an error when it should return the `OAuth2Client` with a redirect uri that matches the `GOOGLE_REDIRECT_URI`  

## Test Plan
To mimic prod you have to test locally and make changes in `/backend` to files: `.env` and `/src/index.ts`

`.env`: change `STAGE=local` to `STAGE=prod`

`index.ts`: change line 69 to `if (env.STAGE !== 'local')`

Note: To replicate the prod bug the the above local 

## Issues

Closes #
#1288 

<!-- [Optional]
## Future Followup
-->