### PR TITLE
feat: add EmptyState to calendar and added courses pane

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -3,6 +3,7 @@
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import './calendar.css';
 
+import { CalendarMonth } from '@mui/icons-material';
 import { Box, Backdrop, useTheme } from '@mui/material';
 import moment from 'moment';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -15,6 +16,7 @@ import { CalendarEventPopover } from '$components/Calendar/CalendarEventPopover'
 import type { CalendarEvent, CourseEvent, SkeletonEvent } from '$components/Calendar/CourseCalendarEvent';
 import { CalendarToolbar } from '$components/Calendar/Toolbar/CalendarToolbar';
 import { skeletonBlueprintVariations } from '$components/Calendar/skeletonBlueprintVariations';
+import { EmptyState } from '$components/EmptyState';
 import { useIsMobile } from '$hooks/useIsMobile';
 import {
     getLocalStorageSkeletonBlueprint,
@@ -26,6 +28,7 @@ import AppStore from '$stores/AppStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
+import { useTabStore } from '$stores/TabStore';
 
 /*
 //  * Always start week on Saturday for finals potentially on weekends.
@@ -352,8 +355,35 @@ export const ScheduleCalendar = memo(() => {
                 showFinalsSchedule={showFinalsSchedule}
                 scheduleNames={scheduleNames}
             />
-            <Box id="screenshot" height="0" flexGrow={1}>
+            <Box id="screenshot" height="0" flexGrow={1} position="relative">
                 <CalendarEventPopover />
+
+                {!loadingSchedule && !showFinalsSchedule && eventsInCalendar.length === 0 && (
+                    <Box
+                        data-html2canvas-ignore
+                        position="absolute"
+                        top={0}
+                        left={0}
+                        right={0}
+                        bottom={0}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        zIndex={1}
+                        sx={{
+                            backgroundColor: (theme) =>
+                                theme.palette.mode === 'dark' ? 'rgba(18, 18, 18, 0.75)' : 'rgba(255, 255, 255, 0.7)',
+                        }}
+                    >
+                        <EmptyState
+                            Icon={CalendarMonth}
+                            title="Your schedule is empty"
+                            description="Search for courses to start building your schedule."
+                            ctaLabel="Search for Courses"
+                            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                        />
+                    </Box>
+                )}
 
                 <Calendar<CalendarEvent, object>
                     key={`${culture}-${calendarView}`}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -358,32 +358,37 @@ export const ScheduleCalendar = memo(() => {
             <Box id="screenshot" height="0" flexGrow={1} position="relative">
                 <CalendarEventPopover />
 
-                {!loadingSchedule && !showFinalsSchedule && eventsInCalendar.length === 0 && (
-                    <Box
-                        data-html2canvas-ignore
-                        position="absolute"
-                        top={0}
-                        left={0}
-                        right={0}
-                        bottom={0}
-                        display="flex"
-                        alignItems="center"
-                        justifyContent="center"
-                        zIndex={1}
-                        sx={{
-                            backgroundColor: (theme) =>
-                                theme.palette.mode === 'dark' ? 'rgba(18, 18, 18, 0.75)' : 'rgba(255, 255, 255, 0.7)',
-                        }}
-                    >
-                        <EmptyState
-                            Icon={CalendarMonth}
-                            title="Your schedule is empty"
-                            description="Search for courses to start building your schedule."
-                            ctaLabel="Search for Courses"
-                            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
-                        />
-                    </Box>
-                )}
+                {!loadingSchedule &&
+                    !showFinalsSchedule &&
+                    eventsInCalendar.length === 0 &&
+                    !hoveredCalendarizedCourses && (
+                        <Box
+                            data-html2canvas-ignore
+                            position="absolute"
+                            top={0}
+                            left={0}
+                            right={0}
+                            bottom={0}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            zIndex={1}
+                            sx={{
+                                backgroundColor: (theme) =>
+                                    theme.palette.mode === 'dark'
+                                        ? 'rgba(18, 18, 18, 0.75)'
+                                        : 'rgba(255, 255, 255, 0.7)',
+                            }}
+                        >
+                            <EmptyState
+                                Icon={CalendarMonth}
+                                title="Your schedule is empty"
+                                description="Search for courses to start building your schedule."
+                                ctaLabel="Search for Courses"
+                                onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                            />
+                        </Box>
+                    )}
 
                 <Calendar<CalendarEvent, object>
                     key={`${culture}-${calendarView}`}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -384,8 +384,10 @@ export const ScheduleCalendar = memo(() => {
                             Icon={CalendarMonth}
                             title="Your schedule is empty"
                             description="Search for courses to start building your schedule."
-                            ctaLabel="Search for Courses"
-                            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                            primaryAction={{
+                                label: 'Search for Courses',
+                                onClick: () => useTabStore.getState().setActiveTab('search'),
+                            }}
                         />
                     </Box>
                 )}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -253,6 +253,11 @@ export const ScheduleCalendar = memo(() => {
         return Math.abs(bgBrightness - textBrightness) > minBrightnessDiff;
     };
 
+    const showEmptyState = useMemo(
+        () => !loadingSchedule && !showFinalsSchedule && eventsInCalendar.length === 0 && !hoveredCalendarizedCourses,
+        [loadingSchedule, showFinalsSchedule, eventsInCalendar.length, hoveredCalendarizedCourses]
+    );
+
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
     const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
     const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
@@ -358,37 +363,32 @@ export const ScheduleCalendar = memo(() => {
             <Box id="screenshot" height="0" flexGrow={1} position="relative">
                 <CalendarEventPopover />
 
-                {!loadingSchedule &&
-                    !showFinalsSchedule &&
-                    eventsInCalendar.length === 0 &&
-                    !hoveredCalendarizedCourses && (
-                        <Box
-                            data-html2canvas-ignore
-                            position="absolute"
-                            top={0}
-                            left={0}
-                            right={0}
-                            bottom={0}
-                            display="flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            zIndex={1}
-                            sx={{
-                                backgroundColor: (theme) =>
-                                    theme.palette.mode === 'dark'
-                                        ? 'rgba(18, 18, 18, 0.75)'
-                                        : 'rgba(255, 255, 255, 0.7)',
-                            }}
-                        >
-                            <EmptyState
-                                Icon={CalendarMonth}
-                                title="Your schedule is empty"
-                                description="Search for courses to start building your schedule."
-                                ctaLabel="Search for Courses"
-                                onCtaClick={() => useTabStore.getState().setActiveTab('search')}
-                            />
-                        </Box>
-                    )}
+                {showEmptyState && (
+                    <Box
+                        data-html2canvas-ignore
+                        position="absolute"
+                        top={0}
+                        left={0}
+                        right={0}
+                        bottom={0}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        zIndex={1}
+                        sx={{
+                            backgroundColor: (theme) =>
+                                theme.palette.mode === 'dark' ? 'rgba(18, 18, 18, 0.75)' : 'rgba(255, 255, 255, 0.7)',
+                        }}
+                    >
+                        <EmptyState
+                            Icon={CalendarMonth}
+                            title="Your schedule is empty"
+                            description="Search for courses to start building your schedule."
+                            ctaLabel="Search for Courses"
+                            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                        />
+                    </Box>
+                )}
 
                 <Calendar<CalendarEvent, object>
                     key={`${culture}-${calendarView}`}

--- a/apps/antalmanac/src/components/EmptyState.tsx
+++ b/apps/antalmanac/src/components/EmptyState.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { SvgIconComponent } from '@mui/icons-material';
+import { Box, Button, type SxProps, type Theme, Typography } from '@mui/material';
+
+interface EmptyStateProps {
+    Icon: SvgIconComponent;
+    title: string;
+    description: string;
+    ctaLabel?: string;
+    onCtaClick?: () => void;
+    sx?: SxProps<Theme>;
+}
+
+export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, sx }: EmptyStateProps) {
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            gap={1.5}
+            textAlign="center"
+            p={4}
+            sx={sx}
+        >
+            <Icon sx={{ fontSize: 48, color: 'text.secondary' }} aria-hidden="true" />
+            <Typography variant="h6" color="text.primary">
+                {title}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" maxWidth={360}>
+                {description}
+            </Typography>
+            {ctaLabel && onCtaClick && (
+                <Button variant="contained" onClick={onCtaClick} sx={{ mt: 1 }}>
+                    {ctaLabel}
+                </Button>
+            )}
+        </Box>
+    );
+}

--- a/apps/antalmanac/src/components/EmptyState.tsx
+++ b/apps/antalmanac/src/components/EmptyState.tsx
@@ -43,9 +43,11 @@ export function EmptyState({
             <Typography variant="h6" color="text.primary">
                 {title}
             </Typography>
-            <Typography variant="body2" color="text.secondary" maxWidth={360}>
-                {description}
-            </Typography>
+            {description && (
+                <Typography variant="body2" color="text.secondary" maxWidth={360}>
+                    {description}
+                </Typography>
+            )}
             {(primaryAction || secondaryAction) && (
                 <Box display="flex" flexWrap="wrap" gap={1} mt={1} justifyContent="center">
                     {primaryAction && (

--- a/apps/antalmanac/src/components/EmptyState.tsx
+++ b/apps/antalmanac/src/components/EmptyState.tsx
@@ -3,15 +3,30 @@
 import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, Button, type SxProps, type Theme, Typography } from '@mui/material';
 
-type EmptyStateProps = {
+export interface EmptyStateAction {
+    label: string;
+    onClick: () => void;
+}
+
+export interface EmptyStateProps {
     Icon: SvgIconComponent;
     title: string;
-    description: string;
+    description?: string;
+    primaryAction?: EmptyStateAction;
+    secondaryAction?: EmptyStateAction;
     className?: string;
     sx?: SxProps<Theme>;
-} & ({ ctaLabel: string; onCtaClick: () => void } | { ctaLabel?: never; onCtaClick?: never });
+}
 
-export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, className, sx }: EmptyStateProps) {
+export function EmptyState({
+    Icon,
+    title,
+    description,
+    primaryAction,
+    secondaryAction,
+    className,
+    sx,
+}: EmptyStateProps) {
     return (
         <Box
             display="flex"
@@ -31,10 +46,19 @@ export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, cla
             <Typography variant="body2" color="text.secondary" maxWidth={360}>
                 {description}
             </Typography>
-            {ctaLabel && (
-                <Button variant="contained" onClick={onCtaClick} sx={{ mt: 1 }}>
-                    {ctaLabel}
-                </Button>
+            {(primaryAction || secondaryAction) && (
+                <Box display="flex" flexWrap="wrap" gap={1} mt={1} justifyContent="center">
+                    {primaryAction && (
+                        <Button variant="contained" onClick={primaryAction.onClick}>
+                            {primaryAction.label}
+                        </Button>
+                    )}
+                    {secondaryAction && (
+                        <Button variant="outlined" onClick={secondaryAction.onClick}>
+                            {secondaryAction.label}
+                        </Button>
+                    )}
+                </Box>
             )}
         </Box>
     );

--- a/apps/antalmanac/src/components/EmptyState.tsx
+++ b/apps/antalmanac/src/components/EmptyState.tsx
@@ -3,16 +3,15 @@
 import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, Button, type SxProps, type Theme, Typography } from '@mui/material';
 
-interface EmptyStateProps {
+type EmptyStateProps = {
     Icon: SvgIconComponent;
     title: string;
     description: string;
-    ctaLabel?: string;
-    onCtaClick?: () => void;
+    className?: string;
     sx?: SxProps<Theme>;
-}
+} & ({ ctaLabel: string; onCtaClick: () => void } | { ctaLabel?: never; onCtaClick?: never });
 
-export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, sx }: EmptyStateProps) {
+export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, className, sx }: EmptyStateProps) {
     return (
         <Box
             display="flex"
@@ -22,6 +21,7 @@ export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, sx 
             gap={1.5}
             textAlign="center"
             p={4}
+            className={className}
             sx={sx}
         >
             <Icon sx={{ fontSize: 48, color: 'text.secondary' }} aria-hidden="true" />
@@ -31,7 +31,7 @@ export function EmptyState({ Icon, title, description, ctaLabel, onCtaClick, sx 
             <Typography variant="body2" color="text.secondary" maxWidth={360}>
                 {description}
             </Typography>
-            {ctaLabel && onCtaClick && (
+            {ctaLabel && (
                 <Button variant="contained" onClick={onCtaClick} sx={{ mt: 1 }}>
                     {ctaLabel}
                 </Button>

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,9 +1,11 @@
+import { ClassOutlined } from '@mui/icons-material';
 import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, useTheme } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { updateScheduleNote } from '$actions/AppStoreActions';
+import { EmptyState } from '$components/EmptyState';
 import CustomEventDetailView from '$components/RightPane/AddedCourses/CustomEventDetailView';
 import { NotificationsDialog } from '$components/RightPane/AddedCourses/Notifications/NotificationsDialog';
 import { getMissingSections } from '$components/RightPane/AddedCourses/getMissingSections';
@@ -15,6 +17,7 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
 import { LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
+import { useTabStore } from '$stores/TabStore';
 
 /**
  * All the interactive buttons have the same styles.
@@ -349,11 +352,14 @@ function AddedSectionsGrid() {
         return scheduleNames[scheduleIndex];
     }, [scheduleNames, scheduleIndex]);
 
-    // "No Courses Added Yet!" notification
     const NoCoursesBox = (
-        <Box style={{ paddingTop: '12px', paddingBottom: '12px' }}>
-            <Typography align="left">No Courses Added Yet!</Typography>
-        </Box>
+        <EmptyState
+            Icon={ClassOutlined}
+            title="No courses added yet"
+            description="Search for courses and add them to your schedule."
+            ctaLabel="Search for Courses"
+            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+        />
     );
 
     return (

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -352,16 +352,6 @@ function AddedSectionsGrid() {
         return scheduleNames[scheduleIndex];
     }, [scheduleNames, scheduleIndex]);
 
-    const NoCoursesBox = (
-        <EmptyState
-            Icon={ClassOutlined}
-            title="No courses added yet"
-            description="Search for courses and add them to your schedule."
-            ctaLabel="Search for Courses"
-            onCtaClick={() => useTabStore.getState().setActiveTab('search')}
-        />
-    );
-
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             <Box sx={{ display: 'flex', width: 'fit-content', position: 'absolute', zIndex: 2 }}>
@@ -372,7 +362,15 @@ function AddedSectionsGrid() {
             </Box>
             <Box sx={{ marginTop: 7 }}>
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
-                {courses.length < 1 ? NoCoursesBox : null}
+                {courses.length === 0 && (
+                    <EmptyState
+                        Icon={ClassOutlined}
+                        title="No courses added yet"
+                        description="Search for courses and add them to your schedule."
+                        ctaLabel="Search for Courses"
+                        onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                    />
+                )}
                 <Box display="flex" flexDirection="column" gap={1}>
                     {courses.map((course) => {
                         const missingSections = getMissingSections(course);

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -1,4 +1,4 @@
-import { ClassOutlined } from '@mui/icons-material';
+import { MenuBook } from '@mui/icons-material';
 import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, useTheme } from '@mui/material';
 import { AACourse } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
@@ -17,6 +17,7 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
 import { LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
+import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useTabStore } from '$stores/TabStore';
 
 /**
@@ -364,11 +365,17 @@ function AddedSectionsGrid() {
                 <Typography variant="h6">{`${scheduleName} (${scheduleUnits} Units)`}</Typography>
                 {courses.length === 0 && (
                     <EmptyState
-                        Icon={ClassOutlined}
-                        title="No courses added yet"
-                        description="Search for courses and add them to your schedule."
-                        ctaLabel="Search for Courses"
-                        onCtaClick={() => useTabStore.getState().setActiveTab('search')}
+                        Icon={MenuBook}
+                        title="No Courses Added Yet"
+                        description="Search for courses and add sections to build your schedule. You can also import from your study list."
+                        primaryAction={{
+                            label: 'Search Courses',
+                            onClick: () => useTabStore.getState().setActiveTab('search'),
+                        }}
+                        secondaryAction={{
+                            label: 'Import Schedule',
+                            onClick: () => scheduleComponentsToggleStore.getState().setOpenImportDialog(true),
+                        }}
                     />
                 )}
                 <Box display="flex" flexDirection="column" gap={1}>


### PR DESCRIPTION
## Summary

closes #1505

- add a shared `EmptyState` component (icon, title, description, optional cta button. 
- add overlay `EmptyState` to calendar when schedule has no classes.
- Replace text in `AddedCoursesPane` with new empty state component.

## Tests
- [x] add a course and confirm both empty states disappear
- [x] empty state does not appear on finals view
- [x] take screenshot via site; empty state doesn't appear in exported image

<img width="1470" height="803" alt="Screenshot 2026-03-04 at 7 47 49 PM" src="https://github.com/user-attachments/assets/66983aa9-ae58-4280-9c05-a9283c5b806b" />