### PR TITLE
Fix: Handle clicks on course calendar events with event wrapper only

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarCourseEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarCourseEvent.tsx
@@ -1,33 +1,18 @@
 import { Box } from '@mui/material';
 import { memo } from 'react';
-import { shallow } from 'zustand/shallow';
 
 import type { CalendarEvent, CourseEvent, Location } from '$components/Calendar/CourseCalendarEvent';
 import { isSkeletonEvent } from '$components/Calendar/CourseCalendarEvent';
 import locationIds from '$lib/locations/locations';
-import { useSelectedEventStore } from '$stores/SelectedEventStore';
 
 export const CalendarCourseEvent = memo(({ event }: { event: CalendarEvent }) => {
-    const setSelectedEvent = useSelectedEventStore((state) => state.setSelectedEvent, shallow);
-
-    const handleClick = (e: React.MouseEvent) => {
-        if (isSkeletonEvent(event)) {
-            return;
-        }
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        setSelectedEvent(e, event);
-    };
-
     if (isSkeletonEvent(event)) {
         return;
     }
 
     if (event.isCustomEvent) {
         return (
-            <Box onClick={handleClick}>
+            <Box>
                 <Box
                     style={{
                         display: 'flex',
@@ -49,7 +34,7 @@ export const CalendarCourseEvent = memo(({ event }: { event: CalendarEvent }) =>
 
     const courseEvent = event as CourseEvent;
     return (
-        <Box onClick={handleClick}>
+        <Box>
             <Box
                 style={{
                     display: 'flex',

--- a/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useCallback, useEffect, useRef } from 'react';
+import { cloneElement, isValidElement, useCallback } from 'react';
 import { EventWrapperProps } from 'react-big-calendar';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -11,14 +11,13 @@ import { useQuickSearch } from '$src/hooks/useQuickSearch';
 import { useSelectedEventStore } from '$stores/SelectedEventStore';
 
 interface CalendarCourseEventWrapperProps extends EventWrapperProps<CalendarEvent> {
-    children?: React.ReactNode;
+    children?: React.ReactElement<{ onClick: (e: React.MouseEvent) => void }>;
 }
 
 /**
  * CalendarCourseEventWrapper allows us to override the default onClick event behavior which problamtically rerenders the entire calendar
  */
 export const CalendarCourseEventWrapper = ({ children, ...props }: CalendarCourseEventWrapperProps) => {
-    const ref = useRef<HTMLDivElement>(null);
     const quickSearch = useQuickSearch();
 
     const setSelectedEvent = useSelectedEventStore(useShallow((state) => state.setSelectedEvent));
@@ -42,19 +41,5 @@ export const CalendarCourseEventWrapper = ({ children, ...props }: CalendarCours
         [props.event, quickSearch, setSelectedEvent]
     );
 
-    useEffect(() => {
-        const node = ref.current;
-        if (!node) {
-            return;
-        }
-
-        const rbcEvent = node.querySelector('.rbc-event') as HTMLDivElement;
-        if (!rbcEvent) {
-            return;
-        }
-
-        rbcEvent.onclick = (e) => handleClick(e as unknown as React.MouseEvent); // the native onclick requires a little type hacking
-    }, [handleClick]);
-
-    return <Box ref={ref}>{children}</Box>;
+    return <Box>{isValidElement(children) ? cloneElement(children, { onClick: handleClick }) : children}</Box>;
 };


### PR DESCRIPTION
## Summary

Currently, the `CalendarCourseEventWrapper` component sets React Big Calendar's HTML `onclick` event manually, which gets overriden on rerenders to be `noop` by React. To fix this, instead replace the event wrapper's child with React's `onClick` prop.

## Test Plan

1. Ensure that clicking anywhere on events shows the popover
2. Cause the calendar to rerender, whether by switching schedules or just opening/closing the schedule switcher popover
3. Ensure that clicking anywhere on events shows the popover after the rerender

## Issues

Closes #1459

<!-- [Optional]
## Future Followup
-->
