### PR TITLE
fix: enable auto save and hover to preview by default

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -128,7 +128,7 @@ class ActionTypesStore extends EventEmitter {
 
     async autoSaveSchedule(action: ActionType) {
         const sessionStore = useSessionStore.getState();
-        const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() == 'true';
+        const autoSave = typeof Storage === 'undefined' || getLocalStorageAutoSave() !== 'false';
 
         if (!sessionStore.sessionIsValid || !sessionStore.session) {
             if (autoSave) {

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -84,7 +84,7 @@ export interface PreviewStore {
 }
 
 export const usePreviewStore = create<PreviewStore>((set) => {
-    const previewMode = typeof Storage !== 'undefined' && getLocalStoragePreviewMode() == 'true';
+    const previewMode = typeof Storage === 'undefined' || getLocalStoragePreviewMode() !== 'false';
 
     return {
         previewMode: previewMode,
@@ -104,7 +104,7 @@ export interface AutoSaveStore {
 }
 
 export const useAutoSaveStore = create<AutoSaveStore>((set) => {
-    const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() == 'true';
+    const autoSave = typeof Storage === 'undefined' || getLocalStorageAutoSave() !== 'false';
 
     return {
         autoSave,


### PR DESCRIPTION
## Summary
Enables auto save and hover to preview by default.

Hover to preview has some minor issues when adding new sections which I can fix.

Request for comment.
## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
