### PR TITLE
Use RESTAPI for section code aggregation 

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -103,10 +103,6 @@ async function main() {
             const response = await fetch(url, { headers });
             const restApiResponse = await response.json();
 
-            if (year == '2026' && quarter == 'Spring') {
-                await writeFile(join(__dirname, 'test.json'), JSON.stringify(restApiResponse, null, 2));
-            }
-
             if (!restApiResponse.ok || !restApiResponse.data) {
                 throw new Error(`Error fetching section codes for ${term.shortName}.`);
             }

--- a/apps/antalmanac/src/backend/lib/term-section-codes.ts
+++ b/apps/antalmanac/src/backend/lib/term-section-codes.ts
@@ -15,9 +15,13 @@ export interface SectionCodesGraphQLResponse {
     };
 }
 
-export function parseSectionCodes(response: SectionCodesGraphQLResponse): Record<string, SectionSearchResult> {
+export interface SectionCodesResponse {
+    schools: WebsocSchool[];
+}
+
+export function parseSectionCodes(response: SectionCodesResponse): Record<string, SectionSearchResult> {
     const results: Record<string, SectionSearchResult> = {};
-    response.data.websoc.schools.forEach((school: WebsocSchool) => {
+    response.schools.forEach((school: WebsocSchool) => {
         school.departments.forEach((department: WebsocDepartment) => {
             department.courses.forEach((course: WebsocCourse) => {
                 course.sections.forEach((section: WebsocSection) => {


### PR DESCRIPTION
## Summary
Swap the GraphQL query with a RESTAPI call to `v2/rest/websoc` when we run `pnpm get-data`. This seems to be significantly slower to 

Now 
<img width="648" height="262" alt="image" src="https://github.com/user-attachments/assets/88b40fc0-b3b3-4e58-a1e6-8eb7cd753a1c" />

Before
<img width="565" height="216" alt="image" src="https://github.com/user-attachments/assets/41597f90-704c-4a7d-a0cb-192455db7a6b" />

Search results 
<img width="787" height="467" alt="image" src="https://github.com/user-attachments/assets/7f1eb4f0-62da-4ca9-bee7-2ecca12f75b6" />


## Test Plan

## Issues

Closes #1490 

<!-- [Optional]
## Future Followup
-->
