### PR TITLE
replaced "course code" with "section code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AntAlmanac is a schedule planner website for classes at UC Irvine. These are some of its features:
 
-- ___Search bar___ to easily find classes by department (e.g COMPSCI), course code (e.g. ICS 31), and keywords (e.g. artificial intelligence).
+- ___Search bar___ to easily find classes by department (e.g COMPSCI), section code (e.g. ICS 31), and keywords (e.g. artificial intelligence).
 - ___Integrated calendar___ to preview class times.
 - ___Quick links___ to professor reviews, prerequisites, grade distributions, and past enrollment data.
 - ___Interactive map___ with markers for your class locations.

--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -165,7 +165,7 @@ export const CourseCalendarEvent = ({ selectedEvent, scheduleNames, closePopover
                     <tbody>
                         <tr>
                             <td style={{ verticalAlign: 'top' }}>Section code</td>
-                            <Tooltip title="Click to copy course code" placement="right">
+                            <Tooltip title="Click to copy section code" placement="right">
                                 <td style={{ textAlign: 'right' }}>
                                     <Chip
                                         onClick={(event) => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -254,7 +254,7 @@ function SkeletonSchedule() {
                         <Typography variant="h6">{term}</Typography>
                         <Paper key={term} elevation={1}>
                             {sections.map((section, index) => (
-                                <Tooltip title="Click to copy course code" placement="right" key={index}>
+                                <Tooltip title="Click to copy section code" placement="right" key={index}>
                                     <Chip
                                         onClick={(event) => {
                                             clickToCopy(event, section);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -29,7 +29,7 @@ export function CoursePaneRoot() {
         } else {
             openSnackbar(
                 'error',
-                `Please provide one of the following: Department, GE, Course Code/Range, or Instructor`
+                `Please provide one of the following: Department, GE, Section Code/Range, or Instructor`
             );
         }
     }, [advancedSearchEnabled, displaySections, forceUpdate]);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SectionCodeSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SectionCodeSearchBar.tsx
@@ -49,7 +49,7 @@ class SectionCodeSearchBar extends PureComponent {
     render() {
         return (
             <LabeledTextField
-                label="Course Code"
+                label="Section Code"
                 textFieldProps={{
                     value: this.state.sectionCode,
                     onChange: this.handleChange,

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SectionCodeSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SectionCodeSearchBar.tsx
@@ -4,14 +4,14 @@ import { LabeledTextField } from '$components/RightPane/CoursePane/SearchForm/La
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 
 class SectionCodeSearchBar extends PureComponent {
-    updateCourseCodeAndGetFormData() {
-        RightPaneStore.updateFormValue('sectionCode', RightPaneStore.getUrlCourseCodeValue());
+    updateSectionCodeAndGetFormData() {
+        RightPaneStore.updateFormValue('sectionCode', RightPaneStore.getUrlSectionCodeValue());
         return RightPaneStore.getFormData().sectionCode;
     }
 
     getSectionCode() {
-        return RightPaneStore.getUrlCourseCodeValue()
-            ? this.updateCourseCodeAndGetFormData()
+        return RightPaneStore.getUrlSectionCodeValue()
+            ? this.updateSectionCodeAndGetFormData()
             : RightPaneStore.getFormData().sectionCode;
     }
 
@@ -25,9 +25,9 @@ class SectionCodeSearchBar extends PureComponent {
         const stateObj = { url: 'url' };
         const url = new URL(window.location.href);
         const urlParam = new URLSearchParams(url.search);
-        urlParam.delete('courseCode');
+        urlParam.delete('sectionCode');
         if (event.target.value) {
-            urlParam.append('courseCode', event.target.value);
+            urlParam.append('sectionCode', event.target.value);
         }
         const param = urlParam.toString();
         const new_url = `${param.trim() ? '?' : ''}${param}`;

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -33,7 +33,7 @@ export interface BuildingFocusInfo {
 class RightPaneStore extends EventEmitter {
     private formData: Record<ManualSearchParam, string>;
     private prevFormData?: Record<ManualSearchParam, string>;
-    private urlCourseCodeValue: string;
+    private urlSectionCodeValue: string;
     private urlTermValue: string;
     private urlGEValue: string;
     private urlCourseNumValue: string;
@@ -44,7 +44,7 @@ class RightPaneStore extends EventEmitter {
         this.setMaxListeners(15);
         this.formData = structuredClone(defaultFormValues);
         const search = new URLSearchParams(window.location.search);
-        this.urlCourseCodeValue = search.get('courseCode') || '';
+        this.urlSectionCodeValue = search.get('sectionCode') || '';
         this.urlTermValue = search.get('term') || '';
         this.urlGEValue = search.get('ge') || '';
         this.urlCourseNumValue = search.get('courseNumber') || '';
@@ -75,7 +75,7 @@ class RightPaneStore extends EventEmitter {
         return defaultFormValues;
     };
 
-    getUrlCourseCodeValue = () => this.urlCourseCodeValue;
+    getUrlSectionCodeValue = () => this.urlSectionCodeValue;
     getUrlTermValue = () => this.urlTermValue;
     getUrlGEValue = () => this.urlGEValue;
     getUrlCourseNumValue = () => this.urlCourseNumValue;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
@@ -86,7 +86,7 @@ export function ColorAndDelete({ section, term }: ActionProps) {
 }
 
 /**
- * Copying a specific class's link will only copy its course code.
+ * Copying a specific class's link will only copy its section code.
  * If there is random value let in the url, it will interfere with the generated url.
  */
 const fieldsToReset = ['courseCode', 'courseNumber', 'deptValue', 'ge', 'term'];

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/ActionCell.tsx
@@ -89,7 +89,7 @@ export function ColorAndDelete({ section, term }: ActionProps) {
  * Copying a specific class's link will only copy its section code.
  * If there is random value let in the url, it will interfere with the generated url.
  */
-const fieldsToReset = ['courseCode', 'courseNumber', 'deptValue', 'ge', 'term'];
+const fieldsToReset = ['sectionCode', 'courseNumber', 'deptValue', 'ge', 'term'];
 
 /**
  * Sections that have not been added to a schedule can be added to a schedule.
@@ -132,7 +132,7 @@ export function ScheduleAddCell({ section, courseDetails, term, scheduleNames, s
         const url = new URL(window.location.href);
         const urlParam = new URLSearchParams(url.search);
         fieldsToReset.forEach((field) => urlParam.delete(field));
-        urlParam.append('courseCode', String(section.sectionCode));
+        urlParam.append('sectionCode', String(section.sectionCode));
         const new_url = `${url.origin.toString()}/?${urlParam.toString()}`;
         navigator.clipboard.writeText(new_url.toString()).then(
             () => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/CourseCodeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/CourseCodeCell.tsx
@@ -28,7 +28,7 @@ export const CourseCodeCell = ({ sectionCode, analyticsCategory }: CourseCodeCel
 
     return (
         <TableBodyCellContainer sx={{ width: '8%' }}>
-            <Tooltip title="Click to copy course code" placement="bottom" enterDelay={150}>
+            <Tooltip title="Click to copy Section code" placement="bottom" enterDelay={150}>
                 <Chip
                     onClick={(event) => {
                         clickToCopy(event, sectionCode);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
@@ -7,12 +7,12 @@ import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
 import { useThemeStore } from '$stores/SettingsStore';
 
-interface CourseCodeCellProps {
+interface SectionCodeCellProps {
     sectionCode: string;
     analyticsCategory: AnalyticsCategory;
 }
 
-export const CourseCodeCell = ({ sectionCode, analyticsCategory }: CourseCodeCellProps) => {
+export const SectionCodeCell = ({ sectionCode, analyticsCategory }: SectionCodeCellProps) => {
     const isDark = useThemeStore((store) => store.isDark);
     const [isHovered, setIsHovered] = useState(false);
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
@@ -28,7 +28,7 @@ export const SectionCodeCell = ({ sectionCode, analyticsCategory }: SectionCodeC
 
     return (
         <TableBodyCellContainer sx={{ width: '8%' }}>
-            <Tooltip title="Click to copy Section code" placement="bottom" enterDelay={150}>
+            <Tooltip title="Click to copy section code" placement="bottom" enterDelay={150}>
                 <Chip
                     onClick={(event) => {
                         clickToCopy(event, sectionCode);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -4,7 +4,6 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ActionCell } from './SectionTableBodyCells/ActionCell';
 
-import { CourseCodeCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/CourseCodeCell';
 import { DayAndTimeCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DayAndTimeCell';
 import { DetailsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DetailsCell';
 import { EnrollmentCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell';
@@ -12,6 +11,7 @@ import { GpaCell } from '$components/RightPane/SectionTable/SectionTableBody/Sec
 import { InstructorsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell';
 import { LocationsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell';
 import { RestrictionsCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell';
+import { SectionCodeCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell';
 import { StatusCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/StatusCell';
 import { SyllabusCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell';
 import { AnalyticsCategory } from '$lib/analytics/analytics';
@@ -34,7 +34,7 @@ interface SectionTableBodyRowProps {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tableBodyCells: Record<SectionTableColumn, React.ComponentType<any>> = {
     action: ActionCell,
-    sectionCode: CourseCodeCell,
+    sectionCode: SectionCodeCell,
     sectionDetails: DetailsCell,
     instructors: InstructorsCell,
     gpa: GpaCell,

--- a/apps/antalmanac/src/lib/analytics/analytics.ts
+++ b/apps/antalmanac/src/lib/analytics/analytics.ts
@@ -22,7 +22,7 @@ const analyticsEnum: AnalyticsEnum = {
         actions: {
             DELETE_COURSE: 'Delete Course',
             CHANGE_COURSE_COLOR: 'Change Course Color',
-            COPY_COURSE_CODE: 'Copy Course Code',
+            COPY_COURSE_CODE: 'Copy Section Code',
             CLICK_CUSTOM_EVENT: 'Click Custom Event Button',
             ADD_CUSTOM_EVENT: 'Add Custom Event',
             DELETE_CUSTOM_EVENT: 'Delete Custom Event',
@@ -59,7 +59,7 @@ const analyticsEnum: AnalyticsEnum = {
             CLICK_REVIEWS: 'Click "Reviews"',
             CLICK_PAST_ENROLLMENT: 'Click "Past Enrollment"',
             ADD_SPECIFIC: 'Add Course to Specific Schedule',
-            COPY_COURSE_CODE: 'Copy Course Code',
+            COPY_COURSE_CODE: 'Copy Section Code',
             REFRESH: 'Refresh Results',
             TOGGLE_COLUMNS: 'Toggle Columns',
         },
@@ -72,7 +72,7 @@ const analyticsEnum: AnalyticsEnum = {
             COPY_SCHEDULE: 'Copy Schedule',
             CLEAR_SCHEDULE: 'Clear Schedule',
             CHANGE_COURSE_COLOR: 'Change Course Color',
-            COPY_COURSE_CODE: 'Copy Course Code',
+            COPY_COURSE_CODE: 'Copy Section Code',
         },
     },
     map: {

--- a/apps/antalmanac/src/stores/CoursePaneStore.ts
+++ b/apps/antalmanac/src/stores/CoursePaneStore.ts
@@ -33,7 +33,7 @@ export function paramsAreInURL() {
 function requiredParamsAreInURL() {
     const search = new URLSearchParams(window.location.search);
 
-    const searchParams = ['courseCode', 'courseNumber', 'ge', 'deptValue'];
+    const searchParams = ['sectionCode', 'courseNumber', 'ge', 'deptValue'];
 
     return searchParams.some((param) => search.get(param) !== null);
 }

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -96,7 +96,7 @@ async function main() {
         }
         const parsedSectionData = parseSectionCodes(res);
         console.log(
-            `Fetched ${Object.keys(parsedSectionData).length} course codes for ${term.shortName} from Anteater API.`
+            `Fetched ${Object.keys(parsedSectionData).length} section codes for ${term.shortName} from Anteater API.`
         );
 
         const fileName = join(__dirname, `../src/generated/terms/${parsedTerm}.json`);
@@ -107,7 +107,7 @@ async function main() {
     const results = await Promise.all(termPromises);
     count = results.reduce((acc, numKeys) => acc + numKeys, 0);
 
-    console.log(`Fetched ${count} course codes for ${termData.length} terms from Anteater API.`);
+    console.log(`Fetched ${count} section codes for ${termData.length} terms from Anteater API.`);
     console.log('Cache generated.');
 }
 

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -102,7 +102,7 @@ async function main() {
             }
             const parsedSectionData = parseSectionCodes(res);
             console.log(
-                `Fetched ${Object.keys(parsedSectionData).length} course codes for ${term.shortName} from Anteater API.`
+                `Fetched ${Object.keys(parsedSectionData).length} section codes for ${term.shortName} from Anteater API.`
             );
 
             const fileName = join(__dirname, `../src/generated/terms/${parsedTerm}.json`);

--- a/apps/backend/src/routers/search.ts
+++ b/apps/backend/src/routers/search.ts
@@ -59,17 +59,17 @@ const searchRouter = router({
             const num = Number(input.query);
             const matchedSections: SectionSearchResult[] = [];
             if (!isNaN(num) && num >= 0 && Number.isInteger(num)) {
-                const baseCourseCode = input.query;
+                const baseSectionCode = input.query;
                 if (input.query.length === 4) {
                     for (let i = 0; i < 10; i++) {
-                        const possibleCourseCode = `${baseCourseCode}${i}`;
-                        if (termSectionCodes[possibleCourseCode]) {
-                            matchedSections.push(termSectionCodes[possibleCourseCode]);
+                        const possibleSectionCode = `${baseSectionCode}${i}`;
+                        if (termSectionCodes[possibleSectionCode]) {
+                            matchedSections.push(termSectionCodes[possibleSectionCode]);
                         }
                     }
                 } else if (input.query.length === 5) {
-                    if (termSectionCodes[baseCourseCode]) {
-                        matchedSections.push(termSectionCodes[baseCourseCode]);
+                    if (termSectionCodes[baseSectionCode]) {
+                        matchedSections.push(termSectionCodes[baseSectionCode]);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

There was a mismatch between the naming of section codes in AntAlmanac and on the AnteaterAPI. AntAlmanac was using the term "course code" which does not make sense because we already have "course number." "Section code" is more fitting because there are sections of a course by quarter; it's not like course changes every quarter.

## Test Plan

I just browsed through the site to check if there are any mentions of course code. I don't see any.

## Issues

Closes #1087 

<!-- [Optional]
## Future Followup
-->
none for now!
