### PR TITLE
Make AANTS Sender Say "AntAlmanac"

### DIFF
--- a/apps/aants/src/helpers/notificationDispatch.ts
+++ b/apps/aants/src/helpers/notificationDispatch.ts
@@ -154,7 +154,7 @@ async function sendNotification(
                 const text = toPlainText(html);
 
                 return queueEmail({
-                    FromEmailAddress: 'no-reply@icssc.club',
+                    FromEmailAddress: '"AntAlmanac" <no-reply@icssc.club>',
                     Destination: {
                         ToAddresses: [user.email],
                     },


### PR DESCRIPTION
## Summary
AANTS emails used to say the from was "no-reply," this updates it to say "AntAlmanac"

<img width="969" height="40" alt="image" src="https://github.com/user-attachments/assets/d42e5a8f-86f7-46a9-b633-5ec5138bdf01" />

