### PR TITLE
fix: router transition error

### DIFF
--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -1,0 +1,144 @@
+import { EventNote, Route, UnfoldMore } from '@mui/icons-material';
+import {
+    Button,
+    ButtonGroup,
+    CircularProgress,
+    ListItemIcon,
+    ListSubheader,
+    MenuItem,
+    MenuList,
+    Popover,
+    Typography,
+} from '@mui/material';
+import { useState } from 'react';
+
+import { Logo } from '$components/Header/Logo';
+import { BLUE } from '$src/globals';
+
+type AppSwitcherProps = {
+    isMobile: boolean;
+};
+
+export function AppSwitcher({ isMobile }: AppSwitcherProps) {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const [plannerLoading, setPlannerLoading] = useState(false);
+
+    const platform = window.location.pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
+
+    const handlePlannerClick = () => {
+        if (plannerLoading) return;
+        setPlannerLoading(true);
+    };
+
+    const plannerIcon = plannerLoading ? <CircularProgress size={16} color="inherit" /> : <Route />;
+
+    if (isMobile) {
+        return (
+            <>
+                <Button
+                    onClick={(event) => setAnchorEl(event.currentTarget)}
+                    endIcon={<UnfoldMore />}
+                    sx={{
+                        minWidth: 'auto',
+                        p: 0.5,
+                        color: 'white',
+                        '& .MuiTouchRipple-child': {
+                            borderRadius: 0.5,
+                            bgcolor: 'white',
+                        },
+                    }}
+                >
+                    <Logo />
+                </Button>
+
+                <Popover
+                    open={Boolean(anchorEl)}
+                    anchorEl={anchorEl}
+                    onClose={() => setAnchorEl(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                >
+                    <MenuList
+                        subheader={
+                            <ListSubheader component="div" sx={{ lineHeight: '30px' }}>
+                                Switch Apps
+                            </ListSubheader>
+                        }
+                        sx={{ width: 200 }}
+                    >
+                        <MenuItem
+                            component="a"
+                            href="/"
+                            selected={platform === 'Scheduler'}
+                            onClick={() => setAnchorEl(null)}
+                            sx={{ minHeight: 'fit-content', textDecoration: 'none', color: 'inherit' }}
+                        >
+                            <ListItemIcon>
+                                <EventNote />
+                            </ListItemIcon>
+                            <Typography fontSize="15px" fontWeight={500}>
+                                Scheduler
+                            </Typography>
+                        </MenuItem>
+                        <MenuItem
+                            component="a"
+                            href="/planner"
+                            selected={platform === 'Planner'}
+                            onClick={() => {
+                                handlePlannerClick();
+                                setAnchorEl(null);
+                            }}
+                            disabled={plannerLoading}
+                            sx={{ minHeight: 'fit-content', textDecoration: 'none', color: 'inherit' }}
+                        >
+                            <ListItemIcon>{plannerIcon}</ListItemIcon>
+                            <Typography fontSize="15px" fontWeight={500}>
+                                Planner
+                            </Typography>
+                        </MenuItem>
+                    </MenuList>
+                </Popover>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <Logo />
+            <ButtonGroup variant="outlined" color="inherit">
+                <Button
+                    variant="contained"
+                    startIcon={<EventNote />}
+                    sx={{
+                        boxShadow: 'none',
+                        bgcolor: 'white',
+                        color: BLUE,
+                        fontWeight: 500,
+                        fontSize: 14,
+                        py: 0.4,
+                        '&:hover': { bgcolor: 'grey.100' },
+                    }}
+                >
+                    Scheduler
+                </Button>
+                <Button
+                    component="a"
+                    href="/planner"
+                    startIcon={plannerIcon}
+                    onClick={handlePlannerClick}
+                    disabled={plannerLoading}
+                    sx={{
+                        boxShadow: 'none',
+                        color: 'white',
+                        fontWeight: 500,
+                        fontSize: 14,
+                        py: 0.4,
+                        textDecoration: 'none',
+                    }}
+                >
+                    Planner
+                </Button>
+            </ButtonGroup>
+        </>
+    );
+}

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,23 +1,10 @@
-import { EventNote, Route, UnfoldMore } from '@mui/icons-material';
-import {
-    AppBar,
-    Box,
-    Button,
-    ButtonGroup,
-    ListItemIcon,
-    ListSubheader,
-    MenuItem,
-    MenuList,
-    Popover,
-    Stack,
-    Typography,
-} from '@mui/material';
+import { AppBar, Box, Stack } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import { openSnackbar } from '$actions/AppStoreActions';
 import { AlertDialog } from '$components/AlertDialog';
+import { AppSwitcher } from '$components/Header/AppSwitcher';
 import { Import } from '$components/Header/Import';
-import { Logo } from '$components/Header/Logo';
 import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
 import { Signout } from '$components/Header/Signout';
@@ -34,12 +21,9 @@ import { useSessionStore } from '$stores/SessionStore';
 export function Header() {
     const [openSuccessfulSaved, setOpenSuccessfulSaved] = useState(false);
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
-    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const importedUser = getLocalStorageImportedUser() ?? '';
     const { session, sessionIsValid } = useSessionStore();
     const isMobile = useIsMobile();
-
-    const platform = window.location.pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
 
     const clearStorage = () => {
         removeLocalStorageImportedUser();
@@ -101,107 +85,7 @@ export function Header() {
                     }}
                 >
                     <Stack direction="row" alignItems="center" gap={1}>
-                        {isMobile ? (
-                            <>
-                                <Button
-                                    onClick={(event) => setAnchorEl(event.currentTarget)}
-                                    endIcon={<UnfoldMore />}
-                                    sx={{
-                                        minWidth: 'auto',
-                                        p: 0.5,
-                                        color: 'white',
-                                        '& .MuiTouchRipple-child': {
-                                            borderRadius: 0.5,
-                                            bgcolor: 'white',
-                                        },
-                                    }}
-                                >
-                                    <Logo />
-                                </Button>
-
-                                <Popover
-                                    open={Boolean(anchorEl)}
-                                    anchorEl={anchorEl}
-                                    onClose={() => setAnchorEl(null)}
-                                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                                >
-                                    <MenuList
-                                        subheader={
-                                            <ListSubheader component="div" sx={{ lineHeight: '30px' }}>
-                                                Switch Apps
-                                            </ListSubheader>
-                                        }
-                                        sx={{ width: 200 }}
-                                    >
-                                        <MenuItem
-                                            component="a"
-                                            href="/"
-                                            selected={platform === 'Scheduler'}
-                                            onClick={() => setAnchorEl(null)}
-                                            sx={{ minHeight: 'fit-content', textDecoration: 'none', color: 'inherit' }}
-                                        >
-                                            <ListItemIcon>
-                                                <EventNote />
-                                            </ListItemIcon>
-                                            <Typography fontSize="15px" fontWeight={500}>
-                                                Scheduler
-                                            </Typography>
-                                        </MenuItem>
-                                        <MenuItem
-                                            component="a"
-                                            href="/planner"
-                                            selected={platform === 'Planner'}
-                                            onClick={() => setAnchorEl(null)}
-                                            sx={{ minHeight: 'fit-content', textDecoration: 'none', color: 'inherit' }}
-                                        >
-                                            <ListItemIcon>
-                                                <Route />
-                                            </ListItemIcon>
-                                            <Typography fontSize="15px" fontWeight={500}>
-                                                Planner
-                                            </Typography>
-                                        </MenuItem>
-                                    </MenuList>
-                                </Popover>
-                            </>
-                        ) : (
-                            <>
-                                <Logo />
-                                <ButtonGroup variant="outlined" color="inherit">
-                                    <Button
-                                        variant="contained"
-                                        startIcon={<EventNote />}
-                                        sx={{
-                                            boxShadow: 'none',
-                                            bgcolor: 'white',
-                                            color: BLUE,
-                                            fontWeight: 500,
-                                            fontSize: 14,
-                                            py: 0.4,
-                                            '&:hover': { bgcolor: 'grey.100' },
-                                        }}
-                                    >
-                                        Scheduler
-                                    </Button>
-                                    <Button
-                                        component="a"
-                                        href="/planner"
-                                        startIcon={<Route />}
-                                        sx={{
-                                            boxShadow: 'none',
-                                            color: 'white',
-                                            fontWeight: 500,
-                                            fontSize: 14,
-                                            py: 0.4,
-                                            textDecoration: 'none',
-                                        }}
-                                    >
-                                        Planner
-                                    </Button>
-                                </ButtonGroup>
-                            </>
-                        )}
+                        <AppSwitcher isMobile={isMobile} />
                     </Stack>
 
                     <Stack direction="row" alignItems="center">

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -12,7 +12,6 @@ import {
     Stack,
     Typography,
 } from '@mui/material';
-import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { openSnackbar } from '$actions/AppStoreActions';
@@ -136,7 +135,7 @@ export function Header() {
                                         sx={{ width: 200 }}
                                     >
                                         <MenuItem
-                                            component={Link}
+                                            component="a"
                                             href="/"
                                             selected={platform === 'Scheduler'}
                                             onClick={() => setAnchorEl(null)}
@@ -150,7 +149,7 @@ export function Header() {
                                             </Typography>
                                         </MenuItem>
                                         <MenuItem
-                                            component={Link}
+                                            component="a"
                                             href="/planner"
                                             selected={platform === 'Planner'}
                                             onClick={() => setAnchorEl(null)}
@@ -186,7 +185,7 @@ export function Header() {
                                         Scheduler
                                     </Button>
                                     <Button
-                                        component={Link}
+                                        component="a"
                                         href="/planner"
                                         startIcon={<Route />}
                                         sx={{


### PR DESCRIPTION
## Summary

Switch to normal `a` elements instead of attempting to client-side transition between two separate Next.js apps.

## Test Plan
Issue can be replicated by throttling internet speed, then attempting to move between scheduler and planner.
Multiple attempts at using the switcher will compound before falling back to a simple redirect, leading to extremely slow loading times.

<img width="577" height="127" alt="image" src="https://github.com/user-attachments/assets/7cef538d-8195-4866-99fe-51900360f465" />

## Issues

Fixes user complaint:
https://github.com/user-attachments/assets/7a437443-4098-43f3-99c8-c5096319ba7c


Fixes 
<img width="582" height="140" alt="image" src="https://github.com/user-attachments/assets/ce4732b0-d3b0-4fdf-8617-a295de0af68d" />
when transitioning between AntAlmanac scheduler and planner.

<!-- [Optional]
## Future Followup
-->
