### PR TITLE
feat: silent auth

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom';
 
 import { undoDelete, redoDelete } from '$actions/AppStoreActions';
-// import { AutoSignIn } from '$components/AutoSignIn';
+import { AutoSignIn } from '$components/AutoSignIn';
 import PosthogPageviewTracker from '$lib/analytics/PostHogPageviewTracker';
 import AppPostHogProvider from '$providers/PostHog';
 import AppQueryProvider from '$providers/Query';
@@ -26,7 +26,7 @@ function RouteLayout() {
     return (
         <>
             <PosthogPageviewTracker />
-            {/* <AutoSignIn /> */}
+            <AutoSignIn />
             <Outlet />
         </>
     );

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -1,92 +1,39 @@
 import { useEffect, useRef } from 'react';
 
-import { loginUser } from '$actions/AppStoreActions';
 import trpc from '$lib/api/trpc';
 import { getLocalStorageSessionId } from '$lib/localStorage';
-
-const AUTH_ORIGIN = 'https://auth.icssc.club';
-const SESSION_CHECK_TIMEOUT = 5000;
-
-interface SessionCheckResult {
-    valid: boolean;
-    user: {
-        id: string;
-        email: string;
-        name: string;
-        picture?: string;
-    } | null;
-}
+import { hasSsoCookie } from '$lib/ssoCookie';
 
 /**
- * Automatically signs in users who have an active session on auth.icssc.club.
- * This enables seamless SSO across ICSSC apps (AntAlmanac, PeterPortal, etc.)
+ * Automatically signs in users who authenticated via another app on antalmanac.com
+ * (e.g. PeterPortal at /planner).
+ *
+ * Uses a shared first-party cookie (`icssc_logged_in`) as a hint, then performs
+ * a redirect-based silent auth through auth.icssc.club with prompt=none.
+ * Unlike the previous iframe approach this avoids third-party cookie issues.
  */
 export function AutoSignIn() {
     const hasChecked = useRef(false);
 
     useEffect(() => {
-        if (hasChecked.current) {
-            return;
-        }
+        if (hasChecked.current) return;
+        hasChecked.current = true;
 
         const checkAndSignIn = async () => {
-            // Check if user already has a valid local session
+            if (!hasSsoCookie()) return;
+
             const localSessionId = getLocalStorageSessionId();
             if (localSessionId) {
                 const isValid = await trpc.auth.validateSession.query({ token: localSessionId });
-                if (isValid) {
-                    // User is already authenticated locally
-                    return;
-                }
+                if (isValid) return;
             }
 
-            hasChecked.current = true;
-
-            // Check if there's an active ICSSC session
-            const result = await checkIcsscSession();
-            if (result.valid) {
-                // Auto-trigger OAuth flow - it will complete instantly since session exists
-                loginUser();
-            }
+            const authUrl = await trpc.userData.getGoogleAuthUrl.query({ prompt: 'none' });
+            window.location.href = authUrl.toString();
         };
 
         checkAndSignIn();
     }, []);
 
     return null;
-}
-
-function checkIcsscSession(): Promise<SessionCheckResult> {
-    return new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-            cleanup();
-            resolve({ valid: false, user: null });
-        }, SESSION_CHECK_TIMEOUT);
-
-        const iframe = document.createElement('iframe');
-        iframe.style.display = 'none';
-        iframe.src = `${AUTH_ORIGIN}/session/check?origin=${encodeURIComponent(window.location.origin)}`;
-
-        const handleMessage = (event: MessageEvent) => {
-            if (event.origin !== AUTH_ORIGIN) return;
-            if (event.data?.type !== 'icssc-session-check') return;
-
-            cleanup();
-            resolve({
-                valid: event.data.valid,
-                user: event.data.user,
-            });
-        };
-
-        const cleanup = () => {
-            clearTimeout(timeout);
-            window.removeEventListener('message', handleMessage);
-            if (iframe.parentNode) {
-                iframe.parentNode.removeChild(iframe);
-            }
-        };
-
-        window.addEventListener('message', handleMessage);
-        document.body.appendChild(iframe);
-    });
 }

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -6,7 +6,7 @@ import { hasSsoCookie } from '$lib/ssoCookie';
 
 /**
  * Automatically signs in users who authenticated via another app on antalmanac.com
- * (e.g. PeterPortal at /planner).
+ * (e.g. Planner at /planner).
  *
  * Uses a shared first-party cookie (`icssc_logged_in`) as a hint, then performs
  * a redirect-based silent auth through auth.icssc.club with prompt=none.
@@ -16,15 +16,23 @@ export function AutoSignIn() {
     const hasChecked = useRef(false);
 
     useEffect(() => {
-        if (hasChecked.current) return;
+        if (hasChecked.current) {
+            return;
+        }
         hasChecked.current = true;
 
         const checkAndSignIn = async () => {
-            if (!hasSsoCookie()) return;
+            // Don't interfere when AuthPage is already handling an OAuth callback.
+            // Calling getGoogleAuthUrl here would overwrite the oauth_state /
+            // oauth_code_verifier cookies that AuthPage needs to finish the exchange.
+            if (window.location.pathname === '/auth') {
+                return;
+            }
 
-            // If the user already has a local session token, trust it and skip.
-            // This prevents a redirect loop: after AuthPage creates a session and
-            // redirects here, we must not immediately start another auth flow.
+            if (!hasSsoCookie()) {
+                return;
+            }
+
             if (getLocalStorageSessionId()) {
                 return;
             }

--- a/apps/antalmanac/src/lib/ssoCookie.ts
+++ b/apps/antalmanac/src/lib/ssoCookie.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared SSO cookie used to signal across apps on antalmanac.com
+ * that the user has an active ICSSC auth session.
+ *
+ * This is a non-HttpOnly hint cookie readable by both AntAlmanac (/)
+ * and PeterPortal (/planner). It is NOT a session token.
+ */
+
+const COOKIE_NAME = 'icssc_logged_in';
+const MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+function getCookieAttributes(): string {
+    const isLocalhost = window.location.hostname === 'localhost';
+    const domain = isLocalhost ? '' : 'domain=antalmanac.com; ';
+    const secure = isLocalhost ? '' : 'secure; ';
+    return `path=/; ${domain}${secure}samesite=lax`;
+}
+
+export function setSsoCookie() {
+    document.cookie = `${COOKIE_NAME}=1; ${getCookieAttributes()}; max-age=${MAX_AGE_SECONDS}`;
+}
+
+export function clearSsoCookie() {
+    document.cookie = `${COOKIE_NAME}=; ${getCookieAttributes()}; max-age=0`;
+}
+
+export function hasSsoCookie(): boolean {
+    return document.cookie.includes(`${COOKIE_NAME}=1`);
+}

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -16,6 +16,7 @@ import {
     setLocalStorageSessionId,
     setLocalStorageOnFirstSignin,
 } from '$lib/localStorage';
+import { clearSsoCookie, setSsoCookie } from '$lib/ssoCookie';
 import AppStore from '$stores/AppStore';
 
 export function AuthPage() {
@@ -29,6 +30,13 @@ export function AuthPage() {
         }
 
         try {
+            // Silent SSO returned an error — the auth server has no session.
+            if (searchParams.get('error') === 'login_required') {
+                clearSsoCookie();
+                window.location.href = '/';
+                return;
+            }
+
             const code = searchParams.get('code');
             const state = searchParams.get('state');
             if (!code || !state) {
@@ -59,6 +67,7 @@ export function AuthPage() {
             }
 
             setLocalStorageSessionId(sessionToken);
+            setSsoCookie();
 
             // load schedule without saving any changes
             if (fromLoading !== '') {

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -126,7 +126,8 @@ export function AuthPage() {
             window.location.href = '/';
         } catch (error) {
             console.error('Error during authentication', error);
-            isAuthenticatingRef.current = false;
+            clearSsoCookie();
+            window.location.href = '/';
         }
     }, [searchParams]);
 

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import trpc from '$lib/api/trpc';
 import { getLocalStorageSessionId, removeLocalStorageSessionId, setLocalStorageSessionId } from '$lib/localStorage';
+import { clearSsoCookie } from '$lib/ssoCookie';
 import { useNotificationStore } from '$stores/NotificationStore';
 
 interface SessionState {
@@ -59,6 +60,7 @@ export const useSessionStore = create<SessionState>((set) => {
             if (currentSession) {
                 await trpc.auth.invalidateSession.mutate({ token: currentSession });
                 removeLocalStorageSessionId();
+                clearSsoCookie();
                 set({
                     session: null,
                     userId: null,


### PR DESCRIPTION
## Summary
Implements auto sign in via a `prompt=none` request

<details><summary>Agent Plan</summary>
<p>
---
name: Cross-app SSO Implementation
overview: Implement single sign-on between AntAlmanac (antalmanac.com/) and PeterPortal (antalmanac.com/planner) using a shared-domain cookie hint and redirect-based silent auth through the existing OIDC server at auth.icssc.club.
todos:
    - id: auth-server-prompt-none
      content: "Auth server: Add prompt=none handling in /authorize to return error=login_required when no session exists (~/Documents/Code/ICSSC/auth/src/routes/authorize.ts)"
      status: pending
    - id: antalmanac-set-cookie
      content: "AntAlmanac: Set icssc_logged_in cookie on login (AuthPage.tsx) and clear on logout (SessionStore.ts)"
      status: completed
    - id: antalmanac-prompt-param
      content: "AntAlmanac: Add optional prompt parameter to getGoogleAuthUrl tRPC procedure (userData.ts)"
      status: completed
    - id: antalmanac-handle-error
      content: "AntAlmanac: Handle error=login_required in AuthPage.tsx callback"
      status: completed
    - id: antalmanac-autosignin
      content: "AntAlmanac: Replace iframe-based AutoSignIn with shared-cookie + redirect approach, uncomment in App.tsx"
      status: completed
    - id: peterportal-set-cookie
      content: "PeterPortal: Set icssc_logged_in cookie on login and clear on logout (api/src/controllers/auth.ts)"
      status: pending
    - id: peterportal-prompt-param
      content: "PeterPortal: Support prompt=none query param in GET /google route and handle error=login_required in callback"
      status: pending
    - id: peterportal-autosignin
      content: "PeterPortal: Replace iframe-based AutoSignIn with shared-cookie + redirect approach, uncomment in AppProvider.tsx"
      status: pending
isProject: false
---

# Cross-App SSO: AntAlmanac + PeterPortal

## Current Architecture (Confirmed from Code)

Both apps use `auth.icssc.club` as their OIDC provider (OAuth 2.0 + PKCE, public clients), but manage sessions independently:

|                   | AntAlmanac (`antalmanac.com/`)             | PeterPortal (`antalmanac.com/planner`)               |
| ----------------- | ------------------------------------------ | ---------------------------------------------------- |
| Backend           | Next.js + tRPC                             | Express + tRPC                                       |
| Session store     | PostgreSQL (`sessions` table via Drizzle)  | PostgreSQL (`session` table via `connect-pg-simple`) |
| Session mechanism | Token in `localStorage`, sent in tRPC body | `connect.sid` cookie (express-session default)       |
| OIDC client ID    | `antalmanac`                               | `peterportal`                                        |
| Callback URL      | `/auth`                                    | `/planner/api/users/auth/google/callback`            |

The auth server (`[src/routes/authorize.ts](../auth/src/routes/authorize.ts)`) already supports session reuse: if a user has an `sid` cookie on `auth.icssc.club` and scopes are satisfied, it issues an auth code immediately without redirecting to Google. Both apps already have `AutoSignIn` components that are **commented out** (using iframe-based `/session/check`).

## Why the Existing AutoSignIn Approach is Fragile

Both apps' `AutoSignIn` loads a hidden iframe from `auth.icssc.club/session/check`. This requires the browser to send the `sid` cookie (set on `auth.icssc.club`) in a third-party context. Modern browsers (Chrome, Safari, Firefox) increasingly block third-party cookies, even with `SameSite=None; Secure`. This is likely why both components are commented out.

## Proposed Solution: Shared Domain Cookie + Redirect-based Silent Auth

Since both apps are on `antalmanac.com`, we can use a **first-party cookie** as a hint, then perform a **top-level redirect** to the auth server (where its `sid` cookie is first-party):

```mermaid
sequenceDiagram
    participant User
    participant AppA as App A (e.g. AntAlmanac)
    participant AuthServer as auth.icssc.club
    participant Google
    participant AppB as App B (e.g. PeterPortal)

    Note over User,AppA: Step 1: User logs into App A normally
    User->>AppA: Click "Sign In"
    AppA->>AuthServer: Redirect to /authorize
    AuthServer->>Google: Redirect to Google (no existing session)
    Google->>AuthServer: Callback with Google tokens
    AuthServer->>AppA: Redirect with auth code
    AppA->>AppA: Create local session
    AppA->>AppA: Set icssc_logged_in=1 cookie on antalmanac.com

    Note over User,AppB: Step 2: User visits App B
    User->>AppB: Navigate to App B
    AppB->>AppB: No local session, but icssc_logged_in cookie exists
    AppB->>AuthServer: Redirect to /authorize?prompt=none
    Note over AuthServer: Has sid session from Step 1
    AuthServer->>AppB: Redirect with auth code (no Google needed)
    AppB->>AppB: Create local session, user is signed in
```

## Changes Required

### 1. Auth Server: Handle `prompt=none` when no session exists

The schema already accepts `prompt=none` (`[src/lib/schemas/authorize.ts:11](../auth/src/lib/schemas/authorize.ts)`). But the authorize route currently redirects to Google when there's no session, regardless of `prompt`. We need to return an error redirect instead.

**File:** `[~/Documents/Code/ICSSC/auth/src/routes/authorize.ts](../auth/src/routes/authorize.ts)`

In the block where there's no session / scopes don't match / `prompt === "consent"` (line ~59-79), add a check at the top:

```typescript
if (
    !session ||
    !scopesSatisfied(session.scope, scope) ||
    prompt === "consent"
) {
    // NEW: If prompt=none, we can't authenticate silently - return error
    if (prompt === "none") {
        const redirectUrl = new URL(redirect_uri);
        redirectUrl.searchParams.set("error", "login_required");
        if (state) {
            redirectUrl.searchParams.set("state", state);
        }
        return c.redirect(redirectUrl.toString());
    }

    // ... existing Google redirect logic unchanged ...
}
```

This follows the [OpenID Connect spec for `prompt=none](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)`: return `error=login_required` if the user isn't authenticated.

### 2. AntAlmanac: Set/Clear Shared Cookie + Replace AutoSignIn

#### 2a. Set cookie on successful login

**File:** `[apps/antalmanac/src/routes/AuthPage.tsx](apps/antalmanac/src/routes/AuthPage.tsx)`

After `setLocalStorageSessionId(sessionToken)` (around line 67), set the shared cookie:

```typescript
setLocalStorageSessionId(sessionToken);

// Set shared SSO cookie for cross-app sign-in
const isLocalhost = window.location.hostname === "localhost";
const domainAttr = isLocalhost ? "" : "domain=antalmanac.com;";
document.cookie = `icssc_logged_in=1; path=/; ${domainAttr} max-age=2592000; samesite=lax${isLocalhost ? "" : "; secure"}`;
```

#### 2b. Clear cookie on logout

**File:** `[apps/antalmanac/src/stores/SessionStore.ts](apps/antalmanac/src/stores/SessionStore.ts)`

In `clearSession`, before `removeLocalStorageSessionId()`:

```typescript
// Clear shared SSO cookie
const isLocalhost = window.location.hostname === "localhost";
const domainAttr = isLocalhost ? "" : "domain=antalmanac.com;";
document.cookie = `icssc_logged_in=; path=/; ${domainAttr} max-age=0`;
```

#### 2c. Add `prompt` parameter to auth URL generation

**File:** `[apps/antalmanac/src/backend/routers/userData.ts](apps/antalmanac/src/backend/routers/userData.ts)`

Modify `getGoogleAuthUrl` to accept an optional `prompt` parameter:

```typescript
getGoogleAuthUrl: procedure
    .input(z.object({ prompt: z.enum(['none', 'consent']).optional() }).optional())
    .query(async ({ input, ctx }) => {
        // ... existing code to build URL ...
        if (input?.prompt) {
            url.searchParams.set('prompt', input.prompt);
        }
        return url;
    }),
```

#### 2d. Handle `error=login_required` in AuthPage

**File:** `[apps/antalmanac/src/routes/AuthPage.tsx](apps/antalmanac/src/routes/AuthPage.tsx)`

At the top of `handleSearchParamsChange`, before checking for `code`:

```typescript
const error = searchParams.get("error");
if (error === "login_required") {
    // Silent SSO failed - clear the hint cookie
    const isLocalhost = window.location.hostname === "localhost";
    const domainAttr = isLocalhost ? "" : "domain=antalmanac.com;";
    document.cookie = `icssc_logged_in=; path=/; ${domainAttr} max-age=0`;
    window.location.href = "/";
    return;
}
```

#### 2e. Replace AutoSignIn with redirect-based approach

**File:** `[apps/antalmanac/src/components/AutoSignIn.tsx](apps/antalmanac/src/components/AutoSignIn.tsx)`

Replace the iframe-based check with:

```typescript
export function AutoSignIn() {
    const hasChecked = useRef(false);

    useEffect(() => {
        if (hasChecked.current) return;
        hasChecked.current = true;

        const checkAndSignIn = async () => {
            const localSessionId = getLocalStorageSessionId();
            if (localSessionId) {
                const isValid = await trpc.auth.validateSession.query({
                    token: localSessionId,
                });
                if (isValid) return;
            }

            if (!document.cookie.includes("icssc_logged_in=1")) return;

            // Trigger silent OAuth flow with prompt=none
            const authUrl = await trpc.userData.getGoogleAuthUrl.query({
                prompt: "none",
            });
            window.location.href = authUrl;
        };

        checkAndSignIn();
    }, []);

    return null;
}
```

Then **uncomment** `<AutoSignIn />` in `[apps/antalmanac/src/App.tsx](apps/antalmanac/src/App.tsx)` (line 29).

### 3. PeterPortal: Set/Clear Shared Cookie + Replace AutoSignIn

#### 3a. Set cookie on successful login

**File:** `[~/Documents/Code/ICSSC/peterportal-client/api/src/controllers/auth.ts](../peterportal-client/api/src/controllers/auth.ts)`

In `successLogin`, before `res.redirect(returnTo!)`, set the shared cookie:

```typescript
const isLocalhost = req.hostname === "localhost";
res.cookie("icssc_logged_in", "1", {
    path: "/",
    ...(isLocalhost ? {} : { domain: "antalmanac.com" }),
    maxAge: 30 * 24 * 60 * 60 * 1000,
    sameSite: "lax",
    secure: !isLocalhost,
});
res.redirect(returnTo!);
```

#### 3b. Clear cookie on logout

**File:** `[~/Documents/Code/ICSSC/peterportal-client/api/src/controllers/auth.ts](../peterportal-client/api/src/controllers/auth.ts)`

In the logout handler, add:

```typescript
const isLocalhost = req.hostname === "localhost";
res.clearCookie("icssc_logged_in", {
    path: "/",
    ...(isLocalhost ? {} : { domain: "antalmanac.com" }),
});
```

#### 3c. Support `prompt=none` in the OAuth initiation route

**File:** `[~/Documents/Code/ICSSC/peterportal-client/api/src/controllers/auth.ts](../peterportal-client/api/src/controllers/auth.ts)`

In `GET /google`, check for `req.query.prompt` and pass it through:

```typescript
const authUrl = oidcClient.createAuthorizationURLWithPKCE(/* ... */);
if (req.query.prompt === "none") {
    authUrl.searchParams.set("prompt", "none");
}
res.redirect(authUrl.toString());
```

#### 3d. Handle `error=login_required` in callback

**File:** `[~/Documents/Code/ICSSC/peterportal-client/api/src/controllers/auth.ts](../peterportal-client/api/src/controllers/auth.ts)`

In `GET /google/callback`, at the top:

```typescript
if (req.query.error === "login_required") {
    const isLocalhost = req.hostname === "localhost";
    res.clearCookie("icssc_logged_in", {
        path: "/",
        ...(isLocalhost ? {} : { domain: "antalmanac.com" }),
    });
    res.redirect(req.session.returnTo ?? "/planner");
    return;
}
```

#### 3e. Replace AutoSignIn with redirect-based approach

**File:** `[~/Documents/Code/ICSSC/peterportal-client/site/src/component/AutoSignIn/AutoSignIn.tsx](../peterportal-client/site/src/component/AutoSignIn/AutoSignIn.tsx)`

Replace the iframe-based check with a simpler cookie check:

```typescript
export function AutoSignIn() {
    const isLoggedIn = useIsLoggedIn();
    const hasChecked = useRef(false);

    useEffect(() => {
        if (hasChecked.current || isLoggedIn) return;
        hasChecked.current = true;

        if (!document.cookie.includes("icssc_logged_in=1")) return;

        // Redirect to OAuth flow with prompt=none for silent SSO
        window.location.href = "/planner/api/users/auth/google?prompt=none";
    }, [isLoggedIn]);

    return null;
}
```

Then **uncomment** `<AutoSignIn />` in `[~/Documents/Code/ICSSC/peterportal-client/site/src/component/AppProvider/AppProvider.tsx](../peterportal-client/site/src/component/AppProvider/AppProvider.tsx)` (line 53).

## Considerations

- **Local development:** The shared cookie won't work across `localhost:3000` and `localhost:8080` (different ports = different cookie jars). SSO is a production/staging-only feature; developers log in to each app separately.
- **Logout scope:** Logging out of one app clears the shared cookie and the auth server session. The other app retains its local session until refresh or expiry. Full single-logout (SLO) can be added later via OIDC back-channel logout.
- **Cookie collision:** PeterPortal's `connect.sid` (Path=/) is sent to AntAlmanac's backend too, but AntAlmanac doesn't use express-session, so it's harmlessly ignored.
- **Auth server client registration:** The `peterportal` client's `allowedDomainPatterns` already includes `https://antalmanac.com`, so `redirect_uri=https://antalmanac.com/planner/api/users/auth/google/callback` is valid. No client registration changes needed.
- **Staging:** The `icssc_logged_in` cookie with `domain=antalmanac.com` is also sent to `staging-shared.antalmanac.com`, `scheduler-*.antalmanac.com`, etc. This means SSO works across staging environments too.
</p>
</details> 

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
