### PR TITLE
Awkward Menu Button Shape

### DIFF
--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -64,7 +64,7 @@ export function Header() {
             >
                 <Logo />
 
-                <Stack direction="row">
+                <Stack direction="row" sx={{ alignItems: 'center' }}>
                     <Save />
                     <Import key="studylist" />
                     {sessionIsValid ? <Signout /> : <Signin />}


### PR DESCRIPTION
## Summary

Align header items on the right side to the center instead of stretching their heights (default behavior).

## Test Plan

1. Hover over menu button in header and confirm the hover background effect is a circle

## Issues

Closes #1323

<!-- [Optional]
## Future Followup
-->
