### PR TITLE
AAxPP Shared sidebar

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -137,6 +137,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
     return (
         <Paper
             elevation={0}
+            square
             variant="outlined"
             sx={{
                 display: 'flex',
@@ -145,6 +146,7 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                 alignItems: 'center',
                 padding: 1,
                 borderRadius: '4px 4px 0 0',
+                borderWidth: '1px 0px 1px 0px',
             }}
         >
             <Box gap={1} display="flex" alignItems="center">

--- a/apps/antalmanac/src/components/Calendar/calendar.css
+++ b/apps/antalmanac/src/components/Calendar/calendar.css
@@ -14,6 +14,10 @@
     border: none;
 }
 
+.rbc-time-view {
+    border-color: transparent;
+}
+
 .rbc-time-view .rbc-allday-cell {
     height: 0;
     z-index: -1000;
@@ -97,12 +101,7 @@
 }
 
 .rbc-event.calendar-loading-event {
-    background: linear-gradient(
-        90deg,
-        transparent 0%,
-        rgba(255, 255, 255, 0.1) 50%,
-        transparent 100%
-    );
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.1) 50%, transparent 100%);
     background-size: 200% 100%;
     animation: calendar-loading-shimmer 2s ease-in-out infinite;
 }

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -20,6 +20,7 @@ import { About } from './About';
 
 import actionTypesStore from '$actions/ActionTypesStore';
 import { autoSaveSchedule } from '$actions/AppStoreActions';
+import { PlannerButton } from '$components/buttons/Planner';
 import { getLocalStorageUserId } from '$lib/localStorage';
 import appStore from '$stores/AppStore';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
@@ -117,7 +118,7 @@ function TimeMenu() {
 
     return (
         <Box sx={{ padding: '0 1rem', width: '100%' }}>
-            <Typography variant="h6" style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
+            <Typography variant="h6" style={{ marginBottom: '1rem' }}>
                 Time
             </Typography>
 
@@ -160,6 +161,14 @@ function TimeMenu() {
     );
 }
 
+function PlannerMenu() {
+    return (
+        <Box sx={{ padding: '0 1rem', width: '100%', display: 'flex', justifyContent: 'center' }}>
+            <PlannerButton />
+        </Box>
+    );
+}
+
 function ExperimentalMenu() {
     const [previewMode, setPreviewMode] = usePreviewStore((store) => [store.previewMode, store.setPreviewMode]);
     const [autoSave, setAutoSave] = useAutoSaveStore((store) => [store.autoSave, store.setAutoSave]);
@@ -186,13 +195,13 @@ function ExperimentalMenu() {
 
         if (!savedUserID) return;
         actionTypesStore.emit('autoSaveStart');
-        await autoSaveSchedule(savedUserID, postHog);
+        await autoSaveSchedule(savedUserID, undefined, postHog);
         appStore.unsavedChanges = false;
         actionTypesStore.emit('autoSaveEnd');
     };
 
     return (
-        <Stack sx={{ padding: '1rem 1rem 0 1rem', width: '100%', display: 'flex', alignItems: 'middle' }}>
+        <Stack sx={{ padding: '0 1rem', width: '100%', display: 'flex', alignItems: 'middle' }}>
             <Box style={{ display: 'flex', justifyContent: 'space-between', width: '1' }}>
                 <Box style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                     <Typography variant="h6" style={{ display: 'flex', alignItems: 'center', alignContent: 'center' }}>
@@ -222,16 +231,26 @@ function ExperimentalMenu() {
 
 function SettingsMenu() {
     return (
-        <Box>
+        <Stack gap={2}>
             <ThemeMenu />
             <TimeMenu />
 
-            <Divider style={{ marginTop: '16px' }}>
-                <Typography variant="subtitle2">Experimental Features</Typography>
-            </Divider>
+            <Stack gap={2}>
+                <Divider>
+                    <Typography variant="subtitle2">Want a 4-year plan?</Typography>
+                </Divider>
 
-            <ExperimentalMenu />
-        </Box>
+                <PlannerMenu />
+            </Stack>
+
+            <Stack gap={2}>
+                <Divider>
+                    <Typography variant="subtitle2">Experimental Features</Typography>
+                </Divider>
+
+                <ExperimentalMenu />
+            </Stack>
+        </Stack>
     );
 }
 

--- a/apps/antalmanac/src/components/Header/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/SettingsMenu.tsx
@@ -21,6 +21,7 @@ import { About } from './About';
 import actionTypesStore from '$actions/ActionTypesStore';
 import { autoSaveSchedule } from '$actions/AppStoreActions';
 import { PlannerButton } from '$components/buttons/Planner';
+import { useIsMobile } from '$hooks/useIsMobile';
 import { getLocalStorageUserId } from '$lib/localStorage';
 import appStore from '$stores/AppStore';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
@@ -164,7 +165,11 @@ function TimeMenu() {
 function PlannerMenu() {
     return (
         <Box sx={{ padding: '0 1rem', width: '100%', display: 'flex', justifyContent: 'center' }}>
-            <PlannerButton />
+            <PlannerButton
+                buttonSx={{
+                    width: '100%',
+                }}
+            />
         </Box>
     );
 }
@@ -230,18 +235,22 @@ function ExperimentalMenu() {
 }
 
 function SettingsMenu() {
+    const isMobile = useIsMobile();
+
     return (
         <Stack gap={2}>
             <ThemeMenu />
             <TimeMenu />
 
-            <Stack gap={2}>
-                <Divider>
-                    <Typography variant="subtitle2">Want a 4-year plan?</Typography>
-                </Divider>
+            {isMobile && (
+                <Stack gap={2}>
+                    <Divider>
+                        <Typography variant="subtitle2">Want a 4-year plan?</Typography>
+                    </Divider>
 
-                <PlannerMenu />
-            </Stack>
+                    <PlannerMenu />
+                </Stack>
+            )}
 
             <Stack gap={2}>
                 <Divider>

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTabs.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementTabs.tsx
@@ -66,7 +66,12 @@ export function ScheduleManagementTabs() {
     const { activeTab } = useTabStore();
 
     return (
-        <Paper elevation={0} variant="outlined" square sx={{ borderRadius: '4px 4px 0 0' }}>
+        <Paper
+            elevation={0}
+            variant="outlined"
+            square
+            sx={{ borderRadius: '4px 4px 0 0', borderWidth: '1px 0px 1px 0px' }}
+        >
             <Tabs value={activeTab} indicatorColor="primary" variant="fullWidth" centered>
                 {scheduleManagementTabs.map((tab, index) => (
                     <ScheduleManagementTab key={tab.label} tab={tab} value={index} />

--- a/apps/antalmanac/src/components/buttons/Planner.tsx
+++ b/apps/antalmanac/src/components/buttons/Planner.tsx
@@ -1,12 +1,16 @@
 import { Route } from '@mui/icons-material';
-import { Button, Tooltip } from '@mui/material';
+import { Button, SxProps, Tooltip } from '@mui/material';
 
 import { PLANNER_LINK } from '$src/globals';
 
-export const PlannerButton = () => {
+interface PlannerButtonProps {
+    buttonSx?: SxProps;
+}
+
+export const PlannerButton = ({ buttonSx }: PlannerButtonProps) => {
     return (
         <Tooltip title="Check out AntAlmanac Planner!">
-            <Button color="inherit" startIcon={<Route />} size="large" variant="text" href={PLANNER_LINK}>
+            <Button color="inherit" startIcon={<Route />} size="large" variant="text" href={PLANNER_LINK} sx={buttonSx}>
                 Go To Planner
             </Button>
         </Tooltip>

--- a/apps/antalmanac/src/components/buttons/Planner.tsx
+++ b/apps/antalmanac/src/components/buttons/Planner.tsx
@@ -1,0 +1,14 @@
+import { Route } from '@mui/icons-material';
+import { Button, Tooltip } from '@mui/material';
+
+import { PLANNER_LINK } from '$src/globals';
+
+export const PlannerButton = () => {
+    return (
+        <Tooltip title="Check out AntAlmanac Planner!">
+            <Button color="inherit" startIcon={<Route />} size="large" variant="text" href={PLANNER_LINK}>
+                Go To Planner
+            </Button>
+        </Tooltip>
+    );
+};

--- a/apps/antalmanac/src/globals.ts
+++ b/apps/antalmanac/src/globals.ts
@@ -3,3 +3,5 @@ export const DODGER_BLUE = '#1e90ff';
 export const BLUE = '#305db7';
 
 export const FEEDBACK_LINK = 'https://form.asana.com/?k=fZ3SGnuGknDmzTYdocgIUg&d=1208267282546207';
+
+export const PLANNER_LINK = 'https://peterportal.org';

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -12,7 +12,7 @@ import { NotificationSnackbar } from '$components/NotificationSnackbar';
 import PatchNotes from '$components/PatchNotes';
 import { ScheduleManagement } from '$components/ScheduleManagement/ScheduleManagement';
 import { BLUE } from '$src/globals';
-import SideNav from '$src/shared-components/SideNav';
+import { SideNav } from '$src/shared-components/SideNav';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 
 function MobileHome() {

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -12,6 +12,7 @@ import { NotificationSnackbar } from '$components/NotificationSnackbar';
 import PatchNotes from '$components/PatchNotes';
 import { ScheduleManagement } from '$components/ScheduleManagement/ScheduleManagement';
 import { BLUE } from '$src/globals';
+import SideNav from '$src/shared-components/SideNav';
 import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
 
 function MobileHome() {
@@ -83,9 +84,13 @@ export default function Home() {
             <PatchNotes />
             <InstallPWABanner />
 
-            <Stack component="main" height="100dvh">
-                <Header />
-                {isMobileScreen ? <MobileHome /> : <DesktopHome />}
+            <Stack direction="row" height="100dvh">
+                <SideNav />
+
+                <Stack component="main" flex={1}>
+                    <Header />
+                    {isMobileScreen ? <MobileHome /> : <DesktopHome />}
+                </Stack>
             </Stack>
 
             <NotificationSnackbar />

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -1,12 +1,11 @@
-import EventNoteIcon from '@mui/icons-material/EventNote';
-import RouteIcon from '@mui/icons-material/Route';
+import { EventNote, Route } from '@mui/icons-material';
 import { Paper, Stack, SxProps, Typography, useTheme } from '@mui/material';
 import Link from 'next/link';
 
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useThemeStore } from '$stores/SettingsStore';
 
-const SideNav = () => {
+export const SideNav = () => {
     const isMobile = useIsMobile();
     const isDark = useThemeStore((store) => store.isDark);
     const theme = useTheme();
@@ -30,14 +29,14 @@ const SideNav = () => {
             <Stack direction="column" alignItems="center" sx={{ gap: '16px', paddingTop: '8px' }}>
                 <Link href="https://antalmanac.com" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center">
-                        <EventNoteIcon fontSize="medium" />
+                        <EventNote fontSize="medium" />
                         <Typography fontSize={11}>Scheduler</Typography>
                     </Stack>
                 </Link>
 
                 <Link href="/" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center" sx={{ color: isDark ? 'white' : 'black' }}>
-                        <RouteIcon fontSize="medium" />
+                        <Route fontSize="medium" />
                         <Typography fontSize={11}>Planner</Typography>
                     </Stack>
                 </Link>
@@ -45,5 +44,3 @@ const SideNav = () => {
         </Paper>
     );
 };
-
-export default SideNav;

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -1,0 +1,50 @@
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import RouteIcon from '@mui/icons-material/Route';
+import { Paper, Stack, SxProps, Typography, useTheme } from '@mui/material';
+import Link from 'next/link';
+
+import { useIsMobile } from '$hooks/useIsMobile';
+import { useThemeStore } from '$stores/SettingsStore';
+
+const SideNav = () => {
+    const isMobile = useIsMobile();
+    const isDark = useThemeStore((store) => store.isDark);
+    const theme = useTheme();
+
+    if (isMobile) {
+        return null;
+    }
+
+    const paperStyleOverrides: SxProps = {
+        height: '100%',
+        width: 64,
+        zIndex: 300,
+        top: 0,
+        left: 0,
+        borderRight: `1px solid ${theme.palette.divider}`,
+        borderRadius: 0,
+        flexShrink: 0,
+    };
+
+    return (
+        <Paper elevation={0} sx={paperStyleOverrides}>
+            <Stack direction="column" alignItems="center" sx={{ gap: '16px', paddingTop: '8px' }}>
+                <Link href="https://antalmanac.com" style={{ textDecoration: 'none', color: 'primary' }}>
+                    <Stack direction="column" alignItems="center">
+                        <EventNoteIcon fontSize="medium" />
+                        <Typography fontSize={11}>Scheduler</Typography>
+                    </Stack>
+                </Link>
+
+                <Link href="/" style={{ textDecoration: 'none' }}>
+                    <Stack direction="column" alignItems="center" sx={{ color: isDark ? 'white' : 'black' }}>
+                        <RouteIcon fontSize="medium" />
+                        <Typography fontSize={11}>Planner</Typography>
+                    </Stack>
+                </Link>
+            </Stack>
+        </Paper>
+    );
+};
+
+export default SideNav;

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -28,7 +28,7 @@ const SideNav = () => {
     return (
         <Paper elevation={0} sx={paperStyleOverrides}>
             <Stack direction="column" alignItems="center" sx={{ gap: '16px', paddingTop: '8px' }}>
-                <Link href="https://antalmanac.com" style={{ textDecoration: 'none', color: 'primary' }}>
+                <Link href="https://antalmanac.com" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center">
                         <EventNoteIcon fontSize="medium" />
                         <Typography fontSize={11}>Scheduler</Typography>

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -23,7 +23,6 @@ const SideNav = () => {
         left: 0,
         borderRight: `1px solid ${theme.palette.divider}`,
         borderRadius: 0,
-        flexShrink: 0,
     };
 
     return (

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -3,6 +3,7 @@ import { Paper, Stack, SxProps, Typography, useTheme } from '@mui/material';
 import Link from 'next/link';
 
 import { useIsMobile } from '$hooks/useIsMobile';
+import { PLANNER_LINK } from '$src/globals';
 import { useThemeStore } from '$stores/SettingsStore';
 
 // Ported from PeterPortal
@@ -37,7 +38,7 @@ export const SideNav = () => {
                 </Link>
 
                 {/* TODO: Fix PP link after merge */}
-                <Link href="https://peterportal.org" style={{ textDecoration: 'none' }}>
+                <Link href={PLANNER_LINK} style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center" sx={{ color: isDark ? 'white' : 'black' }}>
                         <Route fontSize="medium" />
                         <Typography fontSize={11}>Planner</Typography>

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useThemeStore } from '$stores/SettingsStore';
 
+// Ported from PeterPortal
+// https://github.com/icssc/peterportal-client/blob/branding-changes/site/src/shared-components/SideNav.tsx
 export const SideNav = () => {
     const isMobile = useIsMobile();
     const isDark = useThemeStore((store) => store.isDark);
@@ -27,14 +29,15 @@ export const SideNav = () => {
     return (
         <Paper elevation={0} sx={paperStyleOverrides}>
             <Stack direction="column" alignItems="center" sx={{ gap: '16px', paddingTop: '8px' }}>
-                <Link href="https://antalmanac.com" style={{ textDecoration: 'none' }}>
+                <Link href="/" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center">
                         <EventNote fontSize="medium" />
                         <Typography fontSize={11}>Scheduler</Typography>
                     </Stack>
                 </Link>
 
-                <Link href="/" style={{ textDecoration: 'none' }}>
+                {/* TODO: Fix PP link after merge */}
+                <Link href="https://peterportal.org" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center" sx={{ color: isDark ? 'white' : 'black' }}>
                         <Route fontSize="medium" />
                         <Typography fontSize={11}>Planner</Typography>

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -32,15 +32,15 @@ export const SideNav = () => {
             <Stack direction="column" alignItems="center" sx={{ gap: '16px', paddingTop: '8px' }}>
                 <Link href="/" style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center">
-                        <EventNote fontSize="medium" />
+                        <EventNote sx={{ fontSize: 24 }} />
                         <Typography fontSize={11}>Scheduler</Typography>
                     </Stack>
                 </Link>
 
-                {/* TODO: Fix PP link after merge */}
+                {/* TODO (@xgraceyan): Fix PP link after merge */}
                 <Link href={PLANNER_LINK} style={{ textDecoration: 'none' }}>
                     <Stack direction="column" alignItems="center" sx={{ color: isDark ? 'white' : 'black' }}>
-                        <Route fontSize="medium" />
+                        <Route sx={{ fontSize: 24 }} />
                         <Typography fontSize={11}>Planner</Typography>
                     </Stack>
                 </Link>


### PR DESCRIPTION
> [!CAUTION]
> Do not merge until both AA and PP are ready

## Summary
Adds a shared sidebar to be used between AA and PP. Had to move some stuff (mostly colors) around so it can be used in AntAlmanac.

<img width="1012" height="657" alt="image" src="https://github.com/user-attachments/assets/fc852b1e-3c15-4b4c-ab64-36f9054d84a6" />
<img width="1151" height="608" alt="image" src="https://github.com/user-attachments/assets/331a4e4e-ea96-47ca-9a75-793e78afe5a5" />


## Test Plan
- Ensure design is consistent with PeterPortal's sidebar
- Ensure sidebar looks good in both light and dark mode

## Issues

Closes #1386 partially (w/ about box)

<!-- [Optional]
## Future Followup
-->
