### PR TITLE
fix: SST locking on simultaneous deployment

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -4,6 +4,10 @@ on:
     push:
         branches: [main]
 
+concurrency:
+    group: sst-production-deploy
+    cancel-in-progress: false
+
 env:
     AWS_REGION: ${{ secrets.AWS_REGION }}
 

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,7 +5,7 @@ on:
         branches: [main]
 
 concurrency:
-    group: sst-production-deploy
+    group: sst-production
     cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,7 +7,7 @@ on:
         types: [deploy-command]
 
 concurrency:
-    group: sst-staging-deploy
+    group: sst-staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}-deploy
     cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,7 +7,7 @@ on:
         types: [deploy-command]
 
 concurrency:
-    group: sst-staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}-deploy
+    group: sst-staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
     cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -6,6 +6,10 @@ on:
     repository_dispatch:
         types: [deploy-command]
 
+concurrency:
+    group: sst-staging-deploy
+    cancel-in-progress: false
+
 env:
     AWS_REGION: ${{ secrets.AWS_REGION }}
 

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -6,6 +6,10 @@ on:
     repository_dispatch:
         types: [remove-command]
 
+concurrency:
+    group: sst-staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+    cancel-in-progress: false
+
 env:
     AWS_REGION: ${{ secrets.AWS_REGION }}
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![AntAlmanac](apps/antalmanac/public/banner.png)
-TESTING CONCURRENCY WORKFLOW
+
 # About
 
 AntAlmanac is a schedule planner website for classes at UC Irvine. These are some of its features:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![AntAlmanac](apps/antalmanac/public/banner.png)
-
+TESTING CONCURRENCY WORKFLOW
 # About
 
 AntAlmanac is a schedule planner website for classes at UC Irvine. These are some of its features:


### PR DESCRIPTION
## Summary
Add concurrency to deployment workflows.
Prevent SST from locking due to concurrent deployments. Only one instance of the workflow for a given stage can run.

Since SST can presumably simultaneously deploy as long as the stage is different, I have accounted for this.

I chose `cancel-in-progress: false` for the SST workflows, which is actually the default behavior for concurrency groups (and slightly redundant), because I want to emphasize that I don't want the workflow cancelling while running `sst deploy`.

## Test Plan

## Issues

Part of https://github.com/icssc/AntAlmanac/commit/580d1f293197efa9e58178e71c8a8fc1d2e7c301 (https://github.com/icssc/AntAlmanac/pull/1392) is probably unnecessary.
