### PR TITLE
ci: add posthog key to prod

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -18,6 +18,7 @@ env:
     OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
     OIDC_ISSUER_URL: ${{ secrets.OIDC_ISSUER_URL }}
     GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+    NEXT_PUBLIC_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_PUBLIC_POSTHOG_KEY }}
 
 jobs:
     deploy-production:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -20,6 +20,7 @@ env:
     OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
     OIDC_ISSUER_URL: ${{ secrets.OIDC_ISSUER_URL }}
     GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+    NEXT_PUBLIC_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_PUBLIC_POSTHOG_KEY }}
 
 jobs:
     deploy-staging:

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -38,6 +38,7 @@ export default $config({
                 OIDC_ISSUER_URL: process.env.OIDC_ISSUER_URL,
                 GOOGLE_REDIRECT_URI: `https://${domain}/auth`,
                 NEXT_PUBLIC_BASE_URL: domain,
+                NEXT_PUBLIC_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_PUBLIC_POSTHOG_KEY,
             },
         });
     },


### PR DESCRIPTION
## Summary
Adds `NEXT_PUBLIC_PUBLIC_POSTHOG_KEY` to repo secrets (manually) and SST

## Test Plan

## Issues

Closes #1425

<!-- [Optional]
## Future Followup
-->
