### PR TITLE
Fix: Duplicate users created on sign up

### DIFF
--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreActions';
@@ -20,8 +20,14 @@ import AppStore from '$stores/AppStore';
 
 export function AuthPage() {
     const [searchParams] = useSearchParams();
+    const isAuthenticatingRef = useRef(false);
 
     const handleSearchParamsChange = useCallback(async () => {
+        // Prevent race condition: only allow one authentication attempt at a time
+        if (isAuthenticatingRef.current) {
+            return;
+        }
+
         try {
             const code = searchParams.get('code');
             const state = searchParams.get('state');
@@ -29,6 +35,8 @@ export function AuthPage() {
                 window.location.href = '/';
                 return;
             }
+
+            isAuthenticatingRef.current = true;
 
             const { sessionToken, userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
                 code: code,
@@ -107,6 +115,7 @@ export function AuthPage() {
             window.location.href = '/';
         } catch (error) {
             console.error('Error during authentication', error);
+            isAuthenticatingRef.current = false;
         }
     }, [searchParams]);
 


### PR DESCRIPTION
## Summary
There is a race condition when you first create your AA account two user rows are created. 

Local dev:
<img width="911" height="75" alt="image" src="https://github.com/user-attachments/assets/dd5a620a-27af-45d3-831f-e576a30c2930" />

## Test Plan
1) Signin to AA with an email that's not in the DB 

Expected: Only 1 row should appear in the db for that user and all functionality should be the same 

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
