### PR TITLE
fix: switcher layout shift

### DIFF
--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -48,7 +48,7 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
         setPlannerLoading(true);
     };
 
-    const plannerIcon = plannerLoading ? <CircularProgress size={20} sx={{ margin: 0 }} color="inherit" /> : <Route />;
+    const plannerIcon = plannerLoading ? <CircularProgress size={20} color="inherit" /> : <Route />;
 
     if (isMobile) {
         return (

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -16,6 +16,7 @@ import type { MouseEventHandler } from 'react';
 import { Logo } from '$components/Header/Logo';
 import { BLUE, PLANNER_LINK } from '$src/globals';
 import appStore from '$stores/AppStore';
+
 type AppSwitcherProps = {
     isMobile: boolean;
 };

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -47,7 +47,7 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
         setPlannerLoading(true);
     };
 
-    const plannerIcon = plannerLoading ? <CircularProgress size={16} color="inherit" /> : <Route />;
+    const plannerIcon = plannerLoading ? <CircularProgress size={20} sx={{ margin: 0 }} color="inherit" /> : <Route />;
 
     if (isMobile) {
         return (

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -11,10 +11,11 @@ import {
     Typography,
 } from '@mui/material';
 import { useState } from 'react';
+import type { MouseEventHandler } from 'react';
 
 import { Logo } from '$components/Header/Logo';
-import { BLUE } from '$src/globals';
-
+import { BLUE, PLANNER_LINK } from '$src/globals';
+import appStore from '$stores/AppStore';
 type AppSwitcherProps = {
     isMobile: boolean;
 };
@@ -25,8 +26,24 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
 
     const platform = window.location.pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
 
-    const handlePlannerClick = () => {
+    const handlePlannerClick: MouseEventHandler<HTMLElement> = (event) => {
         if (plannerLoading) return;
+
+        if (appStore.hasUnsavedChanges()) {
+            const shouldLeave = window.confirm(
+                'You have unsaved changes. Are you sure you want to leave without saving?'
+            );
+
+            if (!shouldLeave) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            // user chose to leave, suppress beforeunload warning
+            appStore.unsavedChanges = false;
+        }
+
         setPlannerLoading(true);
     };
 
@@ -82,11 +99,13 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
                         </MenuItem>
                         <MenuItem
                             component="a"
-                            href="/planner"
+                            href={PLANNER_LINK}
                             selected={platform === 'Planner'}
-                            onClick={() => {
-                                handlePlannerClick();
-                                setAnchorEl(null);
+                            onClick={(event) => {
+                                handlePlannerClick(event);
+                                if (!event.defaultPrevented) {
+                                    setAnchorEl(null);
+                                }
                             }}
                             disabled={plannerLoading}
                             sx={{ minHeight: 'fit-content', textDecoration: 'none', color: 'inherit' }}
@@ -123,7 +142,7 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
                 </Button>
                 <Button
                     component="a"
-                    href="/planner"
+                    href={PLANNER_LINK}
                     startIcon={plannerIcon}
                     onClick={handlePlannerClick}
                     disabled={plannerLoading}


### PR DESCRIPTION
## Summary

Fixes layout shift and persistent loading animation when there are unsaved changes and the user is moving between scheduler and planner.

Planner should mirror these changes.

https://github.com/user-attachments/assets/e2ca208a-42e7-421c-b833-9bc108a5824e

## Test Plan

After adding a section, navigating to planner, and activating unsaved changes:

- the loading animation is cancelled if the user decides to make changes
- there is no layout shift


## Issues

Closes #1503

Successor to https://github.com/icssc/AntAlmanac/pull/1548 (adds loading spinner, moves switcher to separate component to mirror https://github.com/icssc/AntAlmanac/pull/1509)