### PR TITLE
fix: add missing query parameters when manual searching by GE

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -24,6 +24,16 @@ class GeDataFetchProvider extends PureComponent<SectionTableProps> {
             ge: 'ANY',
             courseNumber: this.props.courseDetails.courseNumber,
             courseTitle: this.props.courseDetails.courseTitle,
+            instructorName: formData.instructor,
+            units: formData.units,
+            endTime: formData.endTime,
+            startTime: formData.startTime,
+            fullCourses: formData.coursesFull,
+            building: formData.building,
+            room: formData.room,
+            division: formData.division, 
+            excludeRestrictionCodes: formData.excludeRestrictionCodes.split('').join(','),
+            days: formData.days.split(/(?=[A-Z])/).join(','), 
         };
 
         const jsonResp = await WebSOC.query(params);


### PR DESCRIPTION
## Summary
When using manual search and searching by GE, the api query was missing parameters. Searching by GE and e.g. instructor, day, start time, etc would not work. Now, these parameters are included in the api query.
<img width="1553" height="1386" alt="image" src="https://github.com/user-attachments/assets/6024586f-acf3-467a-b5a9-88992541abca" />

## Test Plan
Manual search by GE + some other filter. Make sure all parameters are in the query url

## Issues

Closes #1278
