### PR TITLE
Auto save ScheduleIndex as temporary save data

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -18,6 +18,7 @@ import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStora
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
+import { deleteTempSaveData } from '$stores/localTempSaveDataHelpers';
 export interface CopyScheduleOptions {
     onSuccess: (scheduleName: string) => unknown;
     onError: (scheduleName: string) => unknown;
@@ -129,6 +130,7 @@ export const saveSchedule = async (providerId: string, rememberMe: boolean, post
                         `Schedule saved under username "${providerId}". Don't forget to sign up for classes on WebReg!`
                     );
                 }
+                deleteTempSaveData();
                 AppStore.saveSchedule();
             } catch (e) {
                 if (e instanceof TRPCError) {
@@ -165,6 +167,7 @@ export async function autoSaveSchedule(providerID: string, postHog?: PostHog) {
             },
         });
 
+        deleteTempSaveData();
         AppStore.saveSchedule();
     } catch (e) {
         if (e instanceof TRPCError) {

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -20,6 +20,7 @@ enum LocalStorageKeys {
     newUser = 'newUser',
     importedUser = 'importedUser',
     fromLoading = 'fromLoading',
+    tempSaveData = 'tempSaveData',
 }
 
 const LSK = LocalStorageKeys;
@@ -267,4 +268,16 @@ export function setLocalStoragePWADismissalTime(value: string) {
 
 export function getLocalStoragePWADismissalTime() {
     return window.localStorage.getItem(LSK.pwaDismissalTime);
+}
+
+export function setLocalStorageTempSaveData(value: string) {
+    window.localStorage.setItem(LSK.tempSaveData, value);
+}
+
+export function getLocalStorageTempSaveData() {
+    return window.localStorage.getItem(LSK.tempSaveData);
+}
+
+export function removeLocalStorageTempSaveData() {
+    window.localStorage.removeItem(LSK.tempSaveData);
 }

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -23,6 +23,7 @@ import type {
 import type { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
 import { Schedules } from '$stores/Schedules';
 import { useTabStore } from '$stores/TabStore';
+import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
 
 class AppStore extends EventEmitter {
     schedule: Schedules;
@@ -355,6 +356,7 @@ class AppStore extends EventEmitter {
     }
 
     async loadSchedule(savedSchedule: ScheduleSaveState) {
+        const hasDataChanged = JSON.stringify(this.schedule.getScheduleAsSaveState()) === JSON.stringify(savedSchedule);
         const loadSuccess = await this.loadScheduleFromSaveState(savedSchedule);
         if (!loadSuccess) {
             return false;
@@ -375,6 +377,12 @@ class AppStore extends EventEmitter {
         }
 
         this.schedule.clearPreviousStates();
+
+        if (hasDataChanged) {
+            deleteTempSaveData();
+        } else {
+            loadTempSaveData(savedSchedule.schedules.length);
+        }
 
         this.emit('addedCoursesChange');
         this.emit('customEventsChange');
@@ -403,6 +411,7 @@ class AppStore extends EventEmitter {
 
     changeCurrentSchedule(newScheduleIndex: number) {
         this.schedule.setCurrentScheduleIndex(newScheduleIndex);
+        setTempSaveData({ currentScheduleIndex: newScheduleIndex });
         this.emit('currentScheduleIndexChange');
         this.emit('scheduleNotesChange');
     }

--- a/apps/antalmanac/src/stores/localTempSaveDataHelpers.ts
+++ b/apps/antalmanac/src/stores/localTempSaveDataHelpers.ts
@@ -1,0 +1,76 @@
+import { changeCurrentSchedule } from '$actions/AppStoreActions';
+import {
+    getLocalStorageTempSaveData,
+    removeLocalStorageTempSaveData,
+    setLocalStorageTempSaveData,
+} from '$lib/localStorage';
+
+/**
+ * Any values stored in temporarily saved data should eventually be permanently saved.
+ */
+interface TempSaveData {
+    currentScheduleIndex?: number;
+}
+
+let dataToSave: TempSaveData = {};
+
+/**
+ * Loads temporary save data as override values.
+ *
+ * ```typescript
+ *
+ *   loadTempSaveData(savedSchedule.schedules.length);
+ *
+ * ```
+ *
+ * @param scheduleCount The number of schedules that the user has.
+ */
+export function loadTempSaveData(scheduleCount: number) {
+    const savedDataString = getLocalStorageTempSaveData();
+    if (savedDataString !== null) {
+        const parsedData = JSON.parse(savedDataString) as TempSaveData;
+
+        if (parsedData.currentScheduleIndex !== undefined) {
+            if (parsedData.currentScheduleIndex >= scheduleCount) {
+                parsedData.currentScheduleIndex = scheduleCount = 1;
+            }
+            changeCurrentSchedule(parsedData.currentScheduleIndex);
+        }
+
+        Object.assign(dataToSave, parsedData);
+    }
+}
+
+/**
+ * Stores a value as temporarily saved data.
+ *
+ * ```typescript
+ *
+ *   setTempSaveData({ currentSCheduleIndex: 0 });
+ *
+ * ```
+ *
+ * @param newData An object containing properties and values to override locally stored data with.
+ * Does not need to contain all properties, any omitted properties will not be changed.
+ */
+export function setTempSaveData<T extends TempSaveData>(newData: T) {
+    Object.assign(dataToSave, newData);
+    setLocalStorageTempSaveData(JSON.stringify(dataToSave));
+}
+
+/**
+ * Deletes any temporarily saved data.
+ * This should be done whenever the temporarily saved data isn't needed anymore,
+ * e.g. when autosave runs.
+ *
+ * ```typescript
+ *
+ *   deleteTempSaveData();
+ *
+ * ```
+ *
+ */
+export function deleteTempSaveData() {
+    removeLocalStorageTempSaveData();
+    dataToSave = {};
+}


### PR DESCRIPTION
## Summary

Allow temporary save data to be stored locally before eventually being overwritten or permanently saved. Also save `currentScheduleIndex` as temp save data so the last viewed schedule is stored, instead of just the last edited schedule.

## Test Plan

1. Switching the viewed schedule without making any actions that trigger autosave should save the current schedule index locally.
2. Switching schedules without saving then reloading should load the last viewed schedule, not just the last edited schedule.
3. Saving manually should delete temp save data.
4. Autosaving should delete temp save data.
5. Saving data on one tab then reloading on another tab should overwrite and delete temp save data.

## Issues

Closes #1289

<!-- [Optional]
## Future Followup
-->