### PR TITLE
Retain Search Data on Local AntAlmanac Instance

### DIFF
--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -25,7 +25,7 @@ async function main() {
     if (!apiKey) throw new Error('ANTEATER_API_KEY is required');
 
     try {
-        const cacheFolderStatistics = await stat(join(__dirname, '../src/generated/terms/'));
+        const cacheFolderStatistics = await stat(join(__dirname, '../src/generated/searchData.ts'));
 
         const lastModifiedDate = cacheFolderStatistics.mtime;
         const currentDate = new Date();

--- a/apps/backend/scripts/get-search-data.ts
+++ b/apps/backend/scripts/get-search-data.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, stat } from 'node:fs/promises';
 import { Course, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 import { queryGraphQL } from 'src/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from 'src/lib/term-section-codes';
@@ -10,6 +10,7 @@ import 'dotenv/config';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const MAX_COURSES = 10_000;
+const VALID_CACHE_TIME_DAYS = 14;
 const DELAY_MS = 500; // avoid rate limits from AAPI
 
 const ALIASES: Record<string, string | undefined> = {
@@ -22,6 +23,22 @@ const ALIASES: Record<string, string | undefined> = {
 async function main() {
     const apiKey = process.env.ANTEATER_API_KEY;
     if (!apiKey) throw new Error('ANTEATER_API_KEY is required');
+
+    try {
+        const cacheFolderStatistics = await stat(join(__dirname, '../src/generated/terms/'));
+
+        const lastModifiedDate = cacheFolderStatistics.mtime;
+        const currentDate = new Date();
+        const validCacheMs = VALID_CACHE_TIME_DAYS * 24 * 60 * 60 * 1000;
+
+        if (process.env.STAGE == 'local' && currentDate.getTime() - lastModifiedDate.getTime() < validCacheMs) {
+            console.log('Using existing search cache, last updated ' + lastModifiedDate.toLocaleString() + '.');
+            return;
+        }
+    } catch {
+        console.log('Cache is empty or unreachable, rebuilding from scratch...');
+    }
+
     console.log('Generating cache for fuzzy search.');
     console.log('Fetching courses from Anteater API...');
     const headers = { Authorization: `Bearer ${apiKey}` };

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -65,19 +65,13 @@ export async function start(corsEnabled = false) {
     );
 
     if (env.STAGE === 'local') {
-        const server = app.listen(PORT, async () => {
-            console.log('🚀 Ready. These are routes for AntAlmanac backend (not the Vite frontend).');
-            console.log('────────────────────────────────');
-            console.log(`tRPC    → http://localhost:${PORT}/trpc`);
-            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/directions/*`);
-            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/tiles/*`);
-            console.log('────────────────────────────────');
+        const server = app.listen(PORT, () => {
+            console.log(`🚀 Backend: http://localhost:${PORT}`);
         });
 
         function closeServer() {
             console.log('Closing AntAlmanac backend.');
             server.close();
-            process.exit(0);
         }
 
         process.on('SIGTERM', closeServer);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -66,13 +66,12 @@ export async function start(corsEnabled = false) {
 
     if (env.STAGE === 'local') {
         const server = app.listen(PORT, async () => {
-            console.log('AntAlmanac Backend');
+            console.log("🚀 Ready. These are routes for AntAlmanac backend (not the Vite frontend).")
             console.log('────────────────────────────────');
             console.log(`tRPC    → http://localhost:${PORT}/trpc`);
             console.log(`Mapbox  → http://localhost:${PORT}/mapbox/directions/*`);
             console.log(`Mapbox  → http://localhost:${PORT}/mapbox/tiles/*`);
             console.log('────────────────────────────────');
-            console.log('Ready. This is the AntAlmanac backend (not the Vite frontend).');
         });
 
         process.on('SIGTERM', () => server.close());

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -66,7 +66,7 @@ export async function start(corsEnabled = false) {
 
     if (env.STAGE === 'local') {
         const server = app.listen(PORT, async () => {
-            console.log("🚀 Ready. These are routes for AntAlmanac backend (not the Vite frontend).")
+            console.log('🚀 Ready. These are routes for AntAlmanac backend (not the Vite frontend).');
             console.log('────────────────────────────────');
             console.log(`tRPC    → http://localhost:${PORT}/trpc`);
             console.log(`Mapbox  → http://localhost:${PORT}/mapbox/directions/*`);
@@ -74,8 +74,14 @@ export async function start(corsEnabled = false) {
             console.log('────────────────────────────────');
         });
 
-        process.on('SIGTERM', () => server.close());
-        process.on('SIGINT', () => server.close());
+        function closeServer() {
+            console.log('Closing AntAlmanac backend.');
+            server.close();
+            process.exit(0);
+        }
+
+        process.on('SIGTERM', closeServer);
+        process.on('SIGINT', closeServer);
     }
 
     return app;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -67,8 +67,12 @@ export async function start(corsEnabled = false) {
     if (env.STAGE === 'local') {
         const server = app.listen(PORT, async () => {
             console.log('AntAlmanac Backend');
-            console.log(`-> Local: http://localhost:${PORT}`);
-            console.log(`-> Environment: ${env.STAGE || 'not set'}`);
+            console.log('────────────────────────────────');
+            console.log(`tRPC    → http://localhost:${PORT}/trpc`);
+            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/directions/*`);
+            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/tiles/*`);
+            console.log('────────────────────────────────');
+            console.log('Ready. This is the AntAlmanac backend (not the Vite frontend).');
         });
 
         process.on('SIGTERM', () => server.close());

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -65,9 +65,14 @@ export async function start(corsEnabled = false) {
     );
 
     if (env.STAGE === 'local') {
-        app.listen(PORT, async () => {
-            console.log(`🚀 Server listening at http://localhost:${PORT}`);
+        const server = app.listen(PORT, async () => {
+            console.log('AntAlmanac Backend');
+            console.log(`-> Local: http://localhost:${PORT}`);
+            console.log(`-> Environment: ${env.STAGE || 'not set'}`);
         });
+
+        process.on('SIGTERM', () => server.close());
+        process.on('SIGINT', () => server.close());
     }
 
     return app;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -66,11 +66,16 @@ export async function start(corsEnabled = false) {
 
     if (env.STAGE === 'local') {
         const server = app.listen(PORT, () => {
-            console.log(`🚀 Backend: http://localhost:${PORT}`);
+            console.log(`🚀 Backend listening on port ${PORT}`);
+            console.log('────────────────────────────────');
+            console.log(`tRPC    → http://localhost:${PORT}/trpc`);
+            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/directions/*`);
+            console.log(`Mapbox  → http://localhost:${PORT}/mapbox/tiles/*`);
+            console.log('────────────────────────────────');
         });
 
         function closeServer() {
-            console.log('Closing AntAlmanac backend.');
+            console.log('Closing AntAlmanac backend...');
             server.close();
         }
 


### PR DESCRIPTION
## Summary
Check when the search data cache was last updated, rebuilding when needed. Rebuilds every 14 days.

```
antalmanac-backend:start: Using existing search cache, last updated 12/7/2025, 12:17:18 PM.
```

```
antalmanac-backend:start: Cache is empty or unreachable, rebuilding from scratch...
antalmanac-backend:start: Generating cache for fuzzy search.
antalmanac-backend:start: Fetching courses from Anteater API...
antalmanac-backend:start: Fetched 8932 courses.
antalmanac-backend:start: Fetched 129 departments.
antalmanac-backend:start: Fetched 13172 section codes for 2026 Winter from Anteater API.
antalmanac-backend:start: Fetched 13584 section codes for 2025 Fall from Anteater API.
...
```


I also decided to label the backend server properly so new developers who run `pnpm start` aren't confused by the backend server URLs.

```
antalmanac-backend:start: 🚀 Backend listening on port 3000
antalmanac-backend:start: ────────────────────────────────
antalmanac-backend:start: tRPC    → http://localhost:3000/trpc
antalmanac-backend:start: Mapbox  → http://localhost:3000/mapbox/directions/*
antalmanac-backend:start: Mapbox  → http://localhost:3000/mapbox/tiles/*
antalmanac-backend:start: ────────────────────────────────
```

The Express backend will also attempt to close gracefully when pressing `Ctrl+C`, but it doesn't for macOS at the moment due to https://github.com/privatenumber/tsx/issues/586.


## Test Plan
Run `pnpm start` with no cache, works normally.
Run `pnpm start` with existing search cache, works.

## Issues

Closes #1356

