### PR TITLE
Fix CoursePaneButtonRow covering scrollbar issue

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -60,7 +60,7 @@ export function CoursePaneRoot() {
     }, [handleKeydown]);
 
     return (
-        <Box height={'0px'} flexGrow={1}>
+        <Box sx={{ height: 0, flexGrow: 1, position: 'relative' }}>
             <CoursePaneButtonRow
                 showSearch={!searchFormIsDisplayed}
                 onDismissSearchResults={displaySearch}


### PR DESCRIPTION
## Summary

Changing `CoursePaneRoot`'s position to `relative` lets `CoursePaneButtonRow`'s absolute positioning work correctly.

## Test Plan

1. Confirm that hovering over the scrollbar section next to where the course pane buttons are shows the scrollbar correctly.
2. Also confirm that the course pane buttons' UI has not changed from before.

## Issues

Closes #1235

<!-- [Optional]
## Future Followup
-->
