### PR TITLE
Fix: Use custom event ID as key instead of title

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -124,7 +124,7 @@ function CustomEventsBox() {
             <Box display="flex" flexDirection="column" gap={1}>
                 {customEvents.map((customEvent) => {
                     return (
-                        <Box key={customEvent.title}>
+                        <Box key={customEvent.customEventID}>
                             <CustomEventDetailView
                                 customEvent={customEvent}
                                 scheduleNames={AppStore.getScheduleNames()}


### PR DESCRIPTION
## Summary

Fix a bug where using custom event titles as keys when `.map()`ing causes an error when multiple custom events have the same title.

## Test Plan

1. Create two custom events with the same name (in the same schedule)
2. Navigate to the Added tab and ensure no errors pop up in the console

## Issues

Closes #1436

<!-- [Optional]
## Future Followup
-->
