### PR TITLE
Encode course IDs in peterportal links

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -33,10 +33,13 @@ import { useThemeStore } from '$stores/SettingsStore';
 
 function getColors() {
     const currentCourses = AppStore.schedule.getCurrentCourses();
-    const courseColors = currentCourses.reduce((accumulator, { section }) => {
-        accumulator[section.sectionCode] = section.color;
-        return accumulator;
-    }, {} as Record<string, string>);
+    const courseColors = currentCourses.reduce(
+        (accumulator, { section }) => {
+            accumulator[section.sectionCode] = section.color;
+            return accumulator;
+        },
+        {} as Record<string, string>
+    );
 
     return courseColors;
 }
@@ -202,7 +205,11 @@ const ErrorMessage = () => {
             }}
         >
             {courseId ? (
-                <Link href={`https://peterportal.org/course/${courseId}`} target="_blank" sx={{ width: '100%' }}>
+                <Link
+                    href={`https://peterportal.org/course/${encodeURIComponent(courseId)}`}
+                    target="_blank"
+                    sx={{ width: '100%' }}
+                >
                     <Alert
                         variant="filled"
                         severity="info"

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -123,7 +123,7 @@ function SectionTable(props: SectionTableProps) {
                             height={customIconSize}
                         />
                     }
-                    redirectLink={`https://peterportal.org/course/${courseId}`}
+                    redirectLink={`https://peterportal.org/course/${encodeURIComponent(courseId)}`}
                 />
 
                 <CourseInfoButton


### PR DESCRIPTION
## Summary

Encode course IDs in links to PeterPortal to fix bug where characters like slashes cause 404 errors.

## Test Plan

1. Search any course with a slash, like CRM/LAW
2. Click the PeterPortal link and confirm that it leads to the correct page without errors

## Issues

Closes #1370

<!-- [Optional]
## Future Followup
-->
