### PR TITLE
fix: Persist Search Input on Loss of Focus

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -182,6 +182,10 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
         this.setState({ open: false });
     };
 
+    onFocus = () => {
+        this.setState({ open: true });
+    };
+
     render() {
         return (
             <LabeledAutocomplete
@@ -199,11 +203,13 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                     onInputChange: this.onInputChange,
                     open: this.state.open,
                     popupIcon: '',
+                    clearOnBlur: false,
                 }}
                 textFieldProps={{
                     autoFocus: !isMobile(),
                     placeholder: 'Search for courses, departments, GEs...',
                     fullWidth: true,
+                    onFocus: this.onFocus,
                 }}
                 isAligned
             />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -183,7 +183,9 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
     };
 
     onFocus = () => {
-        this.setState({ open: true });
+        if (this.state.value || Object.keys(this.state.results ?? {}).length > 0) {
+            this.setState({ open: true });
+        }
     };
 
     render() {


### PR DESCRIPTION
## Summary
Reopening https://github.com/icssc/AntAlmanac/pull/1302.
Branch of the PR was deleted, created a new branch.

> When using the fuzzy search bar, clicking away would cause the input to clear.
> 
> Steps to reproduce:
> 
> 1. Select "Search"
> 2. Select "Quick Search"
> 3. In the search bar (Where it says 'Search for courses, departments, GEs...'), enter something
> 4. Click anywhere outside of the search bar
> 5. The input disappears

## Test Plan

> Steps to test:
> 
> 1. Select Search
> 2. Select Quick Search
> 3. In the search bar, enter something
> 4. Click anywhere outside the search bar
> 5. The input stays, and the previous search automatically comes up

## Issues

Closes #1301 
