### PR TITLE
Feat: Async courses added dialogue on Calendar

### DIFF
--- a/apps/antalmanac/src/components/Calendar/AsyncCalendarCard.tsx
+++ b/apps/antalmanac/src/components/Calendar/AsyncCalendarCard.tsx
@@ -1,0 +1,124 @@
+import { List, ListItem, ListItemText, Stack,  Collapse, IconButton, AlertTitle, Snackbar, Alert } from '@mui/material';
+import { ExpandMore, InfoOutlined } from '@mui/icons-material';
+import { useEffect, useMemo, useState } from 'react';
+import AppStore from '$stores/AppStore';
+
+interface TbaSection {
+  courseTitle: string;
+  sectionCode: string;
+}
+
+const COLLAPSE_KEY = (idx: number | null | undefined) =>
+  `aa:tbaSnack:collapsed:${idx ?? 'none'}`;
+
+export default function AsyncCalendarCard() {
+  const [rev, setRev] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Re-renders
+  useEffect(() => {
+    const bump = () => setRev(v => v + 1);
+    AppStore.on('addedCoursesChange', bump);
+    AppStore.on('removedCoursesChange', bump);
+    AppStore.on('clearSchedule', bump);
+    AppStore.on('currentScheduleIndexChange', bump);
+    return () => {
+      AppStore.off('addedCoursesChange', bump);
+      AppStore.off('removedCoursesChange', bump);
+      AppStore.off('clearSchedule', bump);
+      AppStore.off('currentScheduleIndexChange', bump);
+    };
+  }, []);
+
+  const scheduleIndex = AppStore.getCurrentScheduleIndex();
+
+  // Restore per-schedule collapsed preference
+  useEffect(() => {
+    const wasCollapsed = localStorage.getItem(COLLAPSE_KEY(scheduleIndex)) === '1';
+    setCollapsed(wasCollapsed);
+  }, [scheduleIndex]);
+
+  // Compute TBA entries for the current schedule context
+  const tbaSections: TbaSection[] = useMemo(() => {
+    if (scheduleIndex == null) return [];
+    const courses = AppStore.schedule.getCurrentCourses();
+    const flagged: TbaSection[] = [];
+    for (const course of courses) {
+      const section = course.section;
+      if (!section) continue;
+      const meetings = section.meetings ?? [];
+      if (meetings.some((m) => m.timeIsTBA)) {
+        flagged.push({
+          courseTitle: course.courseTitle,
+          sectionCode: section.sectionCode,
+        });
+      }
+    }
+    return flagged;
+  }, [rev, scheduleIndex]);
+
+  // Open/close behavior driven by TBA presence + dismissal flag
+  useEffect(() => {
+    setOpen(tbaSections.length > 0);
+  }, [tbaSections]);
+
+  if (tbaSections.length === 0) return null;
+
+  const handleToggleCollapse = () => {
+    setCollapsed(prev => {
+      const next = !prev;
+      localStorage.setItem(COLLAPSE_KEY(scheduleIndex), next ? '1' : '0');
+      return next;
+    });
+  };
+
+  return (
+    <Snackbar
+      key={`tba-${scheduleIndex}`}
+      open={open}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      autoHideDuration={null}
+      sx={{ 
+        zIndex: theme => theme.zIndex.snackbar - 1, 
+        transform: 'translate(40px)'
+    }}
+    >
+      <Alert
+        icon={<InfoOutlined fontSize="small" />}
+        severity="info"
+        variant="outlined"
+        sx={{
+          bgcolor: 'rgba(255,255,255,0.9)',
+          backdropFilter: 'blur(6px)',
+          py: collapsed ? 0.5 : 0.75,
+          px: 1,
+        }}
+        action={
+        <IconButton size="small" aria-label="toggle details" onClick={handleToggleCollapse}>
+            {collapsed ? <ExpandMore fontSize="small" /> : <ExpandMore fontSize="small" style={{ transform: 'rotate(180deg)' }} />}
+        </IconButton>
+        }
+      >
+        <AlertTitle sx={{ mb: collapsed ? 0 : 1, pr: 0.5 }}>
+          You’ve got classes with TBA times
+        </AlertTitle>
+
+        <Collapse in={!collapsed} timeout="auto" unmountOnExit>
+          <List dense disablePadding sx={{mt: 0.25, py: 0.25}}>
+            {tbaSections.map((c, idx) => (
+              <ListItem key={`${c.courseTitle}-${c.sectionCode}-${idx}`} sx={{ py: 0.25 }}>
+                <ListItemText
+                  primary={`${c.courseTitle} — ${c.sectionCode}`}
+                  secondary="TBA time"
+                  primaryTypographyProps={{ variant: 'body2' }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Collapse>
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/apps/antalmanac/src/components/Calendar/AsyncCalendarCard.tsx
+++ b/apps/antalmanac/src/components/Calendar/AsyncCalendarCard.tsx
@@ -1,15 +1,12 @@
-import { List, ListItem, ListItemText, Collapse, IconButton, Alert, AlertTitle, Box } from '@mui/material';
+import { Collapse, IconButton, Alert, AlertTitle, Box, Typography } from '@mui/material';
 import { ExpandMore, InfoOutlined } from '@mui/icons-material';
 import { useEffect, useMemo, useState } from 'react';
 import AppStore from '$stores/AppStore';
+import { getLocalStorageTbaCollapsed, setLocalStorageTbaCollapsed } from '$lib/localStorage';
 
 interface TbaSection {
   courseTitle: string;
   sectionCode: string;
-}
-
-function getCollapseKey(scheduleIndex: number | null | undefined): string {
-  return `aa:tbaSnack:collapsed:${scheduleIndex ?? 'none'}`;
 }
 
 export default function AsyncCalendarCard() {
@@ -34,7 +31,7 @@ export default function AsyncCalendarCard() {
   }, []);
 
   useEffect(() => {
-    const storedValue = localStorage.getItem(getCollapseKey(scheduleIndex));
+    const storedValue = getLocalStorageTbaCollapsed(scheduleIndex);
     setCollapsed(storedValue === '1');
   }, [scheduleIndex]);
 
@@ -65,14 +62,14 @@ export default function AsyncCalendarCard() {
   useEffect(() => {
     if (visible) {
       setCollapsed(false);
-      localStorage.setItem(getCollapseKey(scheduleIndex), '0');
+      setLocalStorageTbaCollapsed(scheduleIndex, '0');
     }
   }, [visible, scheduleIndex]);
 
   const handleToggleCollapse = () => {
     setCollapsed((prev) => {
       const newValue = !prev;
-      localStorage.setItem(getCollapseKey(scheduleIndex), newValue ? '1' : '0');
+      setLocalStorageTbaCollapsed(scheduleIndex, newValue ? '1' : '0');
       return newValue;
     });
   };
@@ -107,21 +104,17 @@ export default function AsyncCalendarCard() {
         }
       >
         <AlertTitle sx={{ fontSize: '1em' }}>
-          You've got sections with TBA times:
+          Sections with TBA times added:
         </AlertTitle>
 
         <Collapse in={!collapsed} timeout="auto" unmountOnExit>
-          <List dense disablePadding sx={{ mt: 0.25, py: 0.25 }}>
+          <Box sx={{ mt: 0.25, py: 0.25 }}>
             {tbaSections.map((section, idx) => (
-              <ListItem key={`${section.courseTitle}-${section.sectionCode}-${idx}`} sx={{ py: 0.25 }}>
-                <ListItemText
-                  primary={`${section.courseTitle} — ${section.sectionCode}`}
-                  primaryTypographyProps={{ variant: 'body2' }}
-                  sx={{ my: 0 }}
-                />
-              </ListItem>
+              <Typography key={`${section.courseTitle}-${section.sectionCode}-${idx}`} variant="body2" sx={{ py: 0.25 }}>
+                {section.courseTitle} — {section.sectionCode}
+              </Typography>
             ))}
-          </List>
+          </Box>
         </Collapse>
       </Alert>
     </Box>

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -18,6 +18,7 @@ import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
+import AsyncCalendarCard from './AsyncCalendarCard';
 
 /*
  * Always start week on Saturday for finals potentially on weekends.
@@ -218,6 +219,7 @@ export const ScheduleCalendar = memo(() => {
             >
                 <CircularProgress color="inherit" />
             </Backdrop>
+            <AsyncCalendarCard />
             <CalendarToolbar
                 currentScheduleIndex={currentScheduleIndex}
                 toggleDisplayFinalsSchedule={toggleDisplayFinalsSchedule}

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -20,6 +20,7 @@ enum LocalStorageKeys {
     newUser = 'newUser',
     importedUser = 'importedUser',
     fromLoading = 'fromLoading',
+    tbaSnackCollapsed = 'tbaSnackCollapsed',
 }
 
 const LSK = LocalStorageKeys;
@@ -267,4 +268,17 @@ export function setLocalStoragePWADismissalTime(value: string) {
 
 export function getLocalStoragePWADismissalTime() {
     return window.localStorage.getItem(LSK.pwaDismissalTime);
+}
+
+// Helper functions for tbaSnackCollapsed
+export function getTbaCollapsedKey(scheduleIndex: number | null | undefined): string {
+    return `${LSK.tbaSnackCollapsed}${scheduleIndex ?? 'none'}`;
+}
+
+export function getLocalStorageTbaCollapsed(scheduleIndex: number | null | undefined) {
+    return window.localStorage.getItem(getTbaCollapsedKey(scheduleIndex));
+}
+
+export function setLocalStorageTbaCollapsed(scheduleIndex: number | null | undefined, value: string) {
+    window.localStorage.setItem(getTbaCollapsedKey(scheduleIndex), value);
 }


### PR DESCRIPTION
## Summary
When a user adds Async sections to their schedule, a collapsible dialogue is now added to the bottom right of their calendar.
Alternative to #1310 that's less blaring to the user.
<img width="2249" height="1373" alt="image" src="https://github.com/user-attachments/assets/744f559d-e3ac-40ff-89f1-6c53319c0cba" />

When screenshotted:
<img width="767" height="938" alt="image" src="https://github.com/user-attachments/assets/3f1b8f4d-e3f3-4ae1-9888-603ac8f3240f" />

## Test Plan
- [ ] Add/remove TBA time sections
- [ ] Add to multiple schedules and switch through them aimlessly

## Issues
- Could argue that its going to block an event on Friday night but tbh no one has anything there anyways

Closes #1181 

<!-- [Optional]
## Future Followup
-->
