### PR TITLE
Add static data to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Desktop.ini
 
 # sst
 .sst
+
+# generated
+/apps/backend


### PR DESCRIPTION
## Summary
When you run `get-data` the fetched static data should be ignored

## Test Plan
Run `pnpm get-data`: the the static data in `/backend` should not be tracked

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
