### PR TITLE
fix: Enrollment History Dates

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/EnrollmentHistoryPopup.tsx
@@ -1,5 +1,5 @@
 import { ArrowBack, ArrowForward } from '@mui/icons-material';
-import { Box, IconButton, Link, Typography, Skeleton, Tooltip, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Typography, Skeleton, Tooltip, useMediaQuery } from '@mui/material';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
     LineChart,
@@ -95,7 +95,6 @@ export function EnrollmentHistoryPopup({ department, courseNumber }: EnrollmentH
         } | ${currEnrollmentHistory.instructors.join(', ')}`;
     }, [courseNumber, department, enrollmentHistory, graphIndex]);
     const isDark = useThemeStore((state) => state.isDark);
-    const encodedDept = useMemo(() => encodeURIComponent(department), [department]);
     const axisColor = isDark ? '#fff' : '#111';
     const tooltipDateColor = '#111';
 
@@ -153,12 +152,7 @@ export function EnrollmentHistoryPopup({ department, courseNumber }: EnrollmentH
                 popupTitle={popupTitle}
                 enrollmentHistory={enrollmentHistory}
             />
-            <Link
-                href={`https://zot-tracker.herokuapp.com/?dept=${encodedDept}&number=${courseNumber}&courseType=all`}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={{ display: 'flex', height: graphHeight, width: graphWidth }}
-            >
+            <Box sx={{ display: 'flex', height: graphHeight, width: graphWidth }}>
                 <ResponsiveContainer width="95%" height="95%">
                     <LineChart data={lineChartData} style={{ cursor: 'pointer' }}>
                         <CartesianGrid strokeDasharray="3 3" />
@@ -171,7 +165,7 @@ export function EnrollmentHistoryPopup({ department, courseNumber }: EnrollmentH
                         <Line type="monotone" dataKey="waitlist" stroke="#ffc658" name="Waitlist" dot={{ r: 2 }} />
                     </LineChart>
                 </ResponsiveContainer>
-            </Link>
+            </Box>
         </Box>
     );
 }

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -89,16 +89,15 @@ export class DepartmentEnrollmentHistory {
             const enrollmentDays: EnrollmentHistoryDay[] = [];
 
             for (const [i, dateString] of enrollmentHistory.dates.entries()) {
-                const [day = '', month = '', year = ''] = dateString.split('-');
-                const date = new Date(Number(day), Number(month), Number(year));
-                const formattedDate = `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+                const date = new Date(dateString); // dateString is formatted YYYY-MM-DD
+                const formattedDateString = date.toLocaleDateString();
 
                 enrollmentDays.push({
-                    date: formattedDate,
+                    date: formattedDateString,
                     totalEnrolled: Number(enrollmentHistory.totalEnrolledHistory[i]),
                     maxCapacity: Number(enrollmentHistory.maxCapacityHistory[i]),
                     waitlist:
-                        enrollmentHistory.waitlistHistory[i] === 'n/a'
+                        enrollmentHistory.waitlistHistory[i] === '-1'
                             ? null
                             : Number(enrollmentHistory.waitlistHistory[i]),
                 });


### PR DESCRIPTION
## Summary

The API returns dates in YYYY-MM-DD, but `new Date(day, month, year)` uses zero indexing. This creates a problem where the day and month are both one ahead.

Instead of breaking the date apart, it can be passed directly into the Date function.
When displaying the date, it now uses the browser's `toLocaleDateString` which accomplishes the same thing as before. As a side effect, it could also provide some level of localization if the user uses a different language.

I removed the ZotTracker link since the data hasn't been updated for a while now.
The API also seems to return "-1", which makes no sense in terms of waitlist numbers so they are now filtered out. "n/a" doesn't appear to be a response that the API gives anymore and I presume it was replaced with "-1".

## Test Plan
Check any course with enrollment history.

Current:
<img width="445" height="275" alt="image" src="https://github.com/user-attachments/assets/c235dd79-9fb7-4d3c-902f-640ce6fe7691" />

Fixed:
<img width="450" height="288" alt="image" src="https://github.com/user-attachments/assets/a7141d19-e934-4a81-bb1e-52133f93dd21" />

## Issues

The exact opposite problem of https://github.com/icssc/AntAlmanac/pull/1189