### PR TITLE
ci: enforce typescript and eslint errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Setup Node.js and pnpm
+              uses: ./.github/actions/setup-node-and-pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Generate termData
+              env:
+                  ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+              run: pnpm --filter antalmanac get-data
+
+            - name: ESLint
+              run: pnpm --filter antalmanac lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.head_ref }}-lint
+    cancel-in-progress: true
+
 jobs:
     lint:
         runs-on: ubuntu-latest

--- a/apps/antalmanac/next.config.mjs
+++ b/apps/antalmanac/next.config.mjs
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    // TODO: Remove these ignores and fix the underlying issues
-    typescript: {
-        ignoreBuildErrors: true,
-    },
     serverExternalPackages: ['@node-rs/argon2'],
 };
 

--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -22,7 +22,7 @@
         "predeploy": "npm run build",
         "deploy": "gh-pages -d build",
         "format": "prettier --write src",
-        "lint": "eslint src",
+        "lint": "eslint src --max-warnings=0",
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -1,4 +1,10 @@
-import { type AutocompleteInputChangeReason, Box, Divider, Typography } from '@mui/material';
+import {
+    type AutocompleteInputChangeReason,
+    AutocompleteRenderGroupParams,
+    Box,
+    Divider,
+    Typography,
+} from '@mui/material';
 import type { SearchResult } from '@packages/antalmanac-types';
 import { PostHog } from 'posthog-js/react';
 import { PureComponent } from 'react';
@@ -269,7 +275,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
         return isOffered ? groupType.OFFERED : groupType.NOT_OFFERED;
     };
 
-    renderGroup = (params: { key: string; group: string; children?: React.ReactNode }) => {
+    renderGroup = (params: AutocompleteRenderGroupParams) => {
         if (params.group === groupType.UNGROUPED) {
             return <Box key={params.key}>{params.children}</Box>;
         }


### PR DESCRIPTION
## Summary
Fixes the remaining TypeScript errors.

Prevent Typescript and ESLint warnings/errors from creeping back into the codebase. https://github.com/icssc/AntAlmanac/pull/1398#discussion_r2684632005 remains a concern. If there are any good solutions to this problem, please let me know.

After this PR is merged, it is recommended to sync all open PRs to main, as this would be another workflow that should be used during the review process.

## Test Plan

## Issues

Closes https://github.com/icssc/AntAlmanac/issues/1258
