### PR TITLE
fix: Calendar Download on Firefox Android

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -357,7 +357,7 @@ export function exportCalendar() {
 
         // Inject the VTIMEZONE section into the .ics file.
         const data = new Blob([icsString.replace('BEGIN:VEVENT', vTimeZoneSection)], {
-            type: 'text/plain;charset=utf-8',
+            type: 'text/calendar;charset=utf-8',
         });
 
         // Download the .ics file


### PR DESCRIPTION
## Summary
<img src="https://github.com/user-attachments/assets/72ebfc3f-0c0d-4321-96f5-f898da735683" height="500">

Firefox Android uses the MIME type to determine file extension.

## Test Plan
Still works on Chrome, Firefox, Safari
Now works on Firefox Android

