### PR TITLE
Fix: Mobile UI Start

### DIFF
--- a/apps/antalmanac/src/App.css
+++ b/apps/antalmanac/src/App.css
@@ -21,3 +21,10 @@
         scrollbar-width: none;
     }
 }
+
+/* Ensure snackbars sit above the mobile navigation tabs */
+@media (max-width: 600px) {
+    .notification-snackbar-container {
+        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 64px) !important;
+    }
+}

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -118,7 +118,7 @@ export default function App() {
                             }),
                         }}
                     >
-                        <SnackbarProvider>
+                        <SnackbarProvider classes={{ containerRoot: 'notification-snackbar-container' }}>
                             <RouterProvider router={ROUTER} />
                         </SnackbarProvider>
                     </TourProvider>

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
@@ -75,24 +75,6 @@ export function ScheduleManagement() {
         }
 
         setActiveTab('search');
-
-        const tryToShowCalendar = () => {
-            if (!hasLocalScheduleData()) {
-                return;
-            }
-
-            setActiveTab('calendar');
-            AppStore.off('addedCoursesChange', tryToShowCalendar);
-            AppStore.off('customEventsChange', tryToShowCalendar);
-        };
-
-        AppStore.on('addedCoursesChange', tryToShowCalendar);
-        AppStore.on('customEventsChange', tryToShowCalendar);
-
-        return () => {
-            AppStore.off('addedCoursesChange', tryToShowCalendar);
-            AppStore.off('customEventsChange', tryToShowCalendar);
-        };
         // NB: We disable exhaustive deps here as `tab` is a dependency, but we only want this effect to run on mount
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isMobile, setActiveTab]);

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import { ScheduleManagementContent } from '$components/ScheduleManagement/ScheduleManagementContent';
 import { ScheduleManagementTabs } from '$components/ScheduleManagement/ScheduleManagementTabs';
-import { getLocalStorageUserId } from '$lib/localStorage';
+import { getLocalStorageSessionId } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';
 import { paramsAreInURL } from '$stores/CoursePaneStore';
 import { useTabStore } from '$stores/TabStore';
@@ -50,7 +50,7 @@ export function ScheduleManagement() {
             return;
         }
 
-        const userId = getLocalStorageUserId();
+        const sessionId = getLocalStorageSessionId();
         const urlHasManualSearchParams = paramsAreInURL();
         const hasLocalScheduleData = () =>
             AppStore.getAddedCourses().length > 0 || AppStore.getCustomEvents().length > 0;
@@ -61,7 +61,7 @@ export function ScheduleManagement() {
         }
 
         if (!isMobile) {
-            if (userId === null) {
+            if (sessionId === null) {
                 setActiveTab('search');
             } else {
                 setActiveTab('added');
@@ -69,7 +69,7 @@ export function ScheduleManagement() {
             return;
         }
 
-        if (userId !== null || hasLocalScheduleData()) {
+        if (sessionId !== null || hasLocalScheduleData()) {
             setActiveTab('calendar');
             return;
         }

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -50,8 +50,6 @@ class AppStore extends EventEmitter {
 
     skeletonMode: boolean;
 
-    private static readonly DEFAULT_SNACKBAR_DURATION = 3000;
-
     constructor() {
         super();
         this.setMaxListeners(300);
@@ -60,7 +58,7 @@ class AppStore extends EventEmitter {
         this.colorPickers = {};
         this.snackbarMessage = '';
         this.snackbarVariant = 'info';
-        this.snackbarDuration = AppStore.DEFAULT_SNACKBAR_DURATION;
+        this.snackbarDuration = 3000;
         this.snackbarPosition = { vertical: 'bottom', horizontal: 'left' };
         this.snackbarStyle = {};
         this.eventsInCalendar = [];
@@ -467,7 +465,7 @@ class AppStore extends EventEmitter {
     ) {
         this.snackbarVariant = variant;
         this.snackbarMessage = message;
-        this.snackbarDuration = duration != null ? duration * 1000 : AppStore.DEFAULT_SNACKBAR_DURATION;
+        this.snackbarDuration = duration != null ? duration * 1000 : 3000;
         this.snackbarPosition = position ? position : this.snackbarPosition;
         this.snackbarStyle = style ? style : this.snackbarStyle;
         this.emit('openSnackbar');

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -50,6 +50,8 @@ class AppStore extends EventEmitter {
 
     skeletonMode: boolean;
 
+    private static readonly DEFAULT_SNACKBAR_DURATION = 3000;
+
     constructor() {
         super();
         this.setMaxListeners(300);
@@ -58,7 +60,7 @@ class AppStore extends EventEmitter {
         this.colorPickers = {};
         this.snackbarMessage = '';
         this.snackbarVariant = 'info';
-        this.snackbarDuration = 3000;
+        this.snackbarDuration = AppStore.DEFAULT_SNACKBAR_DURATION;
         this.snackbarPosition = { vertical: 'bottom', horizontal: 'left' };
         this.snackbarStyle = {};
         this.eventsInCalendar = [];
@@ -465,7 +467,7 @@ class AppStore extends EventEmitter {
     ) {
         this.snackbarVariant = variant;
         this.snackbarMessage = message;
-        this.snackbarDuration = duration ? duration : this.snackbarDuration;
+        this.snackbarDuration = duration != null ? duration * 1000 : AppStore.DEFAULT_SNACKBAR_DURATION;
         this.snackbarPosition = position ? position : this.snackbarPosition;
         this.snackbarStyle = style ? style : this.snackbarStyle;
         this.emit('openSnackbar');


### PR DESCRIPTION
## Summary
- Move mobile snackbars above the bottom navigation bar for better visibility.
- Fix snackbar duration conversion from seconds to milliseconds so they display for the intended time.
- Update mobile initial tab routing so users with saved/loaded schedules land on **Calendar** instead of **Search**.

## Test Plan
- Snackbar Positioning

- Mobile Tab Routing
  - With `userID` in `localStorage`: reload on mobile → **Calendar** selected by default.
  - Without `userID`: reload on mobile → **Search** selected by default.
  - With loaded schedule data: add a course, open new mobile tab → **Calendar** if data persists, otherwise **Search**.

## Issues 
Closes #1316 
