### PR TITLE
Show RecruitmentBanner over HelpMenu and use MUI theme z-indexes

### DIFF
--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -62,15 +62,14 @@ export function HelpMenu() {
 
     return (
         <Stack
-            sx={{
+            sx={(theme) => ({
                 position: 'fixed',
                 bottom: isMobile ? 65 : 16, // Magic number
                 right: 8,
-            }}
+                zIndex: theme.zIndex.fab,
+            })}
             spacing={1}
             alignItems="center"
-            // If there's a higher zIndex than this, then that other zIndex is the real problem
-            zIndex={1000}
         >
             <Backdrop
                 sx={{

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -79,7 +79,14 @@ const RecruitmentBanner = () => {
     };
 
     return (
-        <Box sx={{ position: 'fixed', bottom: 5, right: isMobileScreen ? 5 : 75, zIndex: 999 }}>
+        <Box
+            sx={(theme) => ({
+                position: 'fixed',
+                bottom: 5,
+                right: isMobileScreen ? 5 : 75,
+                zIndex: theme.zIndex.snackbar,
+            })}
+        >
             {displayRecruitmentBanner ? (
                 <Alert
                     icon={false}


### PR DESCRIPTION
## Summary

Display the RecruitmentBanner snackbar over (closer to viewer) the HelpMenu hint button. Also switch from hardcoding z-index values to using MUI theme z-indexes.

## Test Plan

1. Go into mobile mode
2. Delete `recruitmentDismissalTime` in local storage if needed
3. Search for any CS course
4. The recruitment snackbar should render over the help button

## Issues

Closes #1369

<!-- [Optional]
## Future Followup
-->
