### PR TITLE
fix: increased lazy loading offset

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -333,7 +333,7 @@ export default function CourseRenderPane(props: { id?: number }) {
                             if ((courseData[index] as AACourse).sections !== undefined)
                                 heightEstimate = (courseData[index] as AACourse).sections.length * 60 + 20 + 40;
                             return (
-                                <LazyLoad once key={index} overflow height={heightEstimate} offset={500}>
+                                <LazyLoad once key={index} overflow height={heightEstimate} offset={1000}>
                                     {SectionTableWrapped(index, {
                                         courseData: courseData,
                                         scheduleNames: scheduleNames,


### PR DESCRIPTION
## Summary
Doubled offset of LazyLoad

## Test Plan
![Screen Recording 2026-01-05 at 3 31 53 PM](https://github.com/user-attachments/assets/e8a89153-d50b-4921-aa72-3d021148ff48)
I don't know why there's the circles, just a MOV -> GIF issue

## Issues

Closes #843

<!-- [Optional]
## Future Followup
-->
