### PR TITLE
fix: stop loading on browser back navigation

### DIFF
--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -65,7 +65,9 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
 
     useEffect(() => {
         const handlePageShow = (event: PageTransitionEvent) => {
-            if (event.persisted) setPlannerLoading(false);
+            if (event.persisted) {
+                setPlannerLoading(false);
+            }
         };
 
         window.addEventListener('pageshow', handlePageShow);

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -11,7 +11,7 @@ import {
     Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { MouseEventHandler } from 'react';
 
 import { Logo } from '$components/Header/Logo';
@@ -62,6 +62,15 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
 
         setPlannerLoading(true);
     };
+
+    useEffect(() => {
+        const handlePageShow = (event: PageTransitionEvent) => {
+            if (event.persisted) setPlannerLoading(false);
+        };
+
+        window.addEventListener('pageshow', handlePageShow);
+        return () => window.removeEventListener('pageshow', handlePageShow);
+    }, []);
 
     const plannerIcon = plannerLoading ? <CircularProgress size={20} color="inherit" /> : <Route />;
 


### PR DESCRIPTION
## Summary
The Planner button should no longer have a loading animation or be disabled when using the browser back button.

## Test Plan
This bug only occurs in staging/production and is difficult to replicate in a development environment.

Running
```
pnpm run --filter antalmanac build
pnpm run --filter antalmanac start
```
will allow bfcache to work.

This PR can also be compared to other staging instances.

## Issues

Closes https://github.com/icssc/AntAlmanac/issues/1575
