### PR TITLE
fix: responsive fuzzy search dropdown

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -1,4 +1,10 @@
-import { type AutocompleteInputChangeReason, Box, Divider, Typography } from '@mui/material';
+import {
+    type AutocompleteInputChangeReason,
+    type AutocompleteRenderGroupParams,
+    Box,
+    Divider,
+    Typography,
+} from '@mui/material';
 import type { SearchResult } from '@packages/antalmanac-types';
 import { PostHog } from 'posthog-js/react';
 import { PureComponent } from 'react';
@@ -269,7 +275,7 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
         return isOffered ? groupType.OFFERED : groupType.NOT_OFFERED;
     };
 
-    renderGroup = (params: { key: string; group: string; children?: React.ReactNode }) => {
+    renderGroup = (params: AutocompleteRenderGroupParams) => {
         if (params.group === groupType.UNGROUPED) {
             return <Box key={params.key}>{params.children}</Box>;
         }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -1,10 +1,4 @@
-import {
-    type AutocompleteInputChangeReason,
-    type AutocompleteRenderGroupParams,
-    Box,
-    Divider,
-    Typography,
-} from '@mui/material';
+import { type AutocompleteInputChangeReason, type AutocompleteRenderGroupParams, Box, Divider, Typography } from '@mui/material';
 import type { SearchResult } from '@packages/antalmanac-types';
 import { PostHog } from 'posthog-js/react';
 import { PureComponent } from 'react';

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete.tsx
@@ -1,5 +1,5 @@
-import { Autocomplete, AutocompleteProps, TextFieldProps } from '@mui/material';
-import { useId } from 'react';
+import { Autocomplete, type AutocompleteProps, Popper, type PopperProps, type TextFieldProps } from '@mui/material';
+import { useEffect, useId, useState } from 'react';
 
 import { LabeledTextField } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTextField';
 
@@ -14,6 +14,42 @@ interface LabeledAutocompleteProps<
     textFieldProps?: TextFieldProps;
     isAligned?: boolean;
 }
+
+const ResponsivePopper = (props: PopperProps) => {
+    const { anchorEl, style, ...rest } = props;
+    const [measuredWidth, setMeasuredWidth] = useState<number>();
+
+    useEffect(() => {
+        if (!anchorEl || !(anchorEl instanceof HTMLElement)) return;
+
+        const el = anchorEl;
+        const update = () => setMeasuredWidth(el.clientWidth);
+
+        update();
+
+        const ro = new ResizeObserver(() => update());
+        ro.observe(el);
+
+        // Fallback
+        window.addEventListener('resize', update);
+
+        return () => {
+            ro.disconnect();
+            window.removeEventListener('resize', update);
+        };
+    }, [anchorEl]);
+
+    return (
+        <Popper
+            {...rest}
+            anchorEl={anchorEl}
+            style={{
+                ...style,
+                ...(measuredWidth ? { width: measuredWidth } : null),
+            }}
+        />
+    );
+};
 
 export const LabeledAutocomplete = <T,>({
     label,
@@ -33,6 +69,7 @@ export const LabeledAutocomplete = <T,>({
                 width: '100%',
             }}
             {...autocompleteProps}
+            PopperComponent={ResponsivePopper}
             renderInput={(params) => (
                 <LabeledTextField
                     label={label}


### PR DESCRIPTION
## Summary
Fixed Quick Search autocomplete dropdown so it shrinks/grows with the search bar width (syncs while the pane is resized).

<img width="1624" height="1056" alt="Screenshot 2026-01-23 at 10 11 29 PM" src="https://github.com/user-attachments/assets/67d7e608-8e65-4096-9bf2-30226c609f6a" />
<img width="1624" height="1056" alt="Screenshot 2026-01-23 at 10 11 25 PM" src="https://github.com/user-attachments/assets/f608535e-2c9c-4ad9-be13-1c9b4cee17e2" />


## Test Plan
- Search a class through quick search
- Resize the right pane while the dropdown is open and confirm the dropdown width matches the input width

## Issues

Closes #1452 

<!-- [Optional]
## Future Followup
-->
