### PR TITLE
fix: auth expiration error

### DIFF
--- a/apps/antalmanac/src/components/Header/Load.tsx
+++ b/apps/antalmanac/src/components/Header/Load.tsx
@@ -184,8 +184,8 @@ const ALERT_MESSAGES: Record<string, { title: string; severity: AlertColor }> = 
         severity: 'info',
     },
     SCHEDULE_IMPORTED: {
-        title: 'This schedule seems to have already been imported!',
-        severity: 'warning',
+        title: 'This schedule was previously imported to a Google account. Did you want to sign in with Google?',
+        severity: 'info',
     },
 };
 

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -17,10 +17,8 @@ import {
     setLocalStorageOnFirstSignin,
 } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';
-import { useSessionStore } from '$stores/SessionStore';
 
 export function AuthPage() {
-    const { session } = useSessionStore();
     const [searchParams] = useSearchParams();
 
     const handleSearchParamsChange = useCallback(async () => {
@@ -33,7 +31,7 @@ export function AuthPage() {
 
             const { sessionToken, userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
                 code: code,
-                token: session ?? '',
+                token: '',
             });
 
             const fromLoading = getLocalStorageFromLoading() ?? '';
@@ -103,7 +101,7 @@ export function AuthPage() {
         } catch (error) {
             console.error('Error during authentication', error);
         }
-    }, [searchParams, session]);
+    }, [searchParams]);
 
     useEffect(() => {
         handleSearchParamsChange();


### PR DESCRIPTION
## Summary
Issue: The code that authenticates the user takes a token arguement and it was passing the expired token but didn't validate the token. However, validating the token is unnecessary here because this bug is only caused when the user first logs in, so the the old token is trivial.

When session expires, prompt user to log back in
<img width="890" alt="image" src="https://github.com/user-attachments/assets/c8d96351-d449-40e5-944b-6f0cdd029a34" />

## Test Plan
1. In the DB, filter for your account in `users` and associated `session` rows
2. Login with your email
3. Manually set the `expiration_date` to some day in the past 
4. Refresh page (should be prompted to log back in)
5. Attempt login
6. Note: Logging in and out normally shouldn't be affected
## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
