### PR TITLE
Feat: Add Missing Sections Warning

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -42,7 +42,6 @@ export const addCourse = (
 
     if (terms.size > 1 && !quiet) warnMultipleTerms(terms);
 
-    console.log('Making new Course');
     // The color will be set properly in Schedules
     const newCourse: ScheduleCourse = {
         term: term,
@@ -54,11 +53,6 @@ export const addCourse = (
         section: { ...section, color: '' },
         sectionTypes: courseDetails.sectionTypes,
     };
-    console.log('newCourse :', newCourse);
-    console.log('Course section types: ', courseDetails.sectionTypes);
-    console.log('Is set? ', newCourse.sectionTypes instanceof Set);
-    console.log('Size: ', newCourse.sectionTypes.size);
-    console.log('Values:', [...newCourse.sectionTypes]);
 
     return AppStore.addCourse(newCourse, scheduleIndex);
 };

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -51,6 +51,7 @@ export const addCourse = (
         courseComment: courseDetails.courseComment,
         prerequisiteLink: courseDetails.prerequisiteLink,
         section: { ...section, color: '' },
+        sectionTypes: courseDetails.sectionTypes,
     };
 
     return AppStore.addCourse(newCourse, scheduleIndex);

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -42,6 +42,7 @@ export const addCourse = (
 
     if (terms.size > 1 && !quiet) warnMultipleTerms(terms);
 
+    console.log('Making new Course');
     // The color will be set properly in Schedules
     const newCourse: ScheduleCourse = {
         term: term,
@@ -53,6 +54,11 @@ export const addCourse = (
         section: { ...section, color: '' },
         sectionTypes: courseDetails.sectionTypes,
     };
+    console.log('newCourse :', newCourse);
+    console.log('Course section types: ', courseDetails.sectionTypes);
+    console.log('Is set? ', newCourse.sectionTypes instanceof Set);
+    console.log('Size: ', newCourse.sectionTypes.size);
+    console.log('Values:', [...newCourse.sectionTypes]);
 
     return AppStore.addCourse(newCourse, scheduleIndex);
 };

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -421,8 +421,20 @@ function AddedSectionsGrid() {
                                 missingLabels.push('Lecture');
                             } else if (section === 'sem') {
                                 missingLabels.push('Seminar');
-                            } else if (section === 'rec') {
-                                missingLabels.push('Recitation');
+                            } else if (section === 'res') {
+                                missingLabels.push('Research');
+                            } else if (section == 'qiz') {
+                                missingLabels.push('Quiz');
+                            } else if (section == 'tap') {
+                                missingLabels.push('Tutorial Assistance Program');
+                            } else if (section == 'col') {
+                                missingLabels.push('Colloquium');
+                            } else if (section == 'act') {
+                                missingLabels.push('Activity');
+                            } else if (section == 'stu') {
+                                missingLabels.push('Studio');
+                            } else if (section == 'tut') {
+                                missingLabels.push('Tutorial');
                             }
                         }
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -38,40 +38,21 @@ const NOTE_MAX_LEN = 5000;
 
 //Checks added courses for missing sections
 const checkCompleteSections = (userCourses: CourseWithTerm): string[] => {
-    try {
-        console.log('aaaaaa user course section Types: ', userCourses.sectionTypes);
-        //Get required types from stored section types
-        const requiredTypes = userCourses.sectionTypes
-            ? new Set([...userCourses.sectionTypes].map((t) => t.toLowerCase()))
-            : new Set<string>();
-        console.log('Required Types:', requiredTypes);
+    //Get required types from stored section types
+    const requiredTypes = userCourses.sectionTypes
+        ? new Set([...userCourses.sectionTypes].map((t) => t.toLowerCase()))
+        : new Set<string>();
 
-        //Get the section types the user has added
-        const userTypes = new Set(userCourses.sections.map((section) => section.sectionType.trim().toLowerCase()));
-        console.log('User Types:', userTypes);
-        //Compare types the user added with the required types
-        const missingTypes = [...requiredTypes].filter((type) => !userTypes.has(type));
-        console.log('Missing Types:', missingTypes);
+    //Get the section types the user has added
+    const userTypes = new Set(userCourses.sections.map((section) => section.sectionType.trim().toLowerCase()));
+    //Compare types the user added with the required types
+    const missingTypes = [...requiredTypes].filter((type) => !userTypes.has(type));
 
-        return missingTypes;
-    } catch (error) {
-        console.error(error);
-        return [];
-    }
+    return missingTypes;
 };
 
 function getCourses() {
     const currentCourses = AppStore.schedule.getCurrentCourses();
-    console.log('Current Courses:', currentCourses);
-    console.log('Current Courses Length:', currentCourses.length);
-    console.log(
-        'Current Courses Section Types:',
-        currentCourses.map((c) => c.sectionTypes)
-    );
-    console.log(
-        'Current Courses Section Types Details:',
-        currentCourses.map((c) => [...c.sectionTypes])
-    );
 
     const formattedCourses: CourseWithTerm[] = [];
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -408,31 +408,31 @@ function AddedSectionsGrid() {
                     {courses.map((course) => {
                         const courseKey = `${course.deptCode}${course.courseNumber}`;
                         const missing = missingTypes[courseKey] || [];
-                        const missingLabels = [];
+                        const missingSections = [];
 
                         for (const section of missing) {
                             if (section === 'dis') {
-                                missingLabels.push('Discussion');
+                                missingSections.push('Discussion');
                             } else if (section === 'lab') {
-                                missingLabels.push('Lab');
+                                missingSections.push('Lab');
                             } else if (section === 'lec') {
-                                missingLabels.push('Lecture');
+                                missingSections.push('Lecture');
                             } else if (section === 'sem') {
-                                missingLabels.push('Seminar');
+                                missingSections.push('Seminar');
                             } else if (section === 'res') {
-                                missingLabels.push('Research');
+                                missingSections.push('Research');
                             } else if (section == 'qiz') {
-                                missingLabels.push('Quiz');
+                                missingSections.push('Quiz');
                             } else if (section == 'tap') {
-                                missingLabels.push('Tutorial Assistance Program');
+                                missingSections.push('Tutorial Assistance Program');
                             } else if (section == 'col') {
-                                missingLabels.push('Colloquium');
+                                missingSections.push('Colloquium');
                             } else if (section == 'act') {
-                                missingLabels.push('Activity');
+                                missingSections.push('Activity');
                             } else if (section == 'stu') {
-                                missingLabels.push('Studio');
+                                missingSections.push('Studio');
                             } else if (section == 'tut') {
-                                missingLabels.push('Tutorial');
+                                missingSections.push('Tutorial');
                             }
                         }
 
@@ -444,7 +444,7 @@ function AddedSectionsGrid() {
                                     allowHighlight={false}
                                     analyticsCategory={analyticsEnum.addedClasses}
                                     scheduleNames={scheduleNames}
-                                    missingSections={missingLabels}
+                                    missingSections={missingSections}
                                 />
                             </Box>
                         );
@@ -467,8 +467,6 @@ export function AddedCoursePane() {
         const handleSkeletonModeChange = () => {
             setSkeletonMode(AppStore.getSkeletonMode());
         };
-
-        console.log('Opened added course');
 
         logAnalytics(postHog, {
             category: analyticsEnum.addedClasses,

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, Alert } from '@mui/material';
+import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -428,17 +428,13 @@ function AddedSectionsGrid() {
 
                         return (
                             <Box key={course.deptCode + course.courseNumber + course.courseTitle}>
-                                {missing.length > 0 && (
-                                    <Alert severity="warning" sx={{ mb: 1 }}>
-                                        Missing required sections: {missingLabels.join(',')}
-                                    </Alert>
-                                )}
                                 <SectionTableLazyWrapper
                                     courseDetails={course}
                                     term={course.term}
                                     allowHighlight={false}
                                     analyticsCategory={analyticsEnum.addedClasses}
                                     scheduleNames={scheduleNames}
+                                    missingSections={missingLabels}
                                 />
                             </Box>
                         );

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,5 +1,5 @@
 import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography } from '@mui/material';
-import { AACourse } from '@packages/antalmanac-types';
+import { AACourse, WebsocSectionType } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -41,7 +41,7 @@ const checkCompleteSections = (userCourses: CourseWithTerm): string[] => {
     //Get required types from stored section types
     const requiredTypes = userCourses.sectionTypes
         ? new Set([...userCourses.sectionTypes].map((t) => t.toLowerCase()))
-        : new Set<string>();
+        : new Set<WebsocSectionType>();
 
     //Get the section types the user has added
     const userTypes = new Set(userCourses.sections.map((section) => section.sectionType.trim().toLowerCase()));

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -306,7 +306,6 @@ function AddedSectionsGrid() {
     const [courses, setCourses] = useState(getCourses());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
-    const [missingTypes, setMissingTypes] = useState<Record<string, string[]>>({});
 
     useEffect(() => {
         const handleCoursesChange = () => {
@@ -333,25 +332,6 @@ function AddedSectionsGrid() {
             AppStore.off('currentScheduleIndexChange', handleScheduleIndexChange);
         };
     }, []);
-
-    //Check for any missing sections for each added course
-    useEffect(() => {
-        const checkCourses = async () => {
-            const missing: Record<string, string[]> = {};
-
-            //Check the sections in every course the user has scheduled
-            for (const course of courses) {
-                const courseKey = `${course.deptCode}${course.courseNumber}`;
-                const missingSections = await checkCompleteSections(course);
-                missing[courseKey] = missingSections;
-            }
-
-            setMissingTypes(missing);
-        };
-        if (courses.length > 0) {
-            checkCourses();
-        }
-    }, [courses]);
 
     const scheduleUnits = useMemo(() => {
         let result = 0;
@@ -390,35 +370,35 @@ function AddedSectionsGrid() {
                 {courses.length < 1 ? NoCoursesBox : null}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
-                        const courseKey = `${course.deptCode}${course.courseNumber}`;
-                        const missing = missingTypes[courseKey] || [];
-                        const missingSections = [];
-
-                        for (const section of missing) {
-                            if (section === 'dis') {
-                                missingSections.push('Discussion');
-                            } else if (section === 'lab') {
-                                missingSections.push('Lab');
-                            } else if (section === 'lec') {
-                                missingSections.push('Lecture');
-                            } else if (section === 'sem') {
-                                missingSections.push('Seminar');
-                            } else if (section === 'res') {
-                                missingSections.push('Research');
-                            } else if (section == 'qiz') {
-                                missingSections.push('Quiz');
-                            } else if (section == 'tap') {
-                                missingSections.push('Tutorial Assistance Program');
-                            } else if (section == 'col') {
-                                missingSections.push('Colloquium');
-                            } else if (section == 'act') {
-                                missingSections.push('Activity');
-                            } else if (section == 'stu') {
-                                missingSections.push('Studio');
-                            } else if (section == 'tut') {
-                                missingSections.push('Tutorial');
+                        const missing = checkCompleteSections(course);
+                        const missingSections = missing.map((section) => {
+                            switch (section) {
+                                case 'dis':
+                                    return 'Discussion';
+                                case 'lab':
+                                    return 'Lab';
+                                case 'lec':
+                                    return 'Lecture';
+                                case 'sem':
+                                    return 'Seminar';
+                                case 'res':
+                                    return 'Research';
+                                case 'qiz':
+                                    return 'Quiz';
+                                case 'tap':
+                                    return 'Tutorial Assistance Program';
+                                case 'col':
+                                    return 'Colloquium';
+                                case 'act':
+                                    return 'Activity';
+                                case 'stu':
+                                    return 'Studio';
+                                case 'tut':
+                                    return 'Tutorial';
+                                default:
+                                    return section;
                             }
-                        }
+                        });
 
                         return (
                             <Box key={course.deptCode + course.courseNumber + course.courseTitle}>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -385,7 +385,7 @@ export function AddedCoursePane() {
             setSkeletonMode(AppStore.getSkeletonMode());
         };
 
-        console.log('Opened added ourse');
+        console.log('Opened added course');
 
         logAnalytics(postHog, {
             category: analyticsEnum.addedClasses,

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -47,8 +47,6 @@ const checkCompleteSections = async (userCourses: CourseWithTerm): Promise<strin
         };
 
         const fullCourseData = await WebSOC.query(websocParams);
-        console.log('hi');
-        console.log(fullCourseData);
 
         const sections = fullCourseData?.schools?.[0]?.departments?.[0]?.courses?.[0]?.sections;
 
@@ -353,7 +351,6 @@ function AddedSectionsGrid() {
             AppStore.off('currentScheduleIndexChange', handleScheduleIndexChange);
         };
     }, []);
-    console.log('Courses: ' + courses);
 
     //Check for any missing sections for each added course
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -81,8 +81,6 @@ function getCourses() {
                 needleCourse.courseTitle === course.courseTitle
         );
 
-        //If the course already exists (if the user is already taking a section of this course),
-        //then group them together so they display on top of each other
         if (formattedCourse) {
             formattedCourse.sections.push({
                 ...course.section,

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -16,7 +16,6 @@ import { clickToCopy } from '$lib/helpers';
 import { WebSOC } from '$lib/websoc';
 import AppStore from '$stores/AppStore';
 
-
 /**
  * All the interactive buttons have the same styles.
  */
@@ -416,7 +415,7 @@ function AddedSectionsGrid() {
                         const missing = missingTypes[courseKey] || [];
                         const missingLabels = [];
 
-                        for (const section in missing) {
+                        for (const section of missing) {
                             if (section === 'dis') {
                                 missingLabels.push('Discussion');
                             } else if (section === 'lab') {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
@@ -1,0 +1,41 @@
+import { CourseWithTerm } from './AddedCoursePane';
+
+export const getMissingSections = (userCourses: CourseWithTerm): string[] => {
+    //Get required types from stored section types
+    const requiredTypes = userCourses.sectionTypes;
+    //Get the section types the user has added
+    const userTypes = new Set(userCourses.sections.map((section) => section.sectionType));
+    //Compare types the user added with the required types
+    const missingTypes = [...requiredTypes].filter((type) => !userTypes.has(type));
+    const missingSections = missingTypes.map((section) => {
+        switch (section) {
+            case 'Dis':
+                return 'Discussion';
+            case 'Lab':
+                return 'Lab';
+            case 'Lec':
+                return 'Lecture';
+            case 'Sem':
+                return 'Seminar';
+            case 'Res':
+                return 'Research';
+            case 'Qiz':
+                return 'Quiz';
+            case 'Tap':
+                return 'Tutorial Assistance Program';
+            case 'Col':
+                return 'Colloquium';
+            case 'Act':
+                return 'Activity';
+            case 'Stu':
+                return 'Studio';
+            case 'Tut':
+                return 'Tutorial';
+            case 'Fld':
+                return 'Fieldwork';
+            default:
+                return section;
+        }
+    });
+    return missingSections;
+};

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
@@ -1,4 +1,4 @@
-import { CourseWithTerm } from './AddedCoursePane';
+import { CourseWithTerm } from '$components/RightPane/AddedCourses/AddedCoursePane';
 
 export const getMissingSections = (userCourses: CourseWithTerm): string[] => {
     const requiredTypes = userCourses.sectionTypes;

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
@@ -1,11 +1,8 @@
 import { CourseWithTerm } from './AddedCoursePane';
 
 export const getMissingSections = (userCourses: CourseWithTerm): string[] => {
-    //Get required types from stored section types
     const requiredTypes = userCourses.sectionTypes;
-    //Get the section types the user has added
     const userTypes = new Set(userCourses.sections.map((section) => section.sectionType));
-    //Compare types the user added with the required types
     const missingTypes = [...requiredTypes].filter((type) => !userTypes.has(type));
     const missingSections = missingTypes.map((section) => {
         switch (section) {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -50,6 +50,15 @@ const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
                 for (const section of course.sections) {
                     (section as AASection).color = courseColors[section.sectionCode];
                 }
+
+                const sectionTypes = new Set<string>();
+                course.sections.forEach((section) => {
+                    sectionTypes.add(section.sectionType);
+                });
+
+                (course as AACourse).sectionTypes = sectionTypes;
+                console.log(`${course.courseTitle}:`, (course as AACourse).sectionTypes);
+
                 accumulator.push(course as AACourse);
             });
         });

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -116,7 +116,7 @@ const RecruitmentBanner = () => {
                         Join ICSSC and work on AntAlmanac and other projects!
                     </a>
                     <br />
-                    We have opportunities for experienced devs and those with zero experience!
+                    We have opportunities for experienced devs and those with zero experience
                 </Alert>
             ) : null}
         </Box>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -1,6 +1,14 @@
 import { Close } from '@mui/icons-material';
 import { Alert, Box, IconButton, Link, useMediaQuery, useTheme } from '@mui/material';
-import { AACourse, AASection, WebsocDepartment, WebsocSchool, WebsocAPIResponse, GE } from '@packages/antalmanac-types';
+import {
+    AACourse,
+    AASection,
+    WebsocDepartment,
+    WebsocSchool,
+    WebsocAPIResponse,
+    GE,
+    WebsocSectionType,
+} from '@packages/antalmanac-types';
 import { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
@@ -51,7 +59,7 @@ const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
                     (section as AASection).color = courseColors[section.sectionCode];
                 }
 
-                const sectionTypes = new Set<string>();
+                const sectionTypes = new Set<WebsocSectionType>();
                 course.sections.forEach((section) => {
                     sectionTypes.add(section.sectionType);
                 });

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -116,7 +116,7 @@ const RecruitmentBanner = () => {
                         Join ICSSC and work on AntAlmanac and other projects!
                     </a>
                     <br />
-                    We have opportunities for experienced devs and those with zero experience
+                    We have opportunities for experienced devs and those with zero experience!
                 </Alert>
             ) : null}
         </Box>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -57,7 +57,6 @@ const flattenSOCObject = (SOCObject: WebsocAPIResponse): (WebsocSchool | WebsocD
                 });
 
                 (course as AACourse).sectionTypes = sectionTypes;
-                console.log(`${course.courseTitle}:`, (course as AACourse).sectionTypes);
 
                 accumulator.push(course as AACourse);
             });

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -155,7 +155,7 @@ function SectionTable(props: SectionTableProps) {
                 />
             </Box>
 
-            {missingSections && missingSections.length > 0 && (
+            {missingSections?.length && (
                 <Alert severity="warning" sx={{ mb: 1 }}>
                     Missing required sections: {missingSections.join(', ')}
                 </Alert>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,5 +1,6 @@
 import { Assessment, ShowChart as ShowChartIcon } from '@mui/icons-material';
 import { Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery } from '@mui/material';
+import { Alert } from '@mui/material';
 import { useMemo } from 'react';
 
 import PeterPortalIcon from '$assets/peterportal-logo.png';
@@ -15,6 +16,7 @@ import analyticsEnum from '$lib/analytics/analytics';
 import { MOBILE_BREAKPOINT } from '$src/globals';
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import { useTabStore } from '$stores/TabStore';
+
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
@@ -68,7 +70,7 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
 const tableHeaderColumnEntries = Object.entries(tableHeaderColumns);
 
 function SectionTable(props: SectionTableProps) {
-    const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory } = props;
+    const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory, missingSections } = props;
 
     const [activeColumns] = useColumnStore((store) => [store.activeColumns]);
     const [activeTab] = useTabStore((store) => [store.activeTab]);
@@ -154,6 +156,12 @@ function SectionTable(props: SectionTableProps) {
                     }
                 />
             </Box>
+
+            {missingSections && missingSections.length > 0 && (
+                <Alert severity="warning" sx={{ mb: 1 }}>
+                    Missing required sections: {missingSections.join(',')}
+                </Alert>
+            )}
 
             <TableContainer
                 component={Paper}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -68,7 +68,7 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
 const tableHeaderColumnEntries = Object.entries(tableHeaderColumns);
 
 function SectionTable(props: SectionTableProps) {
-    const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory, missingSections } = props;
+    const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory, missingSections = [] } = props;
 
     const [activeColumns] = useColumnStore((store) => [store.activeColumns]);
     const [activeTab] = useTabStore((store) => [store.activeTab]);
@@ -155,12 +155,11 @@ function SectionTable(props: SectionTableProps) {
                 />
             </Box>
 
-            {missingSections?.length && (
-                <Alert severity="warning" sx={{ mb: 1 }}>
+            {missingSections?.length > 0 && (
+                <Alert severity="warning" sx={{ mb: 1, backgroundColor: '#fff4e5ff', color: '#856404ff' }}>
                     Missing required sections: {missingSections.join(', ')}
                 </Alert>
             )}
-
             <TableContainer
                 component={Paper}
                 sx={{ margin: '8px 0px 8px 0px', width: '100%' }}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -17,7 +17,6 @@ import { MOBILE_BREAKPOINT } from '$src/globals';
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import { useTabStore } from '$stores/TabStore';
 
-
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
 interface TableHeaderColumnDetails {
@@ -159,7 +158,7 @@ function SectionTable(props: SectionTableProps) {
 
             {missingSections && missingSections.length > 0 && (
                 <Alert severity="warning" sx={{ mb: 1 }}>
-                    Missing required sections: {missingSections.join(',')}
+                    Missing required sections: {missingSections.join(', ')}
                 </Alert>
             )}
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -156,7 +156,7 @@ function SectionTable(props: SectionTableProps) {
             </Box>
 
             {missingSections?.length > 0 && (
-                <Alert severity="warning" sx={{ mb: 1, backgroundColor: '#fff4e5ff', color: '#856404ff' }}>
+                <Alert severity="warning" sx={{ mb: 1 }}>
                     Missing required sections: {missingSections.join(', ')}
                 </Alert>
             )}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,5 +1,5 @@
 import { Assessment, ShowChart as ShowChartIcon } from '@mui/icons-material';
-import { Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery, Alert } from '@mui/material';
+import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery } from '@mui/material';
 import { useMemo } from 'react';
 
 import PeterPortalIcon from '$assets/peterportal-logo.png';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,6 +1,5 @@
 import { Assessment, ShowChart as ShowChartIcon } from '@mui/icons-material';
-import { Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery } from '@mui/material';
-import { Alert } from '@mui/material';
+import { Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow, useMediaQuery, Alert } from '@mui/material';
 import { useMemo } from 'react';
 
 import PeterPortalIcon from '$assets/peterportal-logo.png';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.types.ts
@@ -12,4 +12,5 @@ export interface SectionTableProps {
     allowHighlight: boolean;
     scheduleNames: string[];
     analyticsCategory: AnalyticsCategory;
+    missingSections?: string[];
 }

--- a/apps/antalmanac/src/providers/Theme.tsx
+++ b/apps/antalmanac/src/providers/Theme.tsx
@@ -138,6 +138,14 @@ export default function AppThemeProvider(props: Props) {
                             variant: 'standard',
                         },
                     },
+                    MuiAlert: {
+                        styleOverrides: {
+                            standardWarning: {
+                                backgroundColor: appTheme === 'dark' ? '#fff4e5ff' : '#FFEA99',
+                                color: appTheme === 'dark' ? '#856404ff' : '#302800ff',
+                            },
+                        },
+                    },
                 },
                 breakpoints: {
                     /**

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -122,6 +122,8 @@ class AppStore extends EventEmitter {
         };
         actionTypesStore.autoSaveSchedule(action);
         this.emit('addedCoursesChange');
+        console.log('Added course:', addedCourse);
+        console.log('course.sectionTypes:', addedCourse.sectionTypes);
         return addedCourse;
     }
 

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -122,8 +122,7 @@ class AppStore extends EventEmitter {
         };
         actionTypesStore.autoSaveSchedule(action);
         this.emit('addedCoursesChange');
-        console.log('Added course:', addedCourse);
-        console.log('course.sectionTypes:', addedCourse.sectionTypes);
+
         return addedCourse;
     }
 

--- a/packages/types/src/courseData.ts
+++ b/packages/types/src/courseData.ts
@@ -6,6 +6,7 @@ export interface CourseDetails {
     courseTitle: string;
     courseComment: string;
     prerequisiteLink: string;
+    sectionTypes: Set<string>;
 }
 
 export interface CourseInfo {

--- a/packages/types/src/courseData.ts
+++ b/packages/types/src/courseData.ts
@@ -1,4 +1,4 @@
-import { WebsocSection } from '@packages/anteater-api-types';
+import { WebsocSection, WebsocSectionType } from '@packages/anteater-api-types';
 
 export interface CourseDetails {
     deptCode: string;
@@ -6,7 +6,7 @@ export interface CourseDetails {
     courseTitle: string;
     courseComment: string;
     prerequisiteLink: string;
-    sectionTypes: Set<string>;
+    sectionTypes: Set<WebsocSectionType>;
 }
 
 export interface CourseInfo {

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -1,6 +1,7 @@
 import { type, arrayOf } from 'arktype';
 import { RepeatingCustomEvent, RepeatingCustomEventSchema } from './customevent';
 import { AASection } from './websoc';
+import { WebsocSectionType } from '@packages/anteater-api-types';
 
 export type ScheduleCourse = {
     courseComment: string;
@@ -10,7 +11,7 @@ export type ScheduleCourse = {
     prerequisiteLink: string;
     section: AASection;
     term: string;
-    sectionTypes: Set<string>;
+    sectionTypes: Set<WebsocSectionType>;
 };
 
 export type Schedule = {

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -1,6 +1,7 @@
 import { type, arrayOf } from 'arktype';
 import { RepeatingCustomEvent, RepeatingCustomEventSchema } from './customevent';
-import { AASection, WebsocSectionType } from './websoc';
+import { AASection } from './websoc';
+import { WebsocSectionType } from '@packages/anteater-api-types';
 
 export type ScheduleCourse = {
     courseComment: string;

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -1,7 +1,6 @@
 import { type, arrayOf } from 'arktype';
 import { RepeatingCustomEvent, RepeatingCustomEventSchema } from './customevent';
-import { AASection } from './websoc';
-import { WebsocSectionType } from '@packages/anteater-api-types';
+import { AASection, WebsocSectionType } from './websoc';
 
 export type ScheduleCourse = {
     courseComment: string;

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -10,6 +10,7 @@ export type ScheduleCourse = {
     prerequisiteLink: string;
     section: AASection;
     term: string;
+    sectionTypes: Set<string>;
 };
 
 export type Schedule = {

--- a/packages/types/src/websoc.ts
+++ b/packages/types/src/websoc.ts
@@ -8,6 +8,7 @@ export type AASection = WebsocSection & AASectionExtendedProperties;
 
 type AACourseExtendedProperties = {
     sections: AASection[];
+    sectionTypes: Set<string>;
 };
 
 export type AACourse = Omit<WebsocCourse, 'sections'> & AACourseExtendedProperties;

--- a/packages/types/src/websoc.ts
+++ b/packages/types/src/websoc.ts
@@ -4,8 +4,6 @@ type AASectionExtendedProperties = {
     color: string;
 };
 
-export type { WebsocSectionType };
-
 export type AASection = WebsocSection & AASectionExtendedProperties;
 
 type AACourseExtendedProperties = {

--- a/packages/types/src/websoc.ts
+++ b/packages/types/src/websoc.ts
@@ -1,14 +1,16 @@
-import { WebsocSection, WebsocCourse } from '@packages/anteater-api-types';
+import { WebsocSection, WebsocCourse, WebsocSectionType } from '@packages/anteater-api-types';
 
 type AASectionExtendedProperties = {
     color: string;
 };
 
+export type { WebsocSectionType };
+
 export type AASection = WebsocSection & AASectionExtendedProperties;
 
 type AACourseExtendedProperties = {
     sections: AASection[];
-    sectionTypes: Set<string>;
+    sectionTypes: Set<WebsocSectionType>;
 };
 
 export type AACourse = Omit<WebsocCourse, 'sections'> & AACourseExtendedProperties;


### PR DESCRIPTION
## Summary
Added a warning displaying the missing sections for a course on the added courses page.

When a user selects classes for a course, the required sections for a course are checked (e.g., lecture, lab, discussion) have been added. If any required section type is missing, the UI displays a warning so the user can correct their schedule.

## Test Plan

- Add SOME sections of a course to schedule, and check the added courses tab to verify there is a warning for whichever section is missing
- Add all sections of a course to a schedule. In the added courses tab, ensure there are no warnings, and then delete one of the sections to verify a warning pops up. Add the section back to verify the warning disappears 
- Check UI on both light mode and dark mode
## Issues

Closes #1330

## Before
<img width="1232" height="458" alt="image" src="https://github.com/user-attachments/assets/1874d32a-0a5a-4df5-895d-954ae54293d7" />

## After
<img width="1539" height="1240" alt="image" src="https://github.com/user-attachments/assets/d3149a4c-5fec-435a-9dd8-4b7f83580b6f" />

## Future Followup 

- Could add a hyperlink to the Alert banner that directs the user to the scheduling page for whichever course they have a missing section 
- Could add an alert for if a user schedules two different sections in two different categories (e.g. the user schedules a lecture 'A' but a discussion 'B')
