### PR TITLE
Fix: Disable HelpMenu container's pointer events

### DIFF
--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -8,7 +8,6 @@ import {
     type SvgIconProps,
     Tooltip,
     IconButton,
-    SxProps,
 } from '@mui/material';
 import { useCallback, useState } from 'react';
 
@@ -29,11 +28,6 @@ export type HelpMenuAction = {
     disableOnMobile?: boolean;
     onClick: VoidFunction;
 } | null;
-
-/** When adding a new item, add this to its `sx` prop */
-const commonChildItemStyles: SxProps = {
-    pointerEvents: 'auto',
-};
 
 export function HelpMenu() {
     const isMobile = useIsMobile();
@@ -76,6 +70,9 @@ export function HelpMenu() {
                 right: 8,
                 zIndex: theme.zIndex.fab,
                 pointerEvents: 'none',
+                '& > *:not(.speedDial)': {
+                    pointerEvents: 'auto',
+                },
             })}
             spacing={1}
             alignItems="center"
@@ -90,6 +87,7 @@ export function HelpMenu() {
 
             <SpeedDial
                 ariaLabel="Help Menu"
+                className="speedDial"
                 icon={
                     <Tooltip title="Help Menu" placement="left">
                         <Box
@@ -135,7 +133,6 @@ export function HelpMenu() {
                     size="large"
                     onClick={handleOpenAutoSaveWarning}
                     sx={{
-                        ...commonChildItemStyles,
                         bgcolor: isDark ? 'warning.dark' : 'warning.main',
                         color: 'white',
                         height: '4rem',

--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -29,6 +29,8 @@ export type HelpMenuAction = {
     onClick: VoidFunction;
 } | null;
 
+const SPEEDDIAL_CLASS_NAME = 'speedDial';
+
 export function HelpMenu() {
     const isMobile = useIsMobile();
     const [open, setOpen] = useState(false);
@@ -70,7 +72,7 @@ export function HelpMenu() {
                 right: 8,
                 zIndex: theme.zIndex.fab,
                 pointerEvents: 'none',
-                '& > *:not(.speedDial)': {
+                [`& > *:not(.${SPEEDDIAL_CLASS_NAME})`]: {
                     pointerEvents: 'auto',
                 },
             })}
@@ -87,7 +89,7 @@ export function HelpMenu() {
 
             <SpeedDial
                 ariaLabel="Help Menu"
-                className="speedDial"
+                className={SPEEDDIAL_CLASS_NAME}
                 icon={
                     <Tooltip title="Help Menu" placement="left">
                         <Box

--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -8,6 +8,7 @@ import {
     type SvgIconProps,
     Tooltip,
     IconButton,
+    SxProps,
 } from '@mui/material';
 import { useCallback, useState } from 'react';
 
@@ -28,6 +29,11 @@ export type HelpMenuAction = {
     disableOnMobile?: boolean;
     onClick: VoidFunction;
 } | null;
+
+/** When adding a new item, add this to its `sx` prop */
+const commonChildItemStyles: SxProps = {
+    pointerEvents: 'auto',
+};
 
 export function HelpMenu() {
     const isMobile = useIsMobile();
@@ -69,6 +75,7 @@ export function HelpMenu() {
                 bottom: isMobile ? 65 : 16, // Magic number
                 right: 8,
                 zIndex: theme.zIndex.fab,
+                pointerEvents: 'none',
             })}
             spacing={1}
             alignItems="center"
@@ -128,6 +135,7 @@ export function HelpMenu() {
                     size="large"
                     onClick={handleOpenAutoSaveWarning}
                     sx={{
+                        ...commonChildItemStyles,
                         bgcolor: isDark ? 'warning.dark' : 'warning.main',
                         color: 'white',
                         height: '4rem',

--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -29,7 +29,7 @@ export type HelpMenuAction = {
     onClick: VoidFunction;
 } | null;
 
-const SPEEDDIAL_CLASS_NAME = 'speedDial';
+const CONTROLS_POINTER_EVENTS_CLASS_NAME = 'controlsPointerEvents';
 
 export function HelpMenu() {
     const isMobile = useIsMobile();
@@ -72,7 +72,7 @@ export function HelpMenu() {
                 right: 8,
                 zIndex: theme.zIndex.fab,
                 pointerEvents: 'none',
-                [`& > *:not(.${SPEEDDIAL_CLASS_NAME})`]: {
+                [`& > *:not(.${CONTROLS_POINTER_EVENTS_CLASS_NAME})`]: {
                     pointerEvents: 'auto',
                 },
             })}
@@ -89,7 +89,7 @@ export function HelpMenu() {
 
             <SpeedDial
                 ariaLabel="Help Menu"
-                className={SPEEDDIAL_CLASS_NAME}
+                className={CONTROLS_POINTER_EVENTS_CLASS_NAME}
                 icon={
                     <Tooltip title="Help Menu" placement="left">
                         <Box

--- a/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
+++ b/apps/antalmanac/src/components/HelpMenu/HelpMenu.tsx
@@ -29,8 +29,6 @@ export type HelpMenuAction = {
     onClick: VoidFunction;
 } | null;
 
-const CONTROLS_POINTER_EVENTS_CLASS_NAME = 'controlsPointerEvents';
-
 export function HelpMenu() {
     const isMobile = useIsMobile();
     const [open, setOpen] = useState(false);
@@ -72,7 +70,8 @@ export function HelpMenu() {
                 right: 8,
                 zIndex: theme.zIndex.fab,
                 pointerEvents: 'none',
-                [`& > *:not(.${CONTROLS_POINTER_EVENTS_CLASS_NAME})`]: {
+                // MUI SpeedDial controls pointer events itself
+                '& > *:not(.MuiSpeedDial-root)': {
                     pointerEvents: 'auto',
                 },
             })}
@@ -89,7 +88,6 @@ export function HelpMenu() {
 
             <SpeedDial
                 ariaLabel="Help Menu"
-                className={CONTROLS_POINTER_EVENTS_CLASS_NAME}
                 icon={
                     <Tooltip title="Help Menu" placement="left">
                         <Box


### PR DESCRIPTION
## Summary

Fixes a bug where the HelpMenu would block pointer events even when the `SpeedDial` was closed.

## Test Plan

Confirm that the area just above the help menu button isn't blocking cursor interaction
Example:
1. Go to map tab
2. Check that hovering cursor over area above help menu button keeps the cursor a grab pointer, and that dragging moves the map

## Issues

Closes #1445

<!-- [Optional]
## Future Followup
-->
