### PR TITLE
fix: Prevent Old Search Results on Loss of Focus

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -183,7 +183,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
     };
 
     onFocus = () => {
-        if (this.state.value || Object.keys(this.state.results ?? {}).length > 0) {
+        if (this.state.value.length >= 2) {
             this.setState({ open: true });
         }
     };


### PR DESCRIPTION
## Summary
Old search results persist after blur.

Regression created by my PR #1352, apologies once more.

## Test Plan
- Query two characters in search, load results
- Delete query
- Focus search box
- Old search results still appear