### PR TITLE
ci: block on TS errors

### DIFF
--- a/apps/antalmanac/next.config.mjs
+++ b/apps/antalmanac/next.config.mjs
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    // TODO: Remove these ignores and fix the underlying issues
-    typescript: {
-        ignoreBuildErrors: true,
-    },
     serverExternalPackages: ['@node-rs/argon2'],
 };
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -1,4 +1,10 @@
-import { type AutocompleteInputChangeReason, Box, Divider, Typography } from '@mui/material';
+import {
+    type AutocompleteInputChangeReason,
+    AutocompleteRenderGroupParams,
+    Box,
+    Divider,
+    Typography,
+} from '@mui/material';
 import type { SearchResult } from '@packages/antalmanac-types';
 import { PostHog } from 'posthog-js/react';
 import { PureComponent } from 'react';
@@ -269,7 +275,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
         return isOffered ? groupType.OFFERED : groupType.NOT_OFFERED;
     };
 
-    renderGroup = (params: { key: string; group: string; children?: React.ReactNode }) => {
+    renderGroup = (params: AutocompleteRenderGroupParams) => {
         if (params.group === groupType.UNGROUPED) {
             return <Box key={params.key}>{params.children}</Box>;
         }


### PR DESCRIPTION
## Summary
Following changes in #1397 and #1398, we can remove the ignore fields from our Next config (which should block deploys and merges) for a more stable deploy

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
