### PR TITLE
feat: staging shared

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -3,6 +3,9 @@ name: Deploy - Staging
 on:
     pull_request:
         types: [opened, synchronize, reopened]
+        branches-ignore:
+            - staging-shared
+            - scheduler
     repository_dispatch:
         types: [deploy-command]
 

--- a/.github/workflows/deploy_staging_shared.yml
+++ b/.github/workflows/deploy_staging_shared.yml
@@ -2,7 +2,7 @@ name: Deploy - Staging Shared
 
 on:
     push:
-        branches: [staging-shared]
+        branches: [scheduler, staging-shared]
     repository_dispatch:
         types: [deploy-command]
 

--- a/.github/workflows/deploy_staging_shared.yml
+++ b/.github/workflows/deploy_staging_shared.yml
@@ -1,0 +1,98 @@
+name: Deploy - Staging Shared
+
+on:
+    push:
+        branches: [staging-shared]
+    repository_dispatch:
+        types: [deploy-command]
+
+concurrency:
+    group: sst-staging-shared
+    cancel-in-progress: false
+
+env:
+    AWS_REGION: ${{ secrets.AWS_REGION }}
+
+    DEV_DB_URL: ${{ secrets.DEV_DB_URL }}
+    MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+    NEXT_PUBLIC_TILES_ENDPOINT: ${{ secrets.NEXT_PUBLIC_TILES_ENDPOINT }}
+    ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+    OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+    OIDC_ISSUER_URL: ${{ secrets.OIDC_ISSUER_URL }}
+    GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+
+jobs:
+    deploy-staging-shared:
+        runs-on: ubuntu-latest
+        env:
+            SST_STAGE: staging-shared
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha || github.event.client_payload.pull_request.head.sha }}
+
+            - name: Create deployment
+              id: create-deployment
+              uses: chrnorm/deployment-action@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  environment: staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+                  ref: ${{ github.event.pull_request.head.sha || github.event.client_payload.pull_request.head.sha }}
+                  description: Staging deployment for PR #${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Setup Node.js and pnpm
+              uses: ./.github/actions/setup-node-and-pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Migrate database
+              env:
+                  DB_URL: ${{ secrets.DEV_DB_URL }}
+              run: pnpm db:migrate
+
+            # TODO (@xgraceyan): Remove this stage once SST fixes deployments
+            - name: Setup Pulumi
+              uses: pulumi/actions@v5
+              with:
+                  pulumi-version: 3.138.0 # Any version < 3.214.0 works
+
+            - name: Deploy SST (staging)
+              id: deploy
+              run: |
+                  echo "Deploying stage: $SST_STAGE"
+                  npx sst deploy --stage "$SST_STAGE"
+
+            - name: Update deployment status (success)
+              if: success()
+              uses: chrnorm/deployment-status@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
+                  state: success
+                  environment-url: https://staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
+
+            - name: Add reaction to comment
+              if: github.event_name == 'repository_dispatch'
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+                  reactions: rocket
+
+            - name: Update deployment status (failure)
+              if: failure()
+              uses: chrnorm/deployment-status@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
+                  state: failure

--- a/.github/workflows/deploy_staging_shared.yml
+++ b/.github/workflows/deploy_staging_shared.yml
@@ -38,7 +38,7 @@ jobs:
               uses: chrnorm/deployment-action@v2
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  environment: staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+                  environment: staging-shared
                   ref: ${{ github.event.pull_request.head.sha || github.event.client_payload.pull_request.head.sha }}
                   description: Staging deployment for PR #${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
 
@@ -79,7 +79,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
                   state: success
-                  environment-url: https://staging-${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}.antalmanac.com
+                  environment-url: https://staging-shared.antalmanac.com
 
             - name: Add reaction to comment
               if: github.event_name == 'repository_dispatch'

--- a/apps/antalmanac/src/globals.ts
+++ b/apps/antalmanac/src/globals.ts
@@ -4,4 +4,4 @@ export const BLUE = '#305db7';
 
 export const FEEDBACK_LINK = 'https://form.asana.com/?k=fZ3SGnuGknDmzTYdocgIUg&d=1208267282546207';
 
-export const PLANNER_LINK = 'https://peterportal.org';
+export const PLANNER_LINK = '/planner';

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -1,5 +1,5 @@
 import { EventNote, Route } from '@mui/icons-material';
-import { Paper, Stack, type SxProps, Typography, useTheme } from '@mui/material';
+import { Paper, Stack, SxProps, Typography, useTheme } from '@mui/material';
 import Link from 'next/link';
 
 import { useIsMobile } from '$hooks/useIsMobile';

--- a/apps/antalmanac/src/shared-components/SideNav.tsx
+++ b/apps/antalmanac/src/shared-components/SideNav.tsx
@@ -1,5 +1,5 @@
 import { EventNote, Route } from '@mui/icons-material';
-import { Paper, Stack, SxProps, Typography, useTheme } from '@mui/material';
+import { Paper, Stack, type SxProps, Typography, useTheme } from '@mui/material';
 import Link from 'next/link';
 
 import { useIsMobile } from '$hooks/useIsMobile';

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -12,14 +12,14 @@ function getDomain() {
     throw new Error('Invalid stage');
 }
 
-// const isPermanentStage = ['production', 'staging-shared'].includes($app.stage);
+const isPermanentStage = ['production', 'scheduler', 'staging-shared'].includes($app.stage);
 
 export default $config({
     app(input) {
         return {
             name: 'antalmanac',
-            removal: ['production', 'staging-shared'].includes(input?.stage) ? 'retain' : 'remove',
-            protect: ['production', 'staging-shared'].includes(input?.stage),
+            removal: isPermanentStage ? 'retain' : 'remove',
+            protect: isPermanentStage,
             home: 'aws',
         };
     },
@@ -39,10 +39,6 @@ export default $config({
                 instance: router,
                 path: '/',
             },
-            // domain: {
-            //     name: domain,
-            //     redirects: $app.stage.match(/^staging-(\d+)$/) ? [] : [`www.${domain}`],
-            // },
             cachePolicy: '92d18877-845e-47e7-97e6-895382b1bf7c',
             environment: {
                 DB_URL: $app.stage === 'production' ? process.env.PROD_DB_URL : process.env.DEV_DB_URL,

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -12,14 +12,14 @@ function getDomain() {
     throw new Error('Invalid stage');
 }
 
-const isPermanentStage = ['production', 'scheduler', 'staging-shared'].includes($app.stage);
+const isPermanentStage = ['production', 'scheduler', 'staging-shared'];
 
 export default $config({
     app(input) {
         return {
             name: 'antalmanac',
-            removal: isPermanentStage ? 'retain' : 'remove',
-            protect: isPermanentStage,
+            removal: isPermanentStage.includes(input?.stage) ? 'retain' : 'remove',
+            protect: isPermanentStage.includes(input?.stage),
             home: 'aws',
         };
     },


### PR DESCRIPTION
## Summary

Defines two permanent stages: `production` and `staging-shared` and, if applicable, directs SST's Next.js constructor to use the Routers (cloudfront distribution) attached to those two stages.

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
