### PR TITLE
feat: deploy staging to `scheduler-#` subdomains

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -26,7 +26,7 @@ jobs:
         runs-on: ubuntu-latest
         environment:
             name: staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
-            url: https://staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
+            url: https://scheduler-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
 
         env:
             SST_STAGE: staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
@@ -83,7 +83,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
                   state: success
-                  environment-url: https://staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
+                  environment-url: https://scheduler-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
 
             - name: Add reaction to comment
               if: github.event_name == 'repository_dispatch'

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -4,7 +4,8 @@ function getDomain() {
     if ($app.stage === 'production') {
         return 'antalmanac.com';
     } else if ($app.stage.match(/^staging-(\d+)$/)) {
-        return `${$app.stage}.antalmanac.com`;
+        const subdomainPrefix = $app.stage.replace('staging-', 'scheduler-');
+        return `${subdomainPrefix}.antalmanac.com`;
     }
 
     throw new Error('Invalid stage');


### PR DESCRIPTION
## Summary
Deploys staging instances of AntAlamanc (scheduler) to the subdomain `scheduler-###.antalmanac.com` for the merge. This is similar to https://github.com/icssc/peterportal-client/pull/909

## Test Plan
Make sure a staging instance deploys properly. On PeterPortal's side, this required no manual build or tear down; changing the subdomain worked automatically.

## Issues

N/A

<!-- [Optional]
## Future Followup
-->
