### PR TITLE
Map fix clean

### DIFF
--- a/apps/antalmanac/src/components/LoadingScreen.tsx
+++ b/apps/antalmanac/src/components/LoadingScreen.tsx
@@ -9,7 +9,7 @@ const FUN_FACTS = [
     'Did you know? Antalmanac is maintained by the ICS Student Council at UCI!',
     'AntAlmanac was created in 2018 by a small group of students under the leadership of @the-rango.',
     'Did you know you can search for classes by pressing "CTRL/CMD" + clicking on your schedule item!',
-    'Need a 4 year plan? Checkout PeterPortal!',
+    'Need a 4 year plan? Checkout AntAlmanac Planner!',
 ];
 type LoadingScreenProps = {
     open: boolean;

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -32,7 +32,7 @@ const WORK_WEEK = ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 const FULL_WEEK = ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekendIndices = [0, 6];
 const CAMPUS_CENTER: LatLngTuple = [33.6459, -117.842717];
-const CAMPUS_BOUND_DELTA = 0.04;
+const CAMPUS_BOUND_DELTA = 0.01;
 const CAMPUS_BOUNDS: [LatLngTuple, LatLngTuple] = [
     [CAMPUS_CENTER[0] - CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] - CAMPUS_BOUND_DELTA],
     [CAMPUS_CENTER[0] + CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] + CAMPUS_BOUND_DELTA],

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -32,7 +32,7 @@ const WORK_WEEK = ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 const FULL_WEEK = ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekendIndices = [0, 6];
 const CAMPUS_CENTER: LatLngTuple = [33.6459, -117.842717];
-const CAMPUS_BOUND_DELTA = 0.01;
+const CAMPUS_BOUND_DELTA = 0.018;
 const CAMPUS_BOUNDS: [LatLngTuple, LatLngTuple] = [
     [CAMPUS_CENTER[0] - CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] - CAMPUS_BOUND_DELTA],
     [CAMPUS_CENTER[0] + CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] + CAMPUS_BOUND_DELTA],

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -31,6 +31,12 @@ const ATTRIBUTION_MARKUP =
 const WORK_WEEK = ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 const FULL_WEEK = ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekendIndices = [0, 6];
+const CAMPUS_CENTER: LatLngTuple = [33.6459, -117.842717];
+const CAMPUS_BOUND_DELTA = 0.001;
+const CAMPUS_BOUNDS: [LatLngTuple, LatLngTuple] = [
+    [CAMPUS_CENTER[0] - CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] - CAMPUS_BOUND_DELTA],
+    [CAMPUS_CENTER[0] + CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] + CAMPUS_BOUND_DELTA],
+];
 
 interface MarkerContent {
     key: string;
@@ -299,13 +305,16 @@ export default function CourseMap() {
      */
     const startDestPairs = useMemo(() => {
         const allEvents = [...markersToDisplay, ...customEventMarkersToDisplay];
-        return allEvents.reduce((acc, cur, index) => {
-            acc.push([cur]);
-            if (index > 0) {
-                acc[index - 1].push(cur);
-            }
-            return acc;
-        }, [] as (typeof allEvents)[]);
+        return allEvents.reduce(
+            (acc, cur, index) => {
+                acc.push([cur]);
+                if (index > 0) {
+                    acc[index - 1].push(cur);
+                }
+                return acc;
+            },
+            [] as (typeof allEvents)[]
+        );
     }, [markersToDisplay, customEventMarkersToDisplay]);
 
     return (
@@ -313,7 +322,14 @@ export default function CourseMap() {
             sx={{ width: '100%', display: 'flex', flexDirection: 'column', flexGrow: 1, height: '100%' }}
             id="map-pane"
         >
-            <MapContainer ref={map} center={[33.6459, -117.842717]} zoom={16} style={{ height: '100%' }}>
+            <MapContainer
+                ref={map}
+                center={CAMPUS_CENTER}
+                zoom={16}
+                style={{ height: '100%' }}
+                maxBounds={CAMPUS_BOUNDS}
+                maxBoundsViscosity={1}
+            >
                 {/* Menu floats above the map. */}
                 <Paper sx={{ position: 'relative', mx: 'auto', my: 2, width: '70%', zIndex: 400 }}>
                     <Tabs value={selectedDayIndex} onChange={handleChange} variant="fullWidth" sx={{ minHeight: 0 }}>

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -32,7 +32,7 @@ const WORK_WEEK = ['All', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 const FULL_WEEK = ['All', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekendIndices = [0, 6];
 const CAMPUS_CENTER: LatLngTuple = [33.6459, -117.842717];
-const CAMPUS_BOUND_DELTA = 0.001;
+const CAMPUS_BOUND_DELTA = 0.04;
 const CAMPUS_BOUNDS: [LatLngTuple, LatLngTuple] = [
     [CAMPUS_CENTER[0] - CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] - CAMPUS_BOUND_DELTA],
     [CAMPUS_CENTER[0] + CAMPUS_BOUND_DELTA, CAMPUS_CENTER[1] + CAMPUS_BOUND_DELTA],

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -207,7 +207,7 @@ const ErrorMessage = () => {
         >
             {courseId ? (
                 <Link
-                    href={`https://peterportal.org/course/${encodeURIComponent(courseId)}`}
+                    href={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
                     target="_blank"
                     sx={{ width: '100%' }}
                 >
@@ -227,7 +227,7 @@ const ErrorMessage = () => {
                             <span style={{ textDecoration: 'underline' }}>
                                 {deptValue} {courseNumber}
                             </span>{' '}
-                            on PeterPortal!
+                            on AntAlmanac Planner!
                         </span>
                     </Alert>
                 </Link>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,4 +1,4 @@
-import { Assessment, ShowChart as ShowChartIcon } from '@mui/icons-material';
+import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
 import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useMemo } from 'react';
 
@@ -86,11 +86,6 @@ function SectionTable(props: SectionTableProps) {
         return (width * numActiveColumns) / TOTAL_NUM_COLUMNS;
     }, [activeColumns]);
 
-    /**
-     * Store the size for the custom PeterPortal icon.
-     */
-    const customIconSize = 18;
-
     return (
         <>
             <Box
@@ -114,16 +109,9 @@ function SectionTable(props: SectionTableProps) {
                 <CourseInfoButton
                     analyticsCategory={analyticsCategory}
                     analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
-                    text="PeterPortal"
-                    icon={
-                        <img
-                            src={'assets/peterportal-logo.png'}
-                            alt="PeterPortal Icon"
-                            width={customIconSize}
-                            height={customIconSize}
-                        />
-                    }
-                    redirectLink={`https://peterportal.org/course/${encodeURIComponent(courseId)}`}
+                    text="Planner"
+                    icon={<Route />}
+                    redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
                 />
 
                 <CourseInfoButton


### PR DESCRIPTION
## Summary
Limits the map rendering viewable area to campus buildings so that users don't scroll into loading gray boxes
## Test Plan
Open map and drag map to go up, down, left, right. Limited in viewing further outside of buildings area. 
Tested at diff zoom levels.

Video demo: https://drive.google.com/file/d/1iAwy1Pj8OGUAgkgI4sgL_iQVLcfZqi7Y/view?usp=sharing
## Issues
One thing is that the map is able to go much more north then other directions because one of the buildings Non-OSHPD Central Plan is so far away north.

Closes #1458

<!-- [Optional]
## Future Followup
-->
