### PR TITLE
Prevent AANTS From Deploying on Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The following environment variables are required for deployment and should be co
 -   `OIDC_CLIENT_ID` - OAuth client ID for Google authentication
 -   `OIDC_ISSUER_URL` - OAuth issuer URL
 -   `GOOGLE_REDIRECT_URI` - OAuth redirect URI (automatically set based on stage)
+-   `ENABLE_AANTS_CRON` - (Optional) Set to `true` to enable AANTS Cron for staging instances. 
 
 # Troubleshooting
 

--- a/apps/aants/.env.example
+++ b/apps/aants/.env.example
@@ -4,3 +4,5 @@ DB_URL=url
 QUEUE_URL=url
 # Optional: development | staging | production
 # STAGE=
+# Optional: Set to 'true' to enable AANTS Cron for staging instances
+# ENABLE_AANTS_CRON=true

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -125,9 +125,14 @@ export default $config({
             },
         });
 
-        new sst.aws.Cron('NotificationCronRule', {
-            schedule: 'rate(5 minutes)', // AANTS runs every 5 minutes - TODO (@IsaacNguyen): Might change in future
-            job: aantsLambda.arn,
-        });
+        // Only enable AANTS Cron for production by default
+        const shouldEnableAantsCron = $app.stage === 'production' || process.env.ENABLE_AANTS_CRON === 'true';
+
+        if (shouldEnableAantsCron) {
+            new sst.aws.Cron('NotificationCronRule', {
+                schedule: 'rate(5 minutes)', // AANTS runs every 5 minutes - TODO (@IsaacNguyen): Might change in future
+                job: aantsLambda.arn,
+            });
+        }
     },
 });


### PR DESCRIPTION
## Summary
AANTS is sending duplicate emails because of multiple staging instances running at the same time. This PR is meant to prevent the Cron Job from enabling unless explicitly enabled.

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
