### PR TITLE
fix: improve fuzzy search keywords

### DIFF
--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -92,7 +92,7 @@ const searchRouter = router({
                 matchedSections.length === MAX_AUTOCOMPLETE_RESULTS
                     ? []
                     : fuzzysort.go(query, searchData.departments, {
-                          keys: ['id', 'alias'],
+                          keys: ['id', 'name', 'alias'],
                           limit: MAX_AUTOCOMPLETE_RESULTS - matchedSections.length,
                       });
 


### PR DESCRIPTION
## Summary
Add department `name` field to fuzzy search keys so searches like "sociology" or "computer science" match departments by their full name, not just abbreviations. Previously just uses `['id', 'alias']`, that's why "sociol" "cs" "compsci" works but not the full word "sociology".

## Test Plan
1. Search "sociology" -> SOCIOL department now appears in results
2. Search "computer science" -> COMPSCI department now appears in results
3. Search by alias/id "CS" and "COMPSCI" still works.

Before:
<img width="530" height="151" alt="image" src="https://github.com/user-attachments/assets/5d972ba1-33b3-4b94-9db0-fc2506534401" />

After:
<img width="530" height="270" alt="image" src="https://github.com/user-attachments/assets/c189d766-d9d4-41d7-9a98-5495e24e9ffe" />

## Issues

Closes #1282 