### PR TITLE
fixed readme issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AntAlmanac is a schedule planner website for classes at UC Irvine. These are some of its features:
 
-- ___Search bar___ to easily find classes by department (e.g COMPSCI), section code (e.g. ICS 31), and keywords (e.g. artificial intelligence).
+- ___Search bar___ to easily find classes by department (e.g COMPSCI), section code (e.g. 36040), and keywords (e.g. artificial intelligence).
 - ___Integrated calendar___ to preview class times.
 - ___Quick links___ to professor reviews, prerequisites, grade distributions, and past enrollment data.
 - ___Interactive map___ with markers for your class locations.


### PR DESCRIPTION

changed "section code (e.g. ICS 31)" to "section code (e.g. 3640)" a more accurate section code

Before:
<img width="836" height="512" alt="Screenshot 2025-10-19 at 11 02 14 PM" src="https://github.com/user-attachments/assets/ce6ad97d-e55a-48f0-9f1a-1b0346047a24" />

After:
<img width="836" height="512" alt="Screenshot 2025-10-19 at 11 15 06 PM" src="https://github.com/user-attachments/assets/77df373c-f96f-48d1-bb4e-cd812312893d" />


Closes #1312 

