### PR TITLE
fix: calendar left header gutter flickering while width is set

### DIFF
--- a/apps/antalmanac/src/components/Calendar/calendar.css
+++ b/apps/antalmanac/src/components/Calendar/calendar.css
@@ -31,7 +31,8 @@
     border: 0;
 }
 
-.rbc-time-slot {
+.rbc-time-slot,
+.rbc-time-header-gutter {
     min-width: 42px;
 }
 


### PR DESCRIPTION
## Summary

Fix a bug where rerendering the calendar would make the header flicker as the left gutter's width was being set.

## Test Plan

1. Switch between finals/normal schedule and confirm that the header doesn't flicker

## Issues

Closes #1444

<!-- [Optional]
## Future Followup
-->
