### PR TITLE
fix: pass user info to save methods

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -48,7 +48,7 @@
         "arktype": "1.0.14-alpha",
         "date-fns": "^2.29.3",
         "dayjs": "^1.11.7",
-        "drizzle-orm": "^0.36.3",
+        "drizzle-orm": "^0.45.1",
         "events": "^3.3.0",
         "file-saver": "^2.0.5",
         "fuzzysort": "3.1.0",

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -138,15 +138,13 @@ class ActionTypesStore extends EventEmitter {
         }
 
         if (autoSave) {
-            const providerId = await trpc.userData.getUserAndAccountBySessionToken
-                .query({
-                    token: sessionStore.session,
-                })
-                .then((res) => res.accounts.providerAccountId);
+            const { users, accounts } = await trpc.userData.getUserAndAccountBySessionToken.query({
+                token: sessionStore.session,
+            });
 
-            if (providerId) {
+            if (accounts.providerAccountId) {
                 this.emit('autoSaveStart');
-                await autoSaveSchedule(providerId);
+                await autoSaveSchedule(accounts.providerAccountId, users);
                 AppStore.unsavedChanges = false;
                 this.emit('autoSaveEnd');
             }

--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -607,7 +607,10 @@ export class RDS {
         });
     }
 
-    static async getUserAndAccountBySessionToken(db: DatabaseOrTransaction, refreshToken: string) {
+    static async getUserAndAccountBySessionToken(
+        db: DatabaseOrTransaction,
+        refreshToken: string
+    ): Promise<{ users: User; accounts: Account }> {
         return db.transaction((tx) =>
             tx
                 .select()

--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -172,7 +172,7 @@ export class RDS {
 
             const account = await db
                 .insert(accounts)
-                .values({ userId: newUserId, providerAccountId: providerId, accountType })
+                .values({ userId: newUserId, providerAccountId: oidcProviderId, accountType })
                 .returning()
                 .then((res) => res[0]);
 
@@ -191,7 +191,7 @@ export class RDS {
 
         const newAccount = await db
             .insert(accounts)
-            .values({ userId: existingUser.id, providerAccountId: providerId, accountType })
+            .values({ userId: existingUser.id, providerAccountId: oidcProviderId, accountType })
             .returning()
             .then((res) => res[0]);
 

--- a/apps/antalmanac/src/components/Header/Save.tsx
+++ b/apps/antalmanac/src/components/Header/Save.tsx
@@ -42,11 +42,11 @@ export const Save = () => {
 
     const saveScheduleData = async () => {
         if (validSession && session) {
-            const accounts = await trpc.userData.getUserAndAccountBySessionToken
-                .query({ token: session })
-                .then((res) => res.accounts);
+            const { users, accounts } = await trpc.userData.getUserAndAccountBySessionToken.query({
+                token: session,
+            });
             setSaving(true);
-            await saveSchedule(accounts.providerAccountId, true);
+            await saveSchedule(accounts.providerAccountId, true, users);
             setSaving(false);
         }
     };

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -90,10 +90,16 @@ export function AuthPage() {
                     scheduleSaveState.scheduleIndex = saveState.schedules.length - 1;
                 }
 
+                // Fetch user info to enable proper account migration
+                const userInfo = await trpc.userData.getUserByUid.query({ userId });
+
                 await trpc.userData.saveUserData.mutate({
                     id: providerId,
                     data: {
                         id: providerId,
+                        email: userInfo?.email ?? undefined,
+                        name: userInfo?.name ?? undefined,
+                        avatar: userInfo?.avatar ?? undefined,
                         userData: scheduleSaveState,
                     },
                 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^1.11.7
         version: 1.11.13
       drizzle-orm:
-        specifier: ^0.36.3
-        version: 0.36.3(@types/pg@8.15.6)(@types/react@19.2.7)(knex@0.8.6)(pg@8.16.3)(postgres@3.4.5)(react@19.2.1)
+        specifier: ^0.45.1
+        version: 0.45.1(@types/pg@8.15.6)(knex@0.8.6)(pg@8.16.3)(postgres@3.4.5)
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2670,98 +2670,6 @@ packages:
   drizzle-kit@0.28.1:
     resolution: {integrity: sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ==}
     hasBin: true
-
-  drizzle-orm@0.36.3:
-    resolution: {integrity: sha512-ffQB7CcyCTvQBK6xtRLMl/Jsd5xFTBs+UTHrgs1hbk68i5TPkbsoCPbKEwiEsQZfq2I7VH632XJpV1g7LS2H9Q==}
-    peerDependencies:
-      '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=3'
-      '@electric-sql/pglite': '>=0.2.0'
-      '@libsql/client': '>=0.10.0'
-      '@libsql/client-wasm': '>=0.10.0'
-      '@neondatabase/serverless': '>=0.1'
-      '@op-engineering/op-sqlite': '>=2'
-      '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
-      '@prisma/client': '*'
-      '@tidbcloud/serverless': '*'
-      '@types/better-sqlite3': '*'
-      '@types/pg': '*'
-      '@types/react': 19.2.7
-      '@types/sql.js': '*'
-      '@vercel/postgres': '>=0.8.0'
-      '@xata.io/client': '*'
-      better-sqlite3: '>=7'
-      bun-types: '*'
-      expo-sqlite: '>=14.0.0'
-      knex: '*'
-      kysely: '*'
-      mysql2: '>=2'
-      pg: '>=8'
-      postgres: '>=3'
-      prisma: '*'
-      react: '>=18'
-      sql.js: '>=1'
-      sqlite3: '>=5'
-    peerDependenciesMeta:
-      '@aws-sdk/client-rds-data':
-        optional: true
-      '@cloudflare/workers-types':
-        optional: true
-      '@electric-sql/pglite':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@libsql/client-wasm':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@prisma/client':
-        optional: true
-      '@tidbcloud/serverless':
-        optional: true
-      '@types/better-sqlite3':
-        optional: true
-      '@types/pg':
-        optional: true
-      '@types/react':
-        optional: true
-      '@types/sql.js':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      bun-types:
-        optional: true
-      expo-sqlite:
-        optional: true
-      knex:
-        optional: true
-      kysely:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      postgres:
-        optional: true
-      prisma:
-        optional: true
-      react:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
 
   drizzle-orm@0.45.1:
     resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
@@ -7481,15 +7389,6 @@ snapshots:
       esbuild-register: 3.6.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
-
-  drizzle-orm@0.36.3(@types/pg@8.15.6)(@types/react@19.2.7)(knex@0.8.6)(pg@8.16.3)(postgres@3.4.5)(react@19.2.1):
-    optionalDependencies:
-      '@types/pg': 8.15.6
-      '@types/react': 19.2.7
-      knex: 0.8.6
-      pg: 8.16.3
-      postgres: 3.4.5
-      react: 19.2.1
 
   drizzle-orm@0.45.1(@types/pg@8.15.6)(knex@0.8.6)(pg@8.16.3)(postgres@3.4.5):
     optionalDependencies:

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -28,6 +28,7 @@ export default $config({
                 name: domain,
                 redirects: $app.stage.match(/^staging-(\d+)$/) ? [] : [`www.${domain}`],
             },
+            cachePolicy: '92d18877-845e-47e7-97e6-895382b1bf7c',
             environment: {
                 DB_URL: $app.stage === 'production' ? process.env.PROD_DB_URL : process.env.DEV_DB_URL,
                 MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN,


### PR DESCRIPTION
## Summary
In #1237, the new auth implementation with OIDC migrates users based on their email, which is used to uniquely key `users` across multiple auth providers (`accounts`). 

```
        const existingUser = email ? await this.getUserByEmail(db, email) : null;
```

However, in the auth methods, we were not passing email information to the methods. This was not detected on staging because all users which logged in for the first time on staging were automatically migrated and migrated correctly, meaning this branch (requiring an existing, logged-in session and no migration) was not tested. 

In the Google callback, the relevant code snippet is as follows (note that email is present):

```
            const account = await RDS.registerUserAccount(db, 'OIDC', oauthUserId, username, email, picture ?? '');
```

In schedule save methods, one example code snippet is as follows (note that email is not present in `data`):

```
 await trpc.userData.saveUserData.mutate({
            id: providerID,
            data: {
                id: providerID,
                userData: scheduleSaveState,
            },
        });
```



> [!NOTE]
> Additionally, to completely "flush" this branch, we will be invalidating all active sessions in which the user does not have an OIDC account (i.e. users who have not migrated yet). This will force a new sign in which should successfully migrate over users.

## Test Plan

## Issues

Closes various bug reports (3) over the past week, beginning no earlier than 12/14 (when the changes were merged). 

<!-- [Optional]
## Future Followup
-->
