### PR TITLE
Fix Schedule Section Colors

### DIFF
--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -7,6 +7,7 @@ import { SketchPicker } from 'react-color';
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
 import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import AppStore from '$stores/AppStore';
+import { colorPickerPresetColors } from '$stores/scheduleHelpers';
 
 interface ColorPickerProps {
     color: string;
@@ -101,7 +102,7 @@ const ColorPicker = memo(function ColorPicker({
                     horizontal: 'left',
                 }}
             >
-                <SketchPicker color={currColor} onChange={handleColorChange} />
+                <SketchPicker color={currColor} onChange={handleColorChange} presetColors={colorPickerPresetColors} />
             </Popover>
         </>
     );

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -18,13 +18,13 @@ import {
 import { ScheduleCourse } from '@packages/antalmanac-types';
 
 const colorVariants: Record<string, string[]> = {
-    blue: [blue[300], blue[200], blue[100]],
-    pink: [pink[300], pink[200], pink[100]],
-    purple: [purple[300], purple[200], purple[100]],
-    green: [green[300], green[200], green[100]],
-    amber: [amber[300], amber[200], amber[100]],
-    deepPurple: [deepPurple[300], deepPurple[200], deepPurple[100]],
-    deepOrange: [deepOrange[300], deepOrange[200], deepOrange[100]],
+    blue: [blue[300], blue[200], blue[100], blue[400], blue[500]],
+    pink: [pink[300], pink[200], pink[100], pink[400], pink[500]],
+    purple: [purple[300], purple[200], purple[100], purple[400], purple[500]],
+    green: [green[300], green[200], green[100], green[400], green[500]],
+    amber: [amber[300], amber[200], amber[100], amber[400], amber[500]],
+    deepPurple: [deepPurple[300], deepPurple[200], deepPurple[100], deepPurple[400], deepPurple[500]],
+    deepOrange: [deepOrange[300], deepOrange[200], deepOrange[100], deepOrange[400], deepOrange[500]],
 };
 
 export const colorPickerPresetColors = [

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -1,4 +1,20 @@
-import { amber, blue, deepOrange, deepPurple, green, pink, purple } from '@mui/material/colors';
+import {
+    amber,
+    brown,
+    blue,
+    cyan,
+    deepOrange,
+    deepPurple,
+    green,
+    grey,
+    indigo,
+    lightBlue,
+    pink,
+    purple,
+    red,
+    teal,
+    yellow,
+} from '@mui/material/colors';
 import { ScheduleCourse } from '@packages/antalmanac-types';
 
 export interface HSLColor {
@@ -7,8 +23,26 @@ export interface HSLColor {
     l: number;
 }
 
-const defaultColors = [blue[500], pink[500], purple[500], green[500], amber[500], deepPurple[500], deepOrange[500]];
+const defaultColors = [blue[200], pink[200], purple[200], green[200], amber[200], deepPurple[200], deepOrange[200]];
 
+export const colorPickerPresetColors = [
+    brown[200],
+    red[200],
+    deepOrange[200],
+    amber[200],
+    yellow[200],
+    green[200],
+    teal[200],
+    cyan[100],
+    lightBlue[200],
+    indigo[200],
+    deepPurple[200],
+    pink[200],
+    green[300],
+    grey[600],
+    grey[300],
+    grey[50],
+];
 /**
  * Converts a hex color to HSL
  * Assumes the hex color is in the format #RRGGBB

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -17,13 +17,15 @@ import {
 } from '@mui/material/colors';
 import { ScheduleCourse } from '@packages/antalmanac-types';
 
-export interface HSLColor {
-    h: number;
-    s: number;
-    l: number;
-}
-
-const defaultColors = [blue[200], pink[200], purple[200], green[200], amber[200], deepPurple[200], deepOrange[200]];
+const colorVariants: Record<string, string[]> = {
+    blue: [blue[200], blue[100], blue[300], blue[400]],
+    pink: [pink[200], pink[100], pink[300], pink[400]],
+    purple: [purple[200], purple[100], purple[300], purple[400]],
+    green: [green[200], green[100], green[300], green[400]],
+    amber: [amber[200], amber[100], amber[300], amber[400]],
+    deepPurple: [deepPurple[200], deepPurple[100], deepPurple[300], deepPurple[400]],
+    deepOrange: [deepOrange[200], deepOrange[100], deepOrange[300], deepOrange[400]],
+};
 
 export const colorPickerPresetColors = [
     brown[200],
@@ -43,163 +45,36 @@ export const colorPickerPresetColors = [
     grey[300],
     grey[50],
 ];
-/**
- * Converts a hex color to HSL
- * Assumes the hex color is in the format #RRGGBB
- * Adapted from https://stackoverflow.com/a/9493060
- *
- * @param hex str: hex string representation of a color
- *
- * @return An HSLColor object where h, s, and l are in the range [0, 1]
- */
-function HexToHSL(hex: string): HSLColor {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-
-    if (!result) {
-        throw new Error('Could not parse Hex Color');
-    }
-
-    const r = parseInt(result[1], 16) / 255;
-    const g = parseInt(result[2], 16) / 255;
-    const b = parseInt(result[3], 16) / 255;
-
-    const max = Math.max(r, g, b),
-        min = Math.min(r, g, b);
-    let h,
-        s,
-        l = (max + min) / 2;
-
-    if (max == min) {
-        h = s = 0; // achromatic
-    } else {
-        const d = max - min;
-        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-        switch (max) {
-            case r:
-                h = (g - b) / d + (g < b ? 6 : 0);
-                break;
-            case g:
-                h = (b - r) / d + 2;
-                break;
-            case b:
-                h = (r - g) / d + 4;
-                break;
-            default:
-                throw new Error('Error converting hex to hsl');
-        }
-        h /= 6;
-    }
-
-    [h, s, l] = [h, s, l].map((val: number) => Math.round(val * 100) / 100);
-
-    return { h, s, l };
-}
 
 /**
- * Converts HSL color in the range [0, 1] to a hex string ("#RRGGBB")
- * Adapted from https://stackoverflow.com/a/9493060
- */
-function HSLToHex({ h, s, l }: HSLColor): string {
-    // Check that h, s, and l are in the range [0, 1]
-    if (h < 0 || h > 1 || s < 0 || s > 1 || l < 0 || l > 1) {
-        throw new Error('Invalid HSLColor');
-    }
-
-    let r, g, b;
-
-    if (s == 0) {
-        r = g = b = l; // achromatic
-    } else {
-        const hue2rgb = function hue2rgb(p: number, q: number, t: number) {
-            if (t < 0) t += 1;
-            if (t > 1) t -= 1;
-            if (t < 1 / 6) return p + (q - p) * 6 * t;
-            if (t < 1 / 2) return q;
-            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-            return p;
-        };
-
-        const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-        const p = 2 * l - q;
-        r = hue2rgb(p, q, h + 1 / 3);
-        g = hue2rgb(p, q, h);
-        b = hue2rgb(p, q, h - 1 / 3);
-    }
-
-    [r, g, b] = [r, g, b].map((x) =>
-        Math.round(x * 255)
-            .toString(16)
-            .padStart(2, '0')
-    );
-
-    return `#${r}${g}${b}`;
-}
-
-/**
- * Checks if an HSL color has already been used, given an array of used colors and a delta.
- */
-function isColorUsed(color: HSLColor, usedColors: Iterable<HSLColor>, delta: number): boolean {
-    for (const usedColor of usedColors) {
-        if (
-            Math.abs(usedColor.h - color.h) < delta &&
-            Math.abs(usedColor.s - color.s) < delta &&
-            Math.abs(usedColor.l - color.l) < delta
-        )
-            return true;
-    }
-    return false;
-}
-
-/**
- * Checks if an HSL color is visible and provides enough contrast against the background.
- *
- * @param color HSLColor: The color to check.
- * @param minimum_luminance number: The minimum luminance value to consider the color visible, defaults to 0.2.
- * @param maximum_luminance number: The maximum luminance value to consider the color visible, defaults to 0.8.
- * @returns boolean: True if the color is visible enough, false otherwise.
- */
-function isColorVisible(color: HSLColor, minimum_luminance = 0.2, maximum_luminance = 0.8): boolean {
-    return color.l >= minimum_luminance && color.l <= maximum_luminance;
-}
-
-/**
- * Takes in a hex color and returns a hex color that is close to the original but not already used.
- * Change the luminance of the color by a small amount until a color that is not already used is found.
- * Prefers lighter colors over darker.
+ * Takes in a hex color and returns a color variant hex color that is not already used.
+ * Uses predefined shade variants from the same color family.
  *
  * @param originalColor string: Hex color ("#RRGGBB") as a basis.
  * @param usedColors Set<string>: A set of hex colors that are already used.
- * @param variation number [0-1]: The step size to use when generating a new color.
- *      The bigger the number, the more different the new color will be.
  *
  * @return Unused hex color that is close to the original color ("#RRGGBB").
  */
-function generateCloseColor(originalColor: string, usedColors: Set<string>, variation = 0.1): string {
-    const usedHSLColors = [...usedColors].map(HexToHSL);
-    const originalHSLColor: HSLColor = HexToHSL(originalColor);
-
-    const MAX_ITERATIONS = 20; // prevent infinite loop when variation <= 0
-
-    let delta = variation;
-    let iterations = 0;
-    while (Math.abs(delta) <= 1 && iterations < MAX_ITERATIONS) {
-        const lighterHSLColor = { ...originalHSLColor, l: originalHSLColor.l + delta };
-        const darkerHSLColor = { ...originalHSLColor, l: originalHSLColor.l - delta };
-
-        if (!isColorUsed(lighterHSLColor, usedHSLColors, variation) && isColorVisible(lighterHSLColor)) {
-            return HSLToHex(lighterHSLColor);
+function generateColorVariant(originalColor: string, usedColors: Set<string>): string {
+    let family: string | null = null;
+    for (const f in colorVariants) {
+        if (colorVariants[f].includes(originalColor)) {
+            family = f;
+            break;
         }
-
-        if (!isColorUsed(darkerHSLColor, usedHSLColors, variation) && isColorVisible(darkerHSLColor)) {
-            return HSLToHex(darkerHSLColor);
-        }
-
-        delta += variation;
-        iterations++;
     }
 
-    // If no suitable color is found, fallback to original color
-    return HSLToHex(originalHSLColor);
+    // Fallback to original color if no family found
+    if (!family) return originalColor;
+
+    for (const variant of colorVariants[family]) {
+        if (!usedColors.has(variant)) {
+            return variant;
+        }
+    }
+
+    // If all variants are used, fallback to original
+    return originalColor;
 }
 
 export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSchedule: ScheduleCourse[]): string {
@@ -220,7 +95,7 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     const existingSectionsType = existingSections.filter(
         (course) => course.section.sectionType === newSection.section.sectionType
     );
-
+    const defaultColors = Object.values(colorVariants).map((variants) => variants[0]);
     const usedColors = sectionsInSchedule.map((course) => course.section.color);
     const lastDefaultColor = usedColors.findLast((materialColor) =>
         (defaultColors as string[]).includes(materialColor)
@@ -230,7 +105,9 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
     if (existingSectionsType.length > 0) return existingSectionsType[0].section.color;
 
     // If the same courseTitle exists, but not the same sectionType, return a close color
-    if (existingSections.length > 0) return generateCloseColor(existingSections[0].section.color, new Set(usedColors));
+    if (existingSections.length > 0) {
+        return generateColorVariant(existingSections[0].section.color, new Set(usedColors));
+    }
 
     // If there are no existing sections with the same course title, generate a new color. If we run out of unique colors, return the next color up after the last default color in use, looping after reaching the end.
     return (

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -18,13 +18,13 @@ import {
 import { ScheduleCourse } from '@packages/antalmanac-types';
 
 const colorVariants: Record<string, string[]> = {
-    blue: [blue[200], blue[100], blue[300], blue[400]],
-    pink: [pink[200], pink[100], pink[300], pink[400]],
-    purple: [purple[200], purple[100], purple[300], purple[400]],
-    green: [green[200], green[100], green[300], green[400]],
-    amber: [amber[200], amber[100], amber[300], amber[400]],
-    deepPurple: [deepPurple[200], deepPurple[100], deepPurple[300], deepPurple[400]],
-    deepOrange: [deepOrange[200], deepOrange[100], deepOrange[300], deepOrange[400]],
+    blue: [blue[300], blue[200], blue[100]],
+    pink: [pink[300], pink[200], pink[100]],
+    purple: [purple[300], purple[200], purple[100]],
+    green: [green[300], green[200], green[100]],
+    amber: [amber[300], amber[200], amber[100]],
+    deepPurple: [deepPurple[300], deepPurple[200], deepPurple[100]],
+    deepOrange: [deepOrange[300], deepOrange[200], deepOrange[100]],
 };
 
 export const colorPickerPresetColors = [

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -184,14 +184,14 @@ function generateCloseColor(originalColor: string, usedColors: Set<string>, vari
     let iterations = 0;
     while (Math.abs(delta) <= 1 && iterations < MAX_ITERATIONS) {
         const lighterHSLColor = { ...originalHSLColor, l: originalHSLColor.l + delta };
-        const darkerColorHSL = { ...originalHSLColor, l: originalHSLColor.l - delta };
+        const darkerHSLColor = { ...originalHSLColor, l: originalHSLColor.l - delta };
 
         if (!isColorUsed(lighterHSLColor, usedHSLColors, variation) && isColorVisible(lighterHSLColor)) {
             return HSLToHex(lighterHSLColor);
         }
 
-        if (!isColorUsed(darkerColorHSL, usedHSLColors, variation) && isColorVisible(darkerColorHSL)) {
-            return HSLToHex(darkerColorHSL);
+        if (!isColorUsed(darkerHSLColor, usedHSLColors, variation) && isColorVisible(darkerHSLColor)) {
+            return HSLToHex(darkerHSLColor);
         }
 
         delta += variation;


### PR DESCRIPTION
## Summary
Fixes #1321, Reverts https://github.com/icssc/AntAlmanac/commit/68f49dcf0c761a434d5997a5e3e67a91cb2d05a2

Restores/improves schedule section colors.

The root cause of the problem was https://github.com/icssc/AntAlmanac/pull/548:
```js
Math.round((color.l + delta) * 100 % 100)/100
```
when generating a new close color. This would keep pushing the luminance value higher until it would rollover, creating extremely bright and dark section colors.

---

The tweaking of HSL seems hacky, especially considering that luminance does not accurately represent how the human eye perceives light. 

I have changed the color generation so it uses MUI colors only. This will also make it significantly easier to add custom themes in the future.

<table>
  <tr>
    <th>Old</th>
<th>
    
<img height="400" alt="Schedule-old" src="https://github.com/user-attachments/assets/90b58fb7-c2fa-4288-b49e-64d1e105327b" />

</th>
  </tr>
  <tr>
     <th>New</th>
<th>
<img height="400" alt="Schedule-new" src="https://github.com/user-attachments/assets/9a7e3739-0dac-41db-9fb8-8f295b35c49b" />

</th>
  </tr>
</table>


In my testing, one other difference is that if the user picks a custom color, any other sections in the same course that are added will also share the same custom color, instead of a close color. I believe this is for the better as the luminance tweaking inherently creates UI/accessibility problems.


My code also has the added benefit of keeping the color consistent when re-adding the same classes.
## Test Plan
Refer to reproduction in #1321
## Issues

Closes #1321

## Future Followup
https://github.com/icssc/AntAlmanac/pull/1326 is likely not necessary.
