### PR TITLE
fix: tutorial box

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
                                     boxShadow: '0 0 10px #000',
                                     padding: 20,
                                     paddingTop: 40,
-                                    margin: 20,
+                                    margin: '10px 20px 20px 20px',
                                 }),
                             }}
                         >

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
                                     boxShadow: '0 0 10px #000',
                                     padding: 20,
                                     paddingTop: 40,
-                                    margin: '10px 20px 20px 20px',
+                                    margin: '4px 20px 20px 20px',
                                 }),
                             }}
                         >

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -70,7 +70,8 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
 
     return {
         welcome: {
-            selector: '#root',
+            selector: '#__next',
+            position: 'center',
             content: (
                 <>
                     Welcome to AntAlmanac!
@@ -87,21 +88,23 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
             },
         },
         searchBar: {
-            selector: '#searchBar',
+            selector: '#fuzzy-search',
             content: 'You can search for your classes here!',
             action: () => {
                 markTourHasRun();
                 setActiveTab('search');
             },
-            mutationObservables: ['#searchBar'],
+            mutationObservables: ['#fuzzy-search'],
         },
         importButton: {
             selector: '#import-button',
             content: 'Quickly add your classes from WebReg or Zotcourse!',
+            position: 'bottom',
         },
         calendar: {
             selector: '.rbc-time-view', // Calendar.
             content: 'See the classes in your schedule!',
+            position: 'bottom',
             action: () => {
                 addSampleClasses();
                 const finalsButtonPressed = document.getElementById('finals-button-pressed');
@@ -190,6 +193,7 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
                     That&apos;s it 🎉 Good luck with your classes!
                 </>
             ),
+            position: 'bottom',
             action: tourActionFactory(() => goToNamedStep(TourStepName.saveAndLoad), {
                 selector: '#load-save-container',
                 eventType: 'click',

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -70,7 +70,7 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
 
     return {
         welcome: {
-            selector: '#__next',
+            selector: '#root',
             position: 'center',
             content: (
                 <>

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -102,7 +102,7 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
             position: 'bottom',
         },
         calendar: {
-            selector: '.rbc-time-view', // Calendar.
+            selector: '#calendar-root',
             content: 'See the classes in your schedule!',
             position: 'right',
             action: () => {
@@ -111,6 +111,8 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
                 if (!finalsButtonPressed) return;
                 finalsButtonPressed.click(); // To switch back to normal view
             },
+            resizeObservables: ['#calendar-root'],
+            mutationObservables: ['#calendar-root'],
         },
         finalsButton: {
             selector: '#finals-button, #finals-button-pressed',
@@ -182,8 +184,23 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
         mapPane: {
             selector: '#map-pane',
             content: 'Click on a day to see your route!',
-            action: () => setActiveTab('map'),
-            mutationObservables: ['#map-pane'],
+            action: () => {
+                setActiveTab('map');
+
+                if (!window.location.pathname.includes('/map')) {
+                    // Clicking the tab will also navigate via the Link component
+                    setTimeout(() => {
+                        document.getElementById('map-tab')?.click();
+                    }, 0);
+                }
+
+                // Re-measure after the map mounts
+                setTimeout(() => {
+                    window.dispatchEvent(new Event('resize'));
+                }, 50);
+            },
+            mutationObservables: ['#root', '#map-pane'],
+            resizeObservables: ['#root', '#map-pane'],
         },
         saveAndLoad: {
             selector: '#save-button',

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -104,7 +104,7 @@ export function namedStepsFactory(goToStep: (step: number) => void): Record<Tour
         calendar: {
             selector: '.rbc-time-view', // Calendar.
             content: 'See the classes in your schedule!',
-            position: 'bottom',
+            position: 'right',
             action: () => {
                 addSampleClasses();
                 const finalsButtonPressed = document.getElementById('finals-button-pressed');


### PR DESCRIPTION
## Summary
Fix the tutorial tour popover getting cut off-screen by adjusting the tour popover margin and setting better step positions (including centering the welcome step). Also updates the search step selector to #fuzzy-search so it anchors correctly.

<img width="1624" height="1056" alt="Screenshot 2026-01-23 at 12 40 44 PM" src="https://github.com/user-attachments/assets/2d8795fd-1b04-4b4e-9685-5f1ba26381f8" />
<img width="1624" height="1056" alt="Screenshot 2026-01-23 at 12 40 50 PM" src="https://github.com/user-attachments/assets/96fee999-57ec-4893-81a0-c84da48ba22d" />
<img width="1624" height="1056" alt="Screenshot 2026-01-23 at 12 40 55 PM" src="https://github.com/user-attachments/assets/462642a0-8abf-4be9-8229-333acb8f1352" />


## Test Plan
- Start the app and launch the tutorial tour through the help button.
- Navigate through the tour steps, especially:
	- Step 2 (search)
	- Map + map pane steps
	- Final save/sign-in step
- Verify the popover does not stick in the top-left during transitions.

## Issues
- Changes were made in the padding, it's either the top will get cut a little bit or the bottom ones. 
- To fix the fallback -> If a selector truly never becomes measurable, the helper times out after ~8s and logs an info message.

Closes #1415 

<!-- [Optional]
## Future Followup
-->
