### PR TITLE
Rapidly resizing the window duplicates schedules

### DIFF
--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -17,7 +17,6 @@ import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 function MobileHome() {
     return (
         <Stack component="main" height="100dvh">
-            <Header />
             <ScheduleManagement />
         </Stack>
     );
@@ -51,8 +50,6 @@ function DesktopHome() {
     return (
         <>
             <Stack height="100dvh">
-                <Header />
-
                 <Split
                     sizes={[45, 55]}
                     minSize={400}
@@ -94,6 +91,7 @@ export default function Home() {
             <PatchNotes />
             <InstallPWABanner />
 
+            <Header />
             {isMobileScreen ? <MobileHome /> : <DesktopHome />}
 
             <NotificationSnackbar />

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -15,11 +15,7 @@ import { BLUE } from '$src/globals';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 
 function MobileHome() {
-    return (
-        <Stack component="main" height="100dvh">
-            <ScheduleManagement />
-        </Stack>
-    );
+    return <ScheduleManagement />;
 }
 
 function DesktopHome() {
@@ -48,36 +44,32 @@ function DesktopHome() {
     }, [handleDrag]);
 
     return (
-        <>
-            <Stack height="100dvh">
-                <Split
-                    sizes={[45, 55]}
-                    minSize={400}
-                    expandToMin={false}
-                    gutterSize={10}
-                    gutterAlign="center"
-                    snapOffset={30}
-                    dragInterval={1}
-                    direction="horizontal"
-                    cursor="col-resize"
-                    style={{ display: 'flex', flexGrow: 1, marginTop: 4 }}
-                    gutterStyle={() => ({
-                        backgroundColor: BLUE,
-                        width: '10px',
-                        // gutter contents are slightly offset to the right, this centers the content
-                        paddingRight: '1px',
-                    })}
-                    onDrag={handleDrag}
-                >
-                    <Stack direction="column">
-                        <ScheduleCalendar />
-                    </Stack>
-                    <Stack direction="column" ref={scheduleManagementRef}>
-                        <ScheduleManagement />
-                    </Stack>
-                </Split>
+        <Split
+            sizes={[45, 55]}
+            minSize={400}
+            expandToMin={false}
+            gutterSize={10}
+            gutterAlign="center"
+            snapOffset={30}
+            dragInterval={1}
+            direction="horizontal"
+            cursor="col-resize"
+            style={{ display: 'flex', flexGrow: 1, marginTop: 4 }}
+            gutterStyle={() => ({
+                backgroundColor: BLUE,
+                width: '10px',
+                // gutter contents are slightly offset to the right, this centers the content
+                paddingRight: '1px',
+            })}
+            onDrag={handleDrag}
+        >
+            <Stack direction="column">
+                <ScheduleCalendar />
             </Stack>
-        </>
+            <Stack direction="column" ref={scheduleManagementRef}>
+                <ScheduleManagement />
+            </Stack>
+        </Split>
     );
 }
 
@@ -91,8 +83,10 @@ export default function Home() {
             <PatchNotes />
             <InstallPWABanner />
 
-            <Header />
-            {isMobileScreen ? <MobileHome /> : <DesktopHome />}
+            <Stack component="main" height="100dvh">
+                <Header />
+                {isMobileScreen ? <MobileHome /> : <DesktopHome />}
+            </Stack>
 
             <NotificationSnackbar />
             <HelpMenu />

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -535,9 +535,6 @@ export class Schedules {
         this.addUndoState();
 
         try {
-            this.schedules.length = 0;
-            this.currentScheduleIndex = saveState.scheduleIndex;
-
             // Get a dictionary of all unique courses
             const courseDict: { [key: string]: Set<string> } = {};
             for (const schedule of saveState.schedules) {
@@ -560,6 +557,9 @@ export class Schedules {
             });
 
             await Promise.all(websocRequests);
+
+            this.schedules.length = 0;
+            this.currentScheduleIndex = saveState.scheduleIndex;
 
             // Map course info to courses and transform shortened schedule to normal schedule
             for (const shortCourseSchedule of saveState.schedules) {


### PR DESCRIPTION
## Summary

Fix unnecessary `Header` and `Stack` wrapper component duplication. Clear schedules after async-fetching data instead of before to avoid double-filling schedules.

## Test Plan

1. Quickly resizing the UI between mobile and desktop versions (through browser window or developer tools section) should not cause schedules to be reloaded. This can be confirmed at a glance by ensuring the "Schedule loaded" snackbar does not open.

## Issues

Closes #1211

<!-- [Optional]
## Future Followup
-->
