### PR TITLE
Ignore Starting and Ending Whitespaces in Course Search

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -204,7 +204,7 @@ const FuzzySearch = ({ toggleSearch, postHog }: FuzzySearchProps) => {
     }, [cache, currentTerm, value, maybeDoSearchFactory, pendingRequest]);
 
     const onInputChange = (_event: unknown, inputValue: string, reason: AutocompleteInputChangeReason) => {
-        const lowerCaseValue = inputValue.toLowerCase();
+        const lowerCaseValue = inputValue.toLowerCase().trim();
         if (reason === 'input') {
             const newValue = lowerCaseValue.slice(-1) === ' ' ? lowerCaseValue.slice(0, -1) : lowerCaseValue;
 


### PR DESCRIPTION
## Summary
Small Quality of Life (QoL) improvement that makes the course search ignore starting and ending whitespaces. This is to avoid situations where ` 36006`, for example, result in `No results found! Please try broadening your search.`
