### PR TITLE
Load departments from Anteater API

### DIFF
--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -3,7 +3,7 @@ import type {
     CourseInfo,
     WebsocCourse,
     WebsocSectionType,
-    WebsocAPIDepartmentResponse,
+    WebsocAPIDepartmentsResponse,
 } from '@packages/antalmanac-types';
 import { z } from 'zod';
 
@@ -92,7 +92,7 @@ const queryWebSocDepartments = async () => {
         },
     });
     const data = await response.json();
-    return data.data as WebsocAPIDepartmentResponse;
+    return data.data as WebsocAPIDepartmentsResponse;
 };
 
 function combineWebsocResponses(responses: WebsocAPIResponse[]) {

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -5,6 +5,7 @@ import type {
     WebsocSectionType,
     WebsocAPIDepartmentsResponse,
 } from '@packages/antalmanac-types';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
@@ -92,6 +93,12 @@ const queryWebSocDepartments = async () => {
         },
     });
     const data = await response.json();
+    if (!data || !data.data) {
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Departments API returned no data',
+        });
+    }
     return data.data as WebsocAPIDepartmentsResponse;
 };
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
@@ -72,7 +72,7 @@ export function DepartmentSearchBar() {
                   )
                 : setRecentSearches((prev) => [newValue, ...prev].slice(0, 5));
         },
-        [recentSearches]
+        [recentSearches, options]
     );
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { DEPARTMENT_MAP } from '$components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/constants';
 import { LabeledAutocomplete } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
+import { useDepartments } from '$hooks/useDepartments';
 import { getLocalStorageRecentlySearched, setLocalStorageRecentlySearched } from '$lib/localStorage';
 
-const options = Object.keys(DEPARTMENT_MAP);
+const DEFAULT_DEPARTMENTS: Record<string, string> = {
+    ALL: 'ALL: Include All Departments',
+};
 
 const parseLocalStorageRecentlySearched = (): string[] => {
     try {
@@ -27,6 +29,12 @@ const parseLocalStorageRecentlySearched = (): string[] => {
 };
 
 export function DepartmentSearchBar() {
+    const { departments } = useDepartments();
+
+    const departmentsWithAll = departments ? { ...DEFAULT_DEPARTMENTS, ...departments } : DEFAULT_DEPARTMENTS;
+
+    const options = Object.keys(departmentsWithAll);
+
     const [value, setValue] = useState(() => RightPaneStore.getFormData().deptValue);
     const [recentSearches, setRecentSearches] = useState<typeof options>(() => parseLocalStorageRecentlySearched());
 
@@ -84,10 +92,10 @@ export function DepartmentSearchBar() {
             label="Department"
             autocompleteProps={{
                 value,
-                options: Array.from(new Set<string>([...recentSearches, ...options])),
+                options: Array.from(new Set([...recentSearches, ...options])),
                 autoHighlight: true,
                 openOnFocus: true,
-                getOptionLabel: (option) => DEPARTMENT_MAP[option.toUpperCase() as keyof typeof DEPARTMENT_MAP],
+                getOptionLabel: (option) => departmentsWithAll[option.toUpperCase()] ?? option,
                 onChange: handleChange,
                 includeInputInList: true,
                 noOptionsText: 'No departments match the search',

--- a/apps/antalmanac/src/hooks/useDepartments.tsx
+++ b/apps/antalmanac/src/hooks/useDepartments.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import { useDepartmentsStore } from '$stores/DepartmentsStore';
+
+export function useDepartments() {
+    const { departments, loadDepartments } = useDepartmentsStore();
+
+    useEffect(() => {
+        loadDepartments();
+    }, [loadDepartments]);
+
+    return {
+        departments,
+    };
+}

--- a/apps/antalmanac/src/lib/websoc.ts
+++ b/apps/antalmanac/src/lib/websoc.ts
@@ -40,6 +40,10 @@ class _WebSOC {
     async getCourseInfo(params: Record<string, string>) {
         return await trpc.websoc.getCourseInfo.query(params);
     }
+
+    async getDepartments() {
+        return await trpc.websoc.getDepartments.query();
+    }
 }
 
 export const WebSOC = new _WebSOC();

--- a/apps/antalmanac/src/stores/DepartmentsStore.ts
+++ b/apps/antalmanac/src/stores/DepartmentsStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+import { WebSOC } from '$lib/websoc';
+
+interface DepartmentsState {
+    departments: Record<string, string> | null;
+    loadDepartments: () => Promise<void>;
+}
+
+export const useDepartmentsStore = create<DepartmentsState>((set, get) => ({
+    departments: null,
+    loadDepartments: async () => {
+        if (get().departments != null) {
+            return;
+        }
+        try {
+            const departmentsData = await WebSOC.getDepartments();
+            const departmentsMap: Record<string, string> = {};
+            for (const dept of departmentsData) {
+                departmentsMap[dept.deptCode] = `${dept.deptCode}: ${dept.deptName}`;
+            }
+            set({ departments: departmentsMap });
+        } catch (error) {
+            console.error('Error loading departments: ', error);
+        }
+    },
+}));

--- a/apps/antalmanac/src/stores/DepartmentsStore.ts
+++ b/apps/antalmanac/src/stores/DepartmentsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+import { DEPARTMENT_MAP } from '$components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/constants';
 import { WebSOC } from '$lib/websoc';
 
 interface DepartmentsState {
@@ -15,13 +16,13 @@ export const useDepartmentsStore = create<DepartmentsState>((set, get) => ({
         }
         try {
             const departmentsData = await WebSOC.getDepartments();
-            const departmentsMap: Record<string, string> = {};
-            for (const dept of departmentsData) {
-                departmentsMap[dept.deptCode] = `${dept.deptCode}: ${dept.deptName}`;
-            }
+            const departmentsMap = Object.fromEntries(
+                departmentsData.map((dept) => [dept.deptCode, `${dept.deptCode}: ${dept.deptName}`])
+            );
             set({ departments: departmentsMap });
         } catch (error) {
             console.error('Error loading departments: ', error);
+            set({ departments: DEPARTMENT_MAP }); //fallback to hardcoded departments
         }
     },
 }));

--- a/packages/anteater-api-types/src/websoc.ts
+++ b/packages/anteater-api-types/src/websoc.ts
@@ -3,7 +3,7 @@ import { paths } from './generated/anteater-api-types';
 export type WebsocAPIResponse =
     paths['/v2/rest/websoc']['get']['responses'][200]['content']['application/json']['data'];
 
-export type WebsocAPIDepartmentResponse =
+export type WebsocAPIDepartmentsResponse =
     paths['/v2/rest/websoc/departments']['get']['responses'][200]['content']['application/json']['data'];
 
 export type WebsocSchool = WebsocAPIResponse['schools'][number];

--- a/packages/anteater-api-types/src/websoc.ts
+++ b/packages/anteater-api-types/src/websoc.ts
@@ -3,6 +3,9 @@ import { paths } from './generated/anteater-api-types';
 export type WebsocAPIResponse =
     paths['/v2/rest/websoc']['get']['responses'][200]['content']['application/json']['data'];
 
+export type WebsocAPIDepartmentResponse =
+    paths['/v2/rest/websoc/departments']['get']['responses'][200]['content']['application/json']['data'];
+
 export type WebsocSchool = WebsocAPIResponse['schools'][number];
 
 export type WebsocDepartment = WebsocSchool['departments'][number];


### PR DESCRIPTION
## Summary
Uses departments fetched from [Anteater API](https://anteaterapi.com/reference#tag/websoc/GET/v2/rest/websoc/departments) instead of the hardcoded `SearchForm/DepartmentSearchBar/constants.ts`

Departments are fetched only once and stored in `DepartmentsStore.ts`
Department search bar calls `useDepartments` hook to get departments

## Test Plan
- Ensure departments are stored in the Zustand store and fetched from there on subsequent renders
- Ensure departments search bar properly loads all departments from the last 10 years (set as 10 for now)
- Ensure departments search bar functions as expected

## Issues

Closes #1333

<!-- [Optional]
## Future Followup
-->
