### PR TITLE
feat: search by prof

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -85,6 +85,7 @@ async function main() {
                             sectionCode
                             sectionType
                             sectionNum
+                            instructors 
                         }
                     }
                 }

--- a/apps/antalmanac/src/backend/lib/term-section-codes.ts
+++ b/apps/antalmanac/src/backend/lib/term-section-codes.ts
@@ -15,13 +15,13 @@ export interface SectionCodesGraphQLResponse {
     };
 }
 export interface ParsedWebSocData {
-    sectionCodes: Record<string, SectionSearchResult>; // Search by Code (Unique)
-    instructors: Record<string, SectionSearchResult[]>; // Search by Name (Grouped)
+    sectionCodes: Record<string, SectionSearchResult>;
+    instructorNames: Set<string>;
 }
 
 export function parseWebSocData(response: SectionCodesGraphQLResponse): ParsedWebSocData {
     const sectionCodes: Record<string, SectionSearchResult> = {};
-    const instructors: Record<string, SectionSearchResult[]> = {};
+    const instructorNames = new Set<string>();
 
     response.data.websoc.schools.forEach((school: WebsocSchool) => {
         school.departments.forEach((department: WebsocDepartment) => {
@@ -36,21 +36,15 @@ export function parseWebSocData(response: SectionCodesGraphQLResponse): ParsedWe
                         sectionType: section.sectionType,
                     };
 
-                    const sectionCode = section.sectionCode;
-                    sectionCodes[sectionCode] = data;
+                    sectionCodes[section.sectionCode] = data;
 
-                    section.instructors.forEach((name) => {
-                        if (!instructors[name]) {
-                            instructors[name] = [];
-                        }
-                        instructors[name].push(data);
-                    });
+                    section.instructors.forEach((name) => instructorNames.add(name));
                 });
             });
         });
     });
 
-    return { sectionCodes, instructors };
+    return { sectionCodes, instructorNames };
 }
 
 export type Term = {

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -101,7 +101,6 @@ const searchRouter = router({
             const matchedGEs = u.search(toMutable(geCategoryKeys), query)[0]?.map((i) => geCategoryKeys[i]) ?? [];
             if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
 
-            // Only return instructors teaching this term
             const termInstructorList = Array.from(termInstructorSet).map((name) => ({
                 id: name,
                 name,

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -20,9 +20,12 @@ export function CoursePaneRoot() {
     const handleSearch = useCallback(() => {
         if (!advancedSearchEnabled) {
             RightPaneStore.storePrevFormData();
+            const currentInstructor = RightPaneStore.getFormData().instructor;
             RightPaneStore.resetAdvancedSearchValues();
+            if (currentInstructor) {
+                RightPaneStore.updateFormValue('instructor', currentInstructor);
+            }
         }
-
         if (RightPaneStore.formDataIsValid()) {
             displaySections();
             forceUpdate();

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -22,10 +22,11 @@ const resultType = {
     DEPARTMENT: 'DEPARTMENT',
     COURSE: 'COURSE',
     SECTION: 'SECTION',
+    INSTRUCTOR: 'INSTRUCTOR',
 } as const;
 
 const groupType = {
-    UNGROUPED: '__ungrgouped__',
+    UNGROUPED: '__ungrouped__',
     NOT_OFFERED: '__notOffered__',
     OFFERED: '__offered__',
 } as const;
@@ -35,6 +36,7 @@ const emojiMap: Record<string, string> = {
     DEPARTMENT: '🏢', // U+1F3E2 :office:
     COURSE: '📚', // U+1F4DA :books:
     SECTION: '📝', // U+1F4DD :memo:
+    INSTRUCTOR: '👩‍🏫',
 };
 
 const romanArr = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII'];
@@ -150,6 +152,11 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                 RightPaneStore.updateFormValue('courseNumber', number);
                 break;
             }
+            case resultType.INSTRUCTOR: {
+                const instructorName = option.key.replace('instructor:', '');
+                RightPaneStore.updateFormValue('instructor', instructorName);
+                break;
+            }
             case resultType.SECTION: {
                 RightPaneStore.updateFormValue('sectionCode', result.sectionCode);
                 break;
@@ -183,6 +190,8 @@ class FuzzySearch extends PureComponent<FuzzySearchProps, FuzzySearchState> {
                 return `${emojiMap.COURSE} ${object.metadata.department} ${object.metadata.number}: ${object.name}`;
             case resultType.SECTION:
                 return `${emojiMap.SECTION} ${object.sectionCode} ${object.sectionType} ${object.sectionNum}: ${object.department} ${object.courseNumber}`;
+            case resultType.INSTRUCTOR:
+                return `${emojiMap.INSTRUCTOR} ${object.name}`;
             default:
                 return '';
         }

--- a/packages/types/src/search.ts
+++ b/packages/types/src/search.ts
@@ -29,4 +29,9 @@ export type SectionSearchResult = {
     sectionType: string;
 };
 
-export type SearchResult = GESearchResult | DepartmentSearchResult | CourseSearchResult | SectionSearchResult;
+export type InstructorSearchResult = {
+    type: 'INSTRUCTOR';
+    name: string;
+};
+
+export type SearchResult = GESearchResult | DepartmentSearchResult | CourseSearchResult | SectionSearchResult | InstructorSearchResult;


### PR DESCRIPTION
Currently waiting for api team to fix instructor matching🫡

https://github.com/icssc/anteater-api/pull/303

## Summary
Users can now search for an instructor in the manual search bar and all courses the instructor is teaching for this term will show. 
<img width="1402" height="549" alt="image" src="https://github.com/user-attachments/assets/4ea38504-f98f-430f-b763-8455da7394c5" />
<img width="1397" height="979" alt="image" src="https://github.com/user-attachments/assets/b368d746-93f7-4633-8ca8-6740b2c8cdbf" />

## Test Plan
- Run pnpm get-data and confirm the instructor JSON files are generated correctly with the new array format. 
- Verify that searching for an active instructors show up in the search dropdown
- Verify courses the instructor teaches shows up in the courses pane

## Issues

Closes #1280

<!-- [Optional]
## Future Followup
-->
