### PR TITLE
Restore GraphQl in get-data

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -4,14 +4,8 @@ import { fileURLToPath } from 'node:url';
 
 import { Course, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 
-import { queryGraphQL, queryHTTPS } from '../src/backend/lib/helpers';
-import {
-    parseSectionCodes,
-    parseSectionCodesREST,
-    SectionCodesGraphQLResponse,
-    SectionCodesRESTResponse,
-    termData,
-} from '../src/backend/lib/term-section-codes';
+import { queryGraphQL } from '../src/backend/lib/helpers';
+import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
 
 import 'dotenv/config';
 
@@ -79,24 +73,7 @@ async function main() {
     }
     console.log(`Fetched ${deptMap.size} departments.`);
 
-    const QUERY_TEMPLATE = `{
-        websoc(query: {year: "$$YEAR$$", quarter: $$QUARTER$$}) {
-            schools {
-                departments {
-                    deptCode
-                    courses {
-                        courseTitle
-                        courseNumber
-                        sections {
-                            sectionCode
-                            sectionType
-                            sectionNum
-                        }
-                    }
-                }
-            }
-        }
-    }`;
+    const QUERY_TEMPLATE = `{websoc(query:{year:"$$YEAR$$",quarter:$$QUARTER$$}){schools{departments{deptCode courses{courseTitle courseNumber sections{sectionCode sectionType sectionNum}}}}}}`;
 
     await mkdir(join(__dirname, '../src/generated/'), { recursive: true });
     await mkdir(join(__dirname, '../src/generated/terms/'), { recursive: true });
@@ -121,24 +98,15 @@ async function main() {
             // TODO (@kevin): remove delay once AAPI resolves OOM issues
             await new Promise((resolve) => setTimeout(resolve, DELAY_MS * index));
 
-            let parsedSectionData: Record<string, unknown>;
+            // Use GraphQL query
+            const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
+            const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);
 
-            // Use REST API for Spring 2026, GraphQL for everything else
-            if (year === '2026' && quarter === 'Spring') {
-                const params = new URLSearchParams({ year, quarter });
-                const res = await queryHTTPS<SectionCodesRESTResponse>(params, headers);
-                if (!res) {
-                    throw new Error(`Error fetching section codes for ${term.shortName}.`);
-                }
-                parsedSectionData = parseSectionCodesREST(res);
-            } else {
-                const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
-                const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);
-                if (!res) {
-                    throw new Error(`Error fetching section codes for ${term.shortName}.`);
-                }
-                parsedSectionData = parseSectionCodes(res);
+            if (!res) {
+                throw new Error(`Error fetching section codes for ${term.shortName}.`);
             }
+
+            const parsedSectionData = parseSectionCodes(res);
 
             console.log(
                 `Fetched ${Object.keys(parsedSectionData).length} section codes for ${

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -98,7 +98,6 @@ async function main() {
             // TODO (@kevin): remove delay once AAPI resolves OOM issues
             await new Promise((resolve) => setTimeout(resolve, DELAY_MS * index));
 
-            // Use GraphQL query
             const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
             const res = await queryGraphQL<SectionCodesGraphQLResponse>(query);
 

--- a/apps/antalmanac/src/backend/lib/term-section-codes.ts
+++ b/apps/antalmanac/src/backend/lib/term-section-codes.ts
@@ -15,33 +15,8 @@ export interface SectionCodesGraphQLResponse {
     };
 }
 
-export interface SectionCodesRESTResponse {
-    data: {
-        schools: WebsocSchool[];
-    };
-}
-
-export function parseSectionCodesREST(response: SectionCodesRESTResponse): Record<string, SectionSearchResult> {
-    const results: Record<string, SectionSearchResult> = {};
-    response.data.schools.forEach((school: WebsocSchool) => {
-        school.departments.forEach((department: WebsocDepartment) => {
-            department.courses.forEach((course: WebsocCourse) => {
-                course.sections.forEach((section: WebsocSection) => {
-                    const sectionCode = section.sectionCode;
-                    results[sectionCode] = {
-                        type: 'SECTION',
-                        department: department.deptCode,
-                        courseNumber: course.courseNumber,
-                        sectionCode: section.sectionCode,
-                        sectionNum: section.sectionNum,
-                        sectionType: section.sectionType,
-                    };
-                });
-            });
-        });
-    });
-
-    return results;
+export interface SectionCodesResponse {
+    schools: WebsocSchool[];
 }
 
 export function parseSectionCodes(response: SectionCodesGraphQLResponse): Record<string, SectionSearchResult> {


### PR DESCRIPTION
## Summary
This PR reverts the bandaid from #1490. The Graphql endpoint should return the proper data so we no longer need a special call to the REST API 

<img width="710" height="341" alt="image" src="https://github.com/user-attachments/assets/5edea309-65f4-4370-973f-727033fd3323" />

## Test Plan
Delete the `/generated` folder and run `pnpm get-data` 

Expected: 12466 courses for Spring 2026 should appear.

In AntAlmanac searching for courses in the MUSIC or STATS departments should provide results 
- Note: these were not the only affected departments 

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
