### PR TITLE
Make text persist on blur

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -182,6 +182,10 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
         this.setState({ open: false });
     };
 
+    onFocus = () => {
+        this.setState({ open: true });
+    };
+
     render() {
         return (
             <LabeledAutocomplete
@@ -199,11 +203,13 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                     onInputChange: this.onInputChange,
                     open: this.state.open,
                     popupIcon: '',
+                    clearOnBlur: false,
                 }}
                 textFieldProps={{
                     autoFocus: !isMobile(),
                     placeholder: 'Search for courses, departments, GEs...',
                     fullWidth: true,
+                    onFocus: this.onFocus,
                 }}
                 isAligned
             />


### PR DESCRIPTION
## Summary
When using the fuzzy search bar, clicking away would cause the input to clear.

Steps to reproduce:
1. Select "Search"
2. Select "Quick Search"
3. In the search bar (Where it says 'Search for courses, departments, GEs...'), enter something
4. Click anywhere outside of the search bar
5. The input disappears

[See video](https://youtu.be/i66kpSpG_4A)

## Test Plan

Steps to test:
1. Select Search
2. Select Quick Search
3. In the search bar, enter something
4. Click anywhere outside the search bar
5. The input stays, and the previous search automatically comes up

## Issues
No issues.

Closes #1301

<!-- [Optional]
## Future Followup
-->
