### PR TITLE
feat: add schedule selector to mobile Added Pane (#1177)

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,4 +1,5 @@
 import { updateScheduleNote } from '$actions/AppStoreActions';
+import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
 import { ClearScheduleButton } from '$components/buttons/Clear';
 import { CopyScheduleButton } from '$components/buttons/Copy';
 import { EmptyState } from '$components/EmptyState';
@@ -7,6 +8,7 @@ import { getMissingSections } from '$components/RightPane/AddedCourses/getMissin
 import { NotificationsDialog } from '$components/RightPane/AddedCourses/Notifications/NotificationsDialog';
 import { ColumnToggleDropdown } from '$components/RightPane/CoursePane/CoursePaneButtonRow';
 import SectionTable from '$components/RightPane/SectionTable/SectionTable';
+import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
@@ -296,7 +298,7 @@ function AddedSectionsGrid() {
     const [courses, setCourses] = useState(getCourses());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
-
+    const isMobile = useIsMobile();
     useEffect(() => {
         const handleCoursesChange = () => {
             setCourses(getCourses());
@@ -350,7 +352,10 @@ function AddedSectionsGrid() {
                 <NotificationsDialog buttonSx={buttonSx} />
             </Box>
             <Box sx={{ marginTop: 7 }}>
-                <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                    {isMobile && <SelectSchedulePopover />}
+                </Box>
                 {courses.length === 0 && (
                     <EmptyState
                         Icon={MenuBook}

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -298,7 +298,9 @@ function AddedSectionsGrid() {
     const [courses, setCourses] = useState(getCourses());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+
     const isMobile = useIsMobile();
+
     useEffect(() => {
         const handleCoursesChange = () => {
             setCourses(getCourses());

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -354,10 +354,14 @@ function AddedSectionsGrid() {
                 <NotificationsDialog buttonSx={buttonSx} />
             </Box>
             <Box sx={{ marginTop: 7 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {isMobile ? (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                        <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                        <SelectSchedulePopover />
+                    </Box>
+                ) : (
                     <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                    {isMobile && <SelectSchedulePopover />}
-                </Box>
+                )}
                 {courses.length === 0 && (
                     <EmptyState
                         Icon={MenuBook}

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -354,14 +354,8 @@ function AddedSectionsGrid() {
                 <NotificationsDialog buttonSx={buttonSx} />
             </Box>
             <Box sx={{ marginTop: 7 }}>
-                {isMobile ? (
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                        <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                        <SelectSchedulePopover />
-                    </Box>
-                ) : (
-                    <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                )}
+                <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                {isMobile && <SelectSchedulePopover />}
                 {courses.length === 0 && (
                     <EmptyState
                         Icon={MenuBook}


### PR DESCRIPTION
## Summary
Adds a schedule selector to the mobile Added Pane, allowing mobile users to switch between schedules. The selector only appears on mobile viewports and reuses the existing `SelectSchedulePopover` component.
## Test Plan
1. Open AntAlmanac on localhost:3000
2. Resize browser window to mobile width (<600px) or use device emulation
3. Navigate to the "Added" courses tab
4. Verify schedule selector button appears next to schedule name (e.g., "Schedule 1 (0 Units)")
5. Click the selector and verify you can switch between schedules
6. Resize to desktop width and verify selector does NOT appear (desktop uses toolbar selector)
## Issues
Closes #1177

<!-- [Optional]
## Future Followup
-->
