### PR TITLE
Disable notifications menu for courses from past terms

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -10,6 +10,7 @@ import { DeleteAndNotifications } from '$components/RightPane/SectionTable/Secti
 import { NotificationsMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { type NotifyOn } from '$stores/NotificationStore';
 
@@ -25,7 +26,7 @@ interface ActionProps {
     /**
      * The term that the section occurs in.
      */
-    term: string;
+    term: Term['shortName'];
 
     /**
      * Additional details about the course that the section occurs in.

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteAndNotifications.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteAndNotifications.tsx
@@ -8,13 +8,14 @@ import { useShallow } from 'zustand/react/shallow';
 import { deleteCourse } from '$actions/AppStoreActions';
 import { NotificationsMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useNotificationStore } from '$stores/NotificationStore';
 
 interface DeleteAndNotificationsProps {
     courseTitle: Course['title'];
     section: AASection;
-    term: string;
+    term: Term['shortName'];
     lastUpdated: string;
     lastCodes: string;
     courseDetails: CourseDetails;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -112,11 +112,15 @@ export const NotificationsMenu = memo(
             <>
                 <Tooltip title={tooltipText}>
                     <span>
-                        <IconButton onClick={handleNotificationClick} disabled={!isTermCurrent || !isGoogleUser}>
-                            {hasNotifications ? (
-                                <EditNotifications fontSize="small" />
+                        <IconButton onClick={handleNotificationClick} disabled={isGoogleUser && !isTermCurrent}>
+                            {isGoogleUser ? (
+                                hasNotifications ? (
+                                    <EditNotifications fontSize="small" />
+                                ) : (
+                                    <NotificationAddOutlined fontSize="small" />
+                                )
                             ) : (
-                                <NotificationAddOutlined fontSize="small" />
+                                <NotificationAddOutlined fontSize="small" sx={{ opacity: 0.5 }} />
                             )}
                         </IconButton>
                     </span>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -89,11 +89,11 @@ export const NotificationsMenu = memo(
             setSignInOpen(false);
         }, []);
 
-        const tooltipText = !isGoogleUser
-            ? 'Sign in to access notifications'
-            : isTermCurrent
-              ? null
-              : "Notifications are only available for the current enrollment period's courses";
+        const tooltipText = !isTermCurrent
+            ? "Notifications are only available for the current enrollment period's courses"
+            : !isGoogleUser
+              ? 'Sign in to access notifications'
+              : null;
 
         return (
             <>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -6,7 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 import { NotificationEmailTooltip } from '$components/RightPane/AddedCourses/Notifications/NotificationEmailTooltip';
 import { SignInDialog } from '$components/dialogs/SignInDialog';
-import { getDefaultTerm } from '$lib/termData';
+import { canTermEnrollmentChange, Term } from '$lib/termData';
 import { NotifyOn, useNotificationStore } from '$stores/NotificationStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';
@@ -20,7 +20,7 @@ const MENU_ITEMS: { status: keyof NotifyOn; label: string }[] = [
 
 interface NotificationsMenuProps {
     section: AASection;
-    term: string;
+    term: Term['shortName'];
     courseTitle: Course['title'];
     deptCode?: string;
     courseNumber?: string;
@@ -46,7 +46,7 @@ export const NotificationsMenu = memo(
             }))
         );
 
-        const isTermCurrent = term === getDefaultTerm().shortName;
+        const isTermCurrent = canTermEnrollmentChange(term);
 
         useEffect(() => {
             if (isGoogleUser) {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 import { NotificationEmailTooltip } from '$components/RightPane/AddedCourses/Notifications/NotificationEmailTooltip';
 import { SignInDialog } from '$components/dialogs/SignInDialog';
+import { getDefaultTerm } from '$lib/termData';
 import { NotifyOn, useNotificationStore } from '$stores/NotificationStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';
@@ -44,6 +45,8 @@ export const NotificationsMenu = memo(
                 fetchUserData: state.fetchUserData,
             }))
         );
+
+        const isTermCurrent = term === getDefaultTerm().shortName;
 
         useEffect(() => {
             if (isGoogleUser) {
@@ -99,21 +102,25 @@ export const NotificationsMenu = memo(
             setSignInOpen(false);
         }, []);
 
+        const tooltipText = !isGoogleUser
+            ? 'Sign in to access notifications'
+            : isTermCurrent
+              ? null
+              : "Notifications are only available for the current enrollment period's courses";
+
         return (
             <>
-                <IconButton onClick={handleNotificationClick}>
-                    {isGoogleUser ? (
-                        hasNotifications ? (
-                            <EditNotifications fontSize="small" />
-                        ) : (
-                            <NotificationAddOutlined fontSize="small" />
-                        )
-                    ) : (
-                        <Tooltip title="Sign in to access notifications">
-                            <NotificationAddOutlined fontSize="small" sx={{ opacity: 0.5 }} />
-                        </Tooltip>
-                    )}
-                </IconButton>
+                <Tooltip title={tooltipText}>
+                    <span>
+                        <IconButton onClick={handleNotificationClick} disabled={!isTermCurrent || !isGoogleUser}>
+                            {hasNotifications ? (
+                                <EditNotifications fontSize="small" />
+                            ) : (
+                                <NotificationAddOutlined fontSize="small" />
+                            )}
+                        </IconButton>
+                    </span>
+                </Tooltip>
 
                 <Menu
                     anchorEl={anchorEl}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -99,7 +99,7 @@ export const NotificationsMenu = memo(
             <>
                 <Tooltip title={tooltipText}>
                     <span>
-                        <IconButton onClick={handleNotificationClick} disabled={isGoogleUser && !isTermCurrent}>
+                        <IconButton onClick={handleNotificationClick} disabled={!isTermCurrent}>
                             {isGoogleUser ? (
                                 hasNotifications ? (
                                     <EditNotifications fontSize="small" />

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -67,6 +67,16 @@ function getFinalsStartDateForTerm(term: string) {
     return new Date(termThatMatches.finalsStartDate);
 }
 
+/**
+ * Enrollment can change until the drop deadline, i.e. when enrollment closes.
+ * For full terms (10-week quarters), enrollment closes on the Friday of Week 2.
+ * For short terms (5-week summer terms), enrollment closes on the Friday of Week 1.
+ *
+ * See {@link https://www.reg.uci.edu/enrollment/adc/adcpolicy.html} for full terms and
+ * {@link https://summer.uci.edu/faq} for shorter summer terms.
+ *
+ * @returns `true` if enrollment is open for the given term, `false` if not.
+ */
 export function canTermEnrollmentChange(termShortName: Term['shortName']) {
     return openEnrollmentTerms.has(termShortName);
 }
@@ -86,6 +96,9 @@ function getOpenEnrollmentTerms() {
     return openEnrollmentTerms;
 }
 
+/**
+ * See {@link canTermEnrollmentChange} docs.
+ */
 function isTermEnrollmentOpen(term: Term): boolean {
     const instructionStartDate = moment(term.startDate);
     const isTermShort = moment(term.finalsStartDate).diff(instructionStartDate, 'week') < 9;


### PR DESCRIPTION
## Summary

Prevents users from subscribing to notifications from past courses.

## Test Plan

1. Ensure the notifications menu works as normal when signed in for courses in the current enrollment period
2. Ensure the notifications menu button is disabled when looking at old courses, with the proper tooltip
3. Ensure the notifications menu button is disabled when not signed in, with the proper tooltip

## Issues

Closes #1478

<!-- [Optional]
## Future Followup
-->
