### PR TITLE
fix: save icon warning pop up when downloading

### DIFF
--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -32,10 +32,12 @@ export type HelpMenuAction = {
 export function HelpMenu() {
     const isMobile = useIsMobile();
     const [open, setOpen] = useState(false);
-    const { sessionIsValid } = useSessionStore();
-    const { openAutoSaveWarning, setOpenAutoSaveWarning } = scheduleComponentsToggleStore();
+    const { sessionIsValid, session } = useSessionStore();
+    const { openAutoSaveWarning, setOpenAutoSaveWarning, openLoadingSchedule } = scheduleComponentsToggleStore();
 
     const autoSave = getLocalStorageAutoSave() ?? 'false';
+
+    const isWaitingToLogin = session !== null && !sessionIsValid;
 
     const isDark = useThemeStore((state) => state.isDark);
 
@@ -120,7 +122,7 @@ export function HelpMenu() {
                 ))}
             </SpeedDial>
 
-            {!sessionIsValid && autoSave === 'true' && (
+            {!sessionIsValid && autoSave === 'true' && !openLoadingSchedule && !isWaitingToLogin && (
                 <IconButton
                     aria-label="warning"
                     color="warning"


### PR DESCRIPTION
## Summary
Fixed problem by not letting it appear when the loadingSkeleton is active and when the user is currently in the process of signing in.

https://streamable.com/hx0nzn

## Test Plan

## Issues

Closes #1368 

<!-- [Optional]
## Future Followup
-->
