### PR TITLE
feat: Add automated workflow to detect new academic quarters

### DIFF
--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -41,7 +41,23 @@ jobs:
                     exit 1
                 fi
 
-                
+                LATEST_TERM=$(echo "$API_RESPONSE" | jq -r '.data[0].longName')
+
+                if [ ! -f .github/deployed_terms.json ]; then
+                    echo "deployed_terms.json does not exist"
+                    echo "Creating initial deployed_terms.json..."
+                    echo "$API_RESPONSE" > .github/deployed_terms.json
+                    echo "update_needed=true" >> $GITHUB_OUTPUT
+                    echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
+                    echo "reason=initial deployed terms tracking file not generated" >> $GITHUB_OUTPUT
+
+                    exit 0
+                fi
+
+        
+
+
+
 
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -66,7 +66,20 @@ jobs:
                     echo "reason=new quarter available, trigger rebuild" >> $GITHUB_OUTPUT
                     echo "$API_RESPONSE" > .github/deployed_terms.json
 
-        
+            - name: Commit and push updated terms
+              if: steps.check.outputs.update_needed == 'true'
+              run: |
+                git config user.name "github-actions[bot]"        
+                git config user.email "github-actions[bot]@users.noreply.github.com"        
+
+                git add .github/deployed_terms.json
+
+                git commit -m "ci: ${{ steps.check.outputs.reason }}
+New term: ${{ steps.check.outputs.new_term }}
+Updated by automated workflow on $(date -u +%Y-%m-%d)
+                
+                git push origin main
+                echo "Updated deployed_terms.json and triggered rebuild"
 
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -52,9 +52,11 @@ jobs:
                       echo "deployed_terms.json does not exist"
                       echo "Creating initial deployed_terms.json..."
                       echo "$API_RESPONSE" > .github/deployed_terms.json
-                      echo "update_needed=true" >> $GITHUB_OUTPUT
-                      echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
-                      echo "reason=initial deployed terms tracking file not generated" >> $GITHUB_OUTPUT
+                      {
+                        echo "update_needed=true"
+                        echo "new_term=$LATEST_TERM"
+                        echo "reason=initial deployed terms tracking file not generated"
+                      } >> $GITHUB_OUTPUT
 
                       exit 0
                   fi

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -56,6 +56,9 @@ jobs:
 
                 LATEST_DEPLOYED=$(cat .github/deployed_terms.json | jq -r '.data[0].longName')
 
+                echo "Latest term from API: $LATEST_TERM"
+                echo "Latest deployed term: $LATEST_DEPLOYED"
+
                 if [[ "$LATEST_DEPLOYED" == "$LATEST_TERM" ]]; then
                     echo "No new quarter found"
                     echo "update_needed=false" >> $GITHUB_OUTPUT
@@ -65,18 +68,16 @@ jobs:
                     echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
                     echo "reason=new quarter available, trigger rebuild" >> $GITHUB_OUTPUT
                     echo "$API_RESPONSE" > .github/deployed_terms.json
+                fi
 
             - name: Commit and push updated terms
               if: steps.check.outputs.update_needed == 'true'
-              run: |
-                git config user.name "github-actions[bot]"        
-                git config user.email "github-actions[bot]@users.noreply.github.com"        
-
+              run: |      
                 git add .github/deployed_terms.json
-
                 git commit -m "ci: ${{ steps.check.outputs.reason }}
 New term: ${{ steps.check.outputs.new_term }}
-Updated by automated workflow on $(date -u +%Y-%m-%d)
+
+Auto-updated by workflow on $(date -u +%Y-%m-%d)"
                 
                 git push origin main
                 echo "Updated deployed_terms.json and triggered rebuild"

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -1,4 +1,5 @@
 name: Check for New Quarter and Reschedule
+
 on:
     schedule:
         # NEXT SOC RELEASE
@@ -6,6 +7,26 @@ on:
         # END NEXT SOC RELEASE
     workflow_dispatch:
   
+env:
+    ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+
+permissions:
+    contents: write
+
+jobs:
+    check-and-reschedule:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+            
+            - name: Configure Git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
 
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -72,12 +72,11 @@ jobs:
 
             - name: Commit and push updated terms
               if: steps.check.outputs.update_needed == 'true'
-              run: |      
+              run: |
                 git add .github/deployed_terms.json
-                git commit -m "ci: ${{ steps.check.outputs.reason }}
-New term: ${{ steps.check.outputs.new_term }}
-
-Auto-updated by workflow on $(date -u +%Y-%m-%d)"
+                git commit -m "ci: ${{ steps.check.outputs.reason }}" \
+                           -m "New term: ${{ steps.check.outputs.new_term }}" \
+                           -m "Auto-updated by workflow on $(date -u +%Y-%m-%d)"
                 
                 git push origin main
                 echo "Updated deployed_terms.json and triggered rebuild"

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -87,5 +87,6 @@ jobs:
                              -m "New term: ${{ steps.check.outputs.new_term }}" \
                              -m "Auto-updated by workflow on $(date -u +%Y-%m-%d)"
 
+                  git pull --rebase origin ${{ github.ref_name }}
                   git push
                   echo "Updated deployed_terms.json and triggered rebuild"

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -73,7 +73,7 @@ jobs:
                       echo "New quarter detected!"
                       echo "$API_RESPONSE" > .github/deployed_terms.json
                       {
-                          echo "update_needed=true" >>
+                          echo "update_needed=true"
                           echo "new_term=$LATEST_TERM"
                           echo "reason=new quarter available, trigger rebuild"
                       } >> $GITHUB_OUTPUT

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -29,19 +29,24 @@ jobs:
               id: check
               run: |
                   echo "Fetching latest terms from AnteaterAPI..."
-                  API_RESPONSE=$(curl -s https://anteaterapi.com/v2/rest/websoc/terms)
+                  API_RESPONSE=$(
+                    curl -s https://anteaterapi.com/v2/rest/websoc/terms \
+                    -H "Authorization: Bearer $ANTEATER_API_KEY" \
+                    -H "Origin: https://antalmanac.com"
+                  )
 
-                  if [ -z "$API_RESPONSE" ]; then
-                      echo "Error: AnteaterAPI returned an empty response"
-                      exit 1
-                  fi 
 
                   if ! echo "$API_RESPONSE" | jq empty 2>/dev/null; then
                       echo "Error: AnteaterAPI returned invalid JSON"
                       exit 1
                   fi
 
-                  LATEST_TERM=$(echo "$API_RESPONSE" | jq -r '.data[0].longName')
+                  LATEST_TERM=$(echo "$API_RESPONSE" | jq -r '.data[0].longName // empty')
+
+                  if [[ -z "$LATEST_TERM" ]]; then
+                      echo "Error: AnteaterAPI returned an empty response"
+                      exit 1
+                  fi
 
                   if [[ ! -f .github/deployed_terms.json ]]; then
                       echo "deployed_terms.json does not exist"

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -54,6 +54,18 @@ jobs:
                     exit 0
                 fi
 
+                LATEST_DEPLOYED=$(cat .github/deployed_terms.json | jq -r '.data[0].longName')
+
+                if [[ "$LATEST_DEPLOYED" == "$LATEST_TERM" ]]; then
+                    echo "No new quarter found"
+                    echo "update_needed=false" >> $GITHUB_OUTPUT
+                else
+                    echo "New quarter detected!"
+                    echo "update_needed=true" >> $GITHUB_OUTPUT
+                    echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
+                    echo "reason=new quarter available, trigger rebuild" >> $GITHUB_OUTPUT
+                    echo "$API_RESPONSE" > .github/deployed_terms.json
+
         
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -78,7 +78,7 @@ jobs:
                            -m "New term: ${{ steps.check.outputs.new_term }}" \
                            -m "Auto-updated by workflow on $(date -u +%Y-%m-%d)"
                 
-                git push origin main
+                git push
                 echo "Updated deployed_terms.json and triggered rebuild"
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -1,10 +1,8 @@
-name: Check for New Quarter and Reschedule
+name: Check for New Quarter and Update Deployed Terms if needed
 
 on:
     schedule:
-        # NEXT SOC RELEASE
         - cron: '0 * * * *'
-        # END NEXT SOC RELEASE
     workflow_dispatch:
   
 env:
@@ -27,6 +25,23 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
+            - name: Check for new Terms
+              id: check
+              run: |
+                echo "Fetching latest terms from AnteaterAPI..."
+                API_RESPONSE=$(curl -s https://anteaterapi.com/v2/rest/websoc/terms)
+
+                if [ -z "$API_RESPONSE" ]; then
+                    echo "Error: AnteaterAPI returned an empty response"
+                    exit 1
+                fi 
+
+                if ! echo "$API_RESPONSE" | jq empty 2>/dev/null; then
+                    echo "Error: AnteaterAPI returned invalid JSON"
+                    exit 1
+                fi
+
+                
 
 
 

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -1,0 +1,11 @@
+name: Check for New Quarter and Reschedule
+on:
+    schedule:
+        # NEXT SOC RELEASE
+        - cron: '0 * * * *'
+        # END NEXT SOC RELEASE
+    workflow_dispatch:
+  
+
+
+

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -1,4 +1,4 @@
-name: Check for New Quarter and Update Deployed Terms if needed
+name: Check for New Quarter and Update Deployed Terms If Needed
 
 on:
     schedule:
@@ -12,11 +12,11 @@ permissions:
     contents: write
 
 jobs:
-    check-and-reschedule:
+    check-quarters:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -25,7 +25,7 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
-            - name: Check for new Terms
+            - name: Check for new terms
               id: check
               run: |
                   echo "Fetching latest terms from AnteaterAPI..."

--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -4,7 +4,7 @@ on:
     schedule:
         - cron: '0 * * * *'
     workflow_dispatch:
-  
+
 env:
     ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
 
@@ -19,7 +19,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-            
+
             - name: Configure Git
               run: |
                   git config user.name "github-actions[bot]"
@@ -28,61 +28,57 @@ jobs:
             - name: Check for new Terms
               id: check
               run: |
-                echo "Fetching latest terms from AnteaterAPI..."
-                API_RESPONSE=$(curl -s https://anteaterapi.com/v2/rest/websoc/terms)
+                  echo "Fetching latest terms from AnteaterAPI..."
+                  API_RESPONSE=$(curl -s https://anteaterapi.com/v2/rest/websoc/terms)
 
-                if [ -z "$API_RESPONSE" ]; then
-                    echo "Error: AnteaterAPI returned an empty response"
-                    exit 1
-                fi 
+                  if [ -z "$API_RESPONSE" ]; then
+                      echo "Error: AnteaterAPI returned an empty response"
+                      exit 1
+                  fi 
 
-                if ! echo "$API_RESPONSE" | jq empty 2>/dev/null; then
-                    echo "Error: AnteaterAPI returned invalid JSON"
-                    exit 1
-                fi
+                  if ! echo "$API_RESPONSE" | jq empty 2>/dev/null; then
+                      echo "Error: AnteaterAPI returned invalid JSON"
+                      exit 1
+                  fi
 
-                LATEST_TERM=$(echo "$API_RESPONSE" | jq -r '.data[0].longName')
+                  LATEST_TERM=$(echo "$API_RESPONSE" | jq -r '.data[0].longName')
 
-                if [ ! -f .github/deployed_terms.json ]; then
-                    echo "deployed_terms.json does not exist"
-                    echo "Creating initial deployed_terms.json..."
-                    echo "$API_RESPONSE" > .github/deployed_terms.json
-                    echo "update_needed=true" >> $GITHUB_OUTPUT
-                    echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
-                    echo "reason=initial deployed terms tracking file not generated" >> $GITHUB_OUTPUT
+                  if [[ ! -f .github/deployed_terms.json ]]; then
+                      echo "deployed_terms.json does not exist"
+                      echo "Creating initial deployed_terms.json..."
+                      echo "$API_RESPONSE" > .github/deployed_terms.json
+                      echo "update_needed=true" >> $GITHUB_OUTPUT
+                      echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
+                      echo "reason=initial deployed terms tracking file not generated" >> $GITHUB_OUTPUT
 
-                    exit 0
-                fi
+                      exit 0
+                  fi
 
-                LATEST_DEPLOYED=$(cat .github/deployed_terms.json | jq -r '.data[0].longName')
+                  LATEST_DEPLOYED=$(jq -r '.data[0].longName // empty' .github/deployed_terms.json)
 
-                echo "Latest term from API: $LATEST_TERM"
-                echo "Latest deployed term: $LATEST_DEPLOYED"
+                  echo "Latest term from API: $LATEST_TERM"
+                  echo "Latest deployed term: $LATEST_DEPLOYED"
 
-                if [[ "$LATEST_DEPLOYED" == "$LATEST_TERM" ]]; then
-                    echo "No new quarter found"
-                    echo "update_needed=false" >> $GITHUB_OUTPUT
-                else
-                    echo "New quarter detected!"
-                    echo "update_needed=true" >> $GITHUB_OUTPUT
-                    echo "new_term=$LATEST_TERM" >> $GITHUB_OUTPUT
-                    echo "reason=new quarter available, trigger rebuild" >> $GITHUB_OUTPUT
-                    echo "$API_RESPONSE" > .github/deployed_terms.json
-                fi
+                  if [[ "$LATEST_DEPLOYED" == "$LATEST_TERM" ]]; then
+                      echo "No new quarter found"
+                      echo "update_needed=false" >> $GITHUB_OUTPUT
+                  else
+                      echo "New quarter detected!"
+                      echo "$API_RESPONSE" > .github/deployed_terms.json
+                      {
+                          echo "update_needed=true" >>
+                          echo "new_term=$LATEST_TERM"
+                          echo "reason=new quarter available, trigger rebuild"
+                      } >> $GITHUB_OUTPUT
+                  fi
 
             - name: Commit and push updated terms
               if: steps.check.outputs.update_needed == 'true'
               run: |
-                git add .github/deployed_terms.json
-                git commit -m "ci: ${{ steps.check.outputs.reason }}" \
-                           -m "New term: ${{ steps.check.outputs.new_term }}" \
-                           -m "Auto-updated by workflow on $(date -u +%Y-%m-%d)"
-                
-                git push
-                echo "Updated deployed_terms.json and triggered rebuild"
+                  git add .github/deployed_terms.json
+                  git commit -m "ci: ${{ steps.check.outputs.reason }}" \
+                             -m "New term: ${{ steps.check.outputs.new_term }}" \
+                             -m "Auto-updated by workflow on $(date -u +%Y-%m-%d)"
 
-
-
-
-
-
+                  git push
+                  echo "Updated deployed_terms.json and triggered rebuild"


### PR DESCRIPTION
## Summary
Adds a GH actions workflow that automatically detects when new academic quarters become available in AnteaterAPI and triggers a rebuild. 

## Test Plan
Tested three scenarios on branch `fp/auto-quarter-rollover`:

1. Bootstrap - File doesn't exist:
- Workflow created `.github/deployed_terms.json` from AnteaterAPI
- Committed and pushed successfully

2. New quarter detection:
- Manually removed the latest term in `deployed_terms.json` to simulate the mismatch
- Workflow detected the change and updated the file
- Committed and pushed the file with the appropriate message

3. No changes (most common case):
- Workflow detected terms match
- Skipped commit step
- No unnecessary commits

## Issues
Closes #1319
