### PR TITLE
 Make environment NOT NULL for AANTS

### DIFF
--- a/packages/db/migrations/0009_brown_next_avengers.sql
+++ b/packages/db/migrations/0009_brown_next_avengers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "subscriptions" ALTER COLUMN "environment" SET NOT NULL;

--- a/packages/db/migrations/meta/0009_snapshot.json
+++ b/packages/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,498 @@
+{
+    "id": "9a3bc7c6-1d80-41d6-afbd-90c250f33a87",
+    "prevId": "abb011a1-63ac-4ac8-9f0f-8755da276938",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.accounts": {
+            "name": "accounts",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "account_type": {
+                    "name": "account_type",
+                    "type": "account_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "accounts_user_id_users_id_fk": {
+                    "name": "accounts_user_id_users_id_fk",
+                    "tableFrom": "accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "accounts_user_id_account_type_pk": {
+                    "name": "accounts_user_id_account_type_pk",
+                    "columns": ["user_id", "account_type"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires": {
+                    "name": "expires",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "phone": {
+                    "name": "phone",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar": {
+                    "name": "avatar",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "imported": {
+                    "name": "imported",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "current_schedule_id": {
+                    "name": "current_schedule_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "users_current_schedule_id_schedules_id_fk": {
+                    "name": "users_current_schedule_id_schedules_id_fk",
+                    "tableFrom": "users",
+                    "tableTo": "schedules",
+                    "columnsFrom": ["current_schedule_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.schedules": {
+            "name": "schedules",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "notes": {
+                    "name": "notes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "index": {
+                    "name": "index",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "schedules_user_id_users_id_fk": {
+                    "name": "schedules_user_id_users_id_fk",
+                    "tableFrom": "schedules",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "schedules_user_id_name_unique": {
+                    "name": "schedules_user_id_name_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["user_id", "name"]
+                },
+                "schedules_user_id_index_unique": {
+                    "name": "schedules_user_id_index_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["user_id", "index"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.coursesInSchedule": {
+            "name": "coursesInSchedule",
+            "schema": "",
+            "columns": {
+                "scheduleId": {
+                    "name": "scheduleId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "sectionCode": {
+                    "name": "sectionCode",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "term": {
+                    "name": "term",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "coursesInSchedule_scheduleId_schedules_id_fk": {
+                    "name": "coursesInSchedule_scheduleId_schedules_id_fk",
+                    "tableFrom": "coursesInSchedule",
+                    "tableTo": "schedules",
+                    "columnsFrom": ["scheduleId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "coursesInSchedule_scheduleId_sectionCode_term_pk": {
+                    "name": "coursesInSchedule_scheduleId_sectionCode_term_pk",
+                    "columns": ["scheduleId", "sectionCode", "term"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.customEvents": {
+            "name": "customEvents",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "scheduleId": {
+                    "name": "scheduleId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "start": {
+                    "name": "start",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end": {
+                    "name": "end",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "days": {
+                    "name": "days",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "building": {
+                    "name": "building",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "customEvents_scheduleId_schedules_id_fk": {
+                    "name": "customEvents_scheduleId_schedules_id_fk",
+                    "tableFrom": "customEvents",
+                    "tableTo": "schedules",
+                    "columnsFrom": ["scheduleId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.subscriptions": {
+            "name": "subscriptions",
+            "schema": "",
+            "columns": {
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sectionCode": {
+                    "name": "sectionCode",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "year": {
+                    "name": "year",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "quarter": {
+                    "name": "quarter",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lastUpdatedStatus": {
+                    "name": "lastUpdatedStatus",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "lastCodes": {
+                    "name": "lastCodes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": "''"
+                },
+                "notifyOnOpen": {
+                    "name": "notifyOnOpen",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "notifyOnWaitlist": {
+                    "name": "notifyOnWaitlist",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "notifyOnFull": {
+                    "name": "notifyOnFull",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "notifyOnRestriction": {
+                    "name": "notifyOnRestriction",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "environment": {
+                    "name": "environment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "subscriptions_userId_users_id_fk": {
+                    "name": "subscriptions_userId_users_id_fk",
+                    "tableFrom": "subscriptions",
+                    "tableTo": "users",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "subscriptions_userId_sectionCode_year_quarter_pk": {
+                    "name": "subscriptions_userId_sectionCode_year_quarter_pk",
+                    "columns": ["userId", "sectionCode", "year", "quarter"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.account_type": {
+            "name": "account_type",
+            "schema": "public",
+            "values": ["GOOGLE", "GUEST", "OIDC"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
             "when": 1771441270972,
             "tag": "0008_skinny_ser_duncan",
             "breakpoints": true
+        },
+        {
+            "idx": 9,
+            "version": "7",
+            "when": 1771874793356,
+            "tag": "0009_brown_next_avengers",
+            "breakpoints": true
         }
     ]
 }

--- a/packages/db/src/schema/subscription.ts
+++ b/packages/db/src/schema/subscription.ts
@@ -67,7 +67,7 @@ export const subscriptions = pgTable(
          * Environment when this subscription was created (e.g. "production", "staging-1337", "staging-1447").
          * AANTS only sends emails when its STAGE matches this value.
          */
-        environment: text('environment'),
+        environment: text('environment').notNull(),
     },
     (table) => [
         primaryKey({


### PR DESCRIPTION
## Summary
-Makes the `environment` column `NOT NULL` in the `subscriptions` table to enforce the addition of environments when creating subscriptions 
    - Will  prevent the creation of subscriptions on old staging instances

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
