### PR TITLE
Group course sections

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -13,7 +13,7 @@ import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } f
 
 import { getDefaultTerm } from '$lib/termData';
 import { WebSOC } from '$lib/websoc';
-import { getColorForNewSection, getCourseId } from '$stores/scheduleHelpers';
+import { getColorForNewSection, getCourseId, groupCourseSections } from '$stores/scheduleHelpers';
 
 /**
  * Manages state of schedules. Only one instance is really needed for the app.
@@ -624,6 +624,9 @@ export class Schedules {
                     }
                 }
 
+                /** See {@link groupCourseSections} */
+                const groupedCourses = groupCourseSections(courses);
+
                 const scheduleNoteId = Math.random();
                 if ('scheduleNote' in shortCourseSchedule) {
                     this.scheduleNoteMap[scheduleNoteId] = shortCourseSchedule.scheduleNote;
@@ -635,7 +638,7 @@ export class Schedules {
 
                 this.schedules.push({
                     scheduleName: shortCourseSchedule.scheduleName,
-                    courses: courses,
+                    courses: groupedCourses,
                     customEvents: shortCourseSchedule.customEvents,
                     scheduleNoteId: scheduleNoteId,
                 });

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -13,7 +13,7 @@ import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } f
 
 import { getDefaultTerm } from '$lib/termData';
 import { WebSOC } from '$lib/websoc';
-import { getColorForNewSection } from '$stores/scheduleHelpers';
+import { getColorForNewSection, getCourseId } from '$stores/scheduleHelpers';
 
 /**
  * Manages state of schedules. Only one instance is really needed for the app.
@@ -269,7 +269,15 @@ export class Schedules {
             },
         };
 
-        this.schedules[scheduleIndex].courses.push(sectionToAdd);
+        const courses = this.schedules[scheduleIndex].courses;
+        const sectionCourseId = getCourseId(sectionToAdd);
+        const courseLastSectionIndex = courses.findLastIndex((course) => getCourseId(course) === sectionCourseId);
+        if (courseLastSectionIndex !== -1) {
+            courses.splice(courseLastSectionIndex + 1, 0, sectionToAdd);
+        } else {
+            courses.push(sectionToAdd);
+        }
+        console.log(courses);
 
         return sectionToAdd;
     }

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -277,7 +277,6 @@ export class Schedules {
         } else {
             courses.push(sectionToAdd);
         }
-        console.log(courses);
 
         return sectionToAdd;
     }

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -115,3 +115,10 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
         defaultColors[(defaultColors.indexOf(lastDefaultColor) + 1) % defaultColors.length]
     );
 }
+
+/**
+ * Combines department code, course number, and course title to create an ID unique to a course.
+ */
+export function getCourseId(course: Pick<ScheduleCourse, 'deptCode' | 'courseNumber' | 'courseTitle'>) {
+    return course.deptCode + course.courseNumber + course.courseTitle;
+}

--- a/apps/antalmanac/src/stores/scheduleHelpers.ts
+++ b/apps/antalmanac/src/stores/scheduleHelpers.ts
@@ -122,3 +122,31 @@ export function getColorForNewSection(newSection: ScheduleCourse, sectionsInSche
 export function getCourseId(course: Pick<ScheduleCourse, 'deptCode' | 'courseNumber' | 'courseTitle'>) {
     return course.deptCode + course.courseNumber + course.courseTitle;
 }
+
+/**
+ * Temporary measure to group each course's sections together
+ * since previous courses were unsorted.
+ *
+ * Once there are likely no users with unsorted courses, probably in a few years,
+ * this function and its call can be deleted.
+ *
+ * Date written: March 2026
+ */
+export function groupCourseSections(courses: ScheduleCourse[]): ScheduleCourse[] {
+    const courseIndexes: { [courseId: string]: number } = {};
+    const groupedCourses: ScheduleCourse[][] = [];
+    let index = 0;
+    for (const course of courses) {
+        const courseId = getCourseId(course);
+        if (!Object.hasOwn(courseIndexes, courseId)) {
+            courseIndexes[courseId] = index;
+            groupedCourses.push([]);
+            index++;
+        }
+    }
+    for (const course of courses) {
+        const courseIndex = courseIndexes[getCourseId(course)];
+        groupedCourses[courseIndex].push(course);
+    }
+    return groupedCourses.flat();
+}


### PR DESCRIPTION
## Summary

Sorts schedules' `courses` array so that sections are consecutive.

## Test Plan

Add some courses in mixed order then delete them and see that course order doesn't change.
For example: Add ICS 6B Lec -> ICS 6D Lec -> ICS 6B Dis, then delete ICS 6B and confirm that ordering of courses in the added courses pane doesn't change.

## Issues

Closes #1564

<!-- [Optional]
## Future Followup
-->
