### PR TITLE
Fix aants package dependency on db package

### DIFF
--- a/apps/aants/package.json
+++ b/apps/aants/package.json
@@ -15,6 +15,7 @@
         "@aws-sdk/client-sesv2": "^3.750.0",
         "@aws-sdk/client-sqs": "^3.750.0",
         "@packages/anteater-api-types": "workspace:*",
+        "@packages/db": "workspace:*",
         "@react-email/components": "^1.0.8",
         "@react-email/render": "^2.0.4",
         "@trpc/server": "^10.30.0",

--- a/apps/aants/src/helpers/subscriptionData.ts
+++ b/apps/aants/src/helpers/subscriptionData.ts
@@ -1,9 +1,8 @@
 import type { WebsocAPIResponse, WebsocSection } from '@packages/anteater-api-types';
+import { db } from '@packages/db/src/index';
+import { type User as DbUser, users } from '@packages/db/src/schema/auth/user';
+import { type Subscription, subscriptions } from '@packages/db/src/schema/subscription';
 import { and, eq, inArray } from 'drizzle-orm';
-
-import { db } from '../../../../packages/db/src/index';
-import { type User as DbUser, users } from '../../../../packages/db/src/schema/auth/user';
-import { type Subscription, subscriptions } from '../../../../packages/db/src/schema/subscription';
 
 const ANTEATER_API_BASE_URL = 'https://anteaterapi.com/v2/rest/websoc';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@packages/anteater-api-types':
         specifier: workspace:*
         version: link:../../packages/anteater-api-types
+      '@packages/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@react-email/components':
         specifier: ^1.0.8
         version: 1.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)


### PR DESCRIPTION
## Summary

Add @packages/db as a dependency to the AANTS package to fix errors.

## Test Plan

Confirm that there are no import errors in `subscriptionData.ts`.

## Issues

Closes #1579

<!-- [Optional]
## Future Followup
-->
