### PR TITLE
fix: add rate limit to get-search-data

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,5 +68,12 @@ jobs:
 
               run: pnpm build
 
+            - name: Generate termData for tests
+              env:
+                HUSKY: 0
+                NODE_ENV: staging
+                ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+              run: pnpm --filter=antalmanac fetch-term-data
+
             - name: Test
               run: pnpm test run

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -10,6 +10,7 @@ import 'dotenv/config';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const MAX_COURSES = 10_000;
+const DELAY_MS = 250; // avoid rate limits from AAPI
 
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',
@@ -86,22 +87,37 @@ async function main() {
     `
     );
     let count = 0;
-    const termPromises = termData.map(async (term) => {
-        const [year, quarter] = term.shortName.split(' ');
-        const parsedTerm = `${quarter}_${year}`;
-        const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
-        const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);
-        if (!res) {
-            throw new Error(`Error fetching section codes for ${term.shortName}.`);
-        }
-        const parsedSectionData = parseSectionCodes(res);
-        console.log(
-            `Fetched ${Object.keys(parsedSectionData).length} course codes for ${term.shortName} from Anteater API.`
-        );
+    const termPromises = termData.map(async (term, index) => {
+        try {
+            const [year, quarter] = term.shortName.split(' ');
+            const parsedTerm = `${quarter}_${year}`;
+            const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
 
-        const fileName = join(__dirname, `../src/generated/terms/${parsedTerm}.json`);
-        await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
-        return Object.keys(parsedSectionData).length;
+            await new Promise((resolve) => setTimeout(resolve, DELAY_MS * index));
+
+            const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);
+            if (!res) {
+                throw new Error(`Error fetching section codes for ${term.shortName}.`);
+            }
+            const parsedSectionData = parseSectionCodes(res);
+            console.log(
+                `Fetched ${Object.keys(parsedSectionData).length} course codes for ${term.shortName} from Anteater API.`
+            );
+
+            const fileName = join(__dirname, `../src/generated/terms/${parsedTerm}.json`);
+            await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
+            return Object.keys(parsedSectionData).length;
+        } catch (error) {
+            console.error(`❌ ERROR in promise ${index} for term "${term.shortName}":`);
+            console.error(`Term details:`, {
+                shortName: term.shortName,
+                year: term.shortName.split(' ')[0],
+                quarter: term.shortName.split(' ')[1],
+                index,
+            });
+
+            throw error;
+        }
     });
 
     const results = await Promise.all(termPromises);

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -10,7 +10,7 @@ import 'dotenv/config';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const MAX_COURSES = 10_000;
-const DELAY_MS = 250; // avoid rate limits from AAPI
+const DELAY_MS = 500; // avoid rate limits from AAPI
 
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -93,6 +93,7 @@ async function main() {
             const parsedTerm = `${quarter}_${year}`;
             const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
 
+            // TODO (@kevin): remove delay once AAPI resolves OOM issues
             await new Promise((resolve) => setTimeout(resolve, DELAY_MS * index));
 
             const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);


### PR DESCRIPTION
## Summary
Adds a small 500ms offset delay to each request to avoid rate limits from the AAPI

## Test Plan
Run `pnpm:start` :)

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
