### PR TITLE
fix: remove Pulumi step from SST workflows

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -45,12 +45,6 @@ jobs:
                   DB_URL: ${{ secrets.PROD_DB_URL }}
               run: pnpm db:migrate
 
-            # TODO (@xgraceyan): Remove this stage once SST fixes deployments
-            - name: Setup Pulumi
-              uses: pulumi/actions@v5
-              with:
-                  pulumi-version: 3.138.0 # Any version < 3.214.0 works
-
             - name: Deploy SST (production)
               env:
                   SST_STAGE: production

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -64,12 +64,6 @@ jobs:
                   DB_URL: ${{ secrets.DEV_DB_URL }}
               run: pnpm db:migrate
 
-            # TODO (@xgraceyan): Remove this stage once SST fixes deployments
-            - name: Setup Pulumi
-              uses: pulumi/actions@v5
-              with:
-                  pulumi-version: 3.138.0 # Any version < 3.214.0 works
-
             - name: Deploy SST (staging)
               id: deploy
               run: |

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -55,12 +55,6 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            # TODO (@xgraceyan): Remove this stage once SST fixes deployments
-            - name: Setup Pulumi
-              uses: pulumi/actions@v5
-              with:
-                  pulumi-version: 3.138.0 # Any version < 3.214.0 works
-
             - name: Remove SST staging stage
               run: |
                   echo "Removing stage: $SST_STAGE"

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -4,12 +4,14 @@ import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { updateScheduleNote } from '$actions/AppStoreActions';
+import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
 import CustomEventDetailView from '$components/RightPane/AddedCourses/CustomEventDetailView';
 import { getMissingSections } from '$components/RightPane/AddedCourses/getMissingSections';
 import { ColumnToggleDropdown } from '$components/RightPane/CoursePane/CoursePaneButtonRow';
 import SectionTableLazyWrapper from '$components/RightPane/SectionTable/SectionTableLazyWrapper';
 import { ClearScheduleButton } from '$components/buttons/Clear';
 import { CopyScheduleButton } from '$components/buttons/Copy';
+import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
 import AppStore from '$stores/AppStore';
@@ -290,7 +292,7 @@ function AddedSectionsGrid() {
     const [courses, setCourses] = useState(getCourses());
     const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
-
+    const isMobile = useIsMobile();
     useEffect(() => {
         const handleCoursesChange = () => {
             setCourses(getCourses());
@@ -350,7 +352,10 @@ function AddedSectionsGrid() {
                 <ColumnToggleDropdown />
             </Box>
             <Box sx={{ marginTop: 7 }}>
-                <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
+                    {isMobile && <SelectSchedulePopover />}
+                </Box>
                 {courses.length < 1 ? NoCoursesBox : null}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {


### PR DESCRIPTION
## Summary
- Removes the temporary Pulumi setup step from production and staging deploy/destroy workflows
- This workaround is no longer needed as SST has fixed the deployment issues

## Changes
- Removed Pulumi setup from `deploy_production.yml`
- Removed Pulumi setup from `deploy_staging.yml`
- Removed Pulumi setup from `destroy_staging.yml`

Fixes #1409