### PR TITLE
Tutorial backdrop Zindex 

### DIFF
--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -69,10 +69,12 @@ export function HelpMenu() {
             }}
             spacing={1}
             alignItems="center"
+            // If there's a higher zIndex than this, then that other zIndex is the real problem
+            zIndex={1000}
         >
             <Backdrop
                 sx={{
-                    zIndex: 1000, // If there's a higher zIndex than this, then that other zIndex is the real problem
+                    zIndex: 'inherit',
                 }}
                 open={open}
                 onClick={handleClose}


### PR DESCRIPTION
## Summary
When we open the help menu, some elements overlay the backdrop

### Before
<img width="1439" height="762" alt="image" src="https://github.com/user-attachments/assets/f88fc169-6ed0-41aa-b8a4-976b28686377" />

### After
<img width="1439" height="762" alt="image" src="https://github.com/user-attachments/assets/12b022fe-8a21-43f4-82f0-1cc2285e1af3" />

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
