### PR TITLE
fix: prevent reactour popover clipping

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -115,6 +115,8 @@ export default function App() {
                                 borderRadius: 5,
                                 boxShadow: '0 0 10px #000',
                                 padding: 20,
+                                paddingTop: 40,
+                                margin: 20,
                             }),
                         }}
                     >


### PR DESCRIPTION
## Summary
- Added `margin` and `paddingTop` to prevent the step count and the X button from being clipped.

## Test Plan
- Set the dimensions of the viewport to 1920x1080 (this problem persists across all the resolutions I tested, but for reproducibility) 
- Start the Tutorial
- Click to the second step

Before:
<img width="279" height="127" alt="image" src="https://github.com/user-attachments/assets/6ca520a8-c51c-4734-9eae-ee0eac0f318d" />

After:
<img width="302" height="170" alt="image" src="https://github.com/user-attachments/assets/3eb2bc13-f708-4ed3-b21c-a992c8bc2e3a" />

## Issues
Closes https://github.com/icssc/AntAlmanac/issues/1011

<!-- [Optional]
## Future Followup
-->
