### PR TITLE
fix: Improve search relevancy

### DIFF
--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -39,14 +39,8 @@ const toGESearchResult = (key: GECategoryKey): [string, SearchResult] => [
 
 const toMutable = <T>(arr: readonly T[]): T[] => arr as T[];
 
-const isCourseOffered = (
-    department: string,
-    courseNumber: string,
-    termSectionCodes: Record<string, SectionSearchResult>
-): boolean => {
-    return Object.values(termSectionCodes).some((section) => {
-        return section.department === department && section.courseNumber === courseNumber;
-    });
+const isCourseOffered = (department: string, courseNumber: string, offeredCourseSet: Set<string>): boolean => {
+    return offeredCourseSet.has(`${department}-${courseNumber}`);
 };
 
 const searchRouter = router({
@@ -65,6 +59,10 @@ const searchRouter = router({
             } catch (err) {
                 throw new Error(`Failed to load term data for ${parsedTerm}: ${err}`);
             }
+
+            const offeredCourseSet = new Set(
+                Object.values(termSectionCodes).map((s) => `${s.department}-${s.sectionCode}`)
+            );
 
             const num = Number(input.query);
             const matchedSections: SectionSearchResult[] = [];
@@ -112,7 +110,7 @@ const searchRouter = router({
                                       isOffered: isCourseOffered(
                                           course.obj.metadata.department,
                                           course.obj.metadata.number,
-                                          termSectionCodes
+                                          offeredCourseSet
                                       ),
                                   },
                               };

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -61,7 +61,7 @@ const searchRouter = router({
             }
 
             const offeredCourseSet = new Set(
-                Object.values(termSectionCodes).map((s) => `${s.department}-${s.sectionCode}`)
+                Object.values(termSectionCodes).map((s) => `${s.department}-${s.courseNumber}`)
             );
 
             const num = Number(input.query);

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -92,6 +92,7 @@ const searchRouter = router({
                     : fuzzysort.go(query, searchData.departments, {
                           keys: ['id', 'name', 'alias'],
                           limit: MAX_AUTOCOMPLETE_RESULTS - matchedSections.length,
+                          threshold: 0.7,
                       });
 
             const matchedCourses =

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -100,7 +100,7 @@ const searchRouter = router({
                     : fuzzysort
                           .go(query, searchData.courses, {
                               keys: ['id', 'name', 'alias', 'metadata.department', 'metadata.number'],
-                              limit: MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - matchedSections.length,
+                              limit: 100,
                           })
                           .map((course) => {
                               return {

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -118,7 +118,8 @@ const searchRouter = router({
                           .sort((a, b) => {
                               if (a.obj.isOffered === b.obj.isOffered) return 0;
                               return a.obj.isOffered ? -1 : 1;
-                          });
+                          })
+                          .slice(0, MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - matchedSections.length);
 
             return Object.fromEntries([
                 ...matchedSections.map((x) => [x.sectionCode, x]),


### PR DESCRIPTION
## Summary
Fix fuzzy search to prioritize relevant offered courses in the current quarter.

**Changes**:
- *Courses*: Pre-compute a hashset of offered courses for O(1) lookup time. Increase the limit of course matches to 100, sort them by availability, then slice down to 12 (or however much space is left)
- *Departmets*: Add a threshold of 0.8 to filter out weak matches (e.g., "econ" no longer shows "Molecular Biology and Biochemistry")

Previously, search results were dominated by "Not Offered" courses and irrelevant department matches.

## Test Plan
1. Search "cs":
- Shows 3 relevant departments and 9 offered courses.

2.  Search "econ":
- Shows only the "Economics" department, and 11 offered econ courses. No irrelevant departments

### Before
<img width="802" height="612" alt="image" src="https://github.com/user-attachments/assets/f950193a-d87c-4a23-bc86-025c1054b68b" />
<img width="802" height="612" alt="image" src="https://github.com/user-attachments/assets/ec29f2e4-91dc-4a92-9152-3413d5f82687" />


### After
<img width="802" height="612" alt="image" src="https://github.com/user-attachments/assets/1735a313-d705-4ba2-8bbb-f6bb543bc706" />
<img width="802" height="612" alt="image" src="https://github.com/user-attachments/assets/090e4fcd-e53b-4276-87ea-4825cd898316" />


## Issues

Closes #1449
