### PR TITLE
Use fetchAnteaterAPI for all AAPI calls

### DIFF
--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -8,7 +8,9 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { CalendarTerm } from '@packages/antalmanac-types';
+import type { CalendarTerm, CalendarAllAPIResult } from '@packages/antalmanac-types';
+
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
 const PUBLIC_ANTEATER_API_KEY = 'INSqn9qP1pXlEwihpQa_GtrJhGOxQyjE5zcAKYLptLg.pk.prj9hlf3sf7q638jkq61u282';
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -33,18 +35,16 @@ function sanitizeTermName(year: string, quarter: keyof typeof QUARTER_MAP): `${s
 }
 
 async function fetchCalendarTerms(): Promise<CalendarTerm[]> {
-    const res = await fetch(API_URL, {
+    const { data } = await fetchAnteaterAPI<CalendarAllAPIResult>(API_URL, {
         headers: {
             Authorization: `Bearer ${PUBLIC_ANTEATER_API_KEY}`,
             Origin: ORIGIN,
         },
+        invalidResponseCallback: (res) => {
+            throw new Error(`Failed to fetch terms: ${res.statusText}`);
+        },
     });
 
-    if (!res.ok) {
-        throw new Error(`Failed to fetch terms: ${res.statusText}`);
-    }
-
-    const { data } = await res.json();
     return data;
 }
 

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { Course, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 
-import { fetchAnteaterAPIData, queryGraphQL } from '../src/backend/lib/helpers';
+import { fetchAnteaterAPI, queryGraphQL } from '../src/backend/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
 
 import 'dotenv/config';
@@ -22,17 +22,13 @@ const ALIASES: Record<string, string | undefined> = {
 };
 
 async function main() {
-    const apiKey = process.env.ANTEATER_API_KEY;
-    if (!apiKey) throw new Error('ANTEATER_API_KEY is required');
-
     console.log('Generating cache for fuzzy search.');
     console.log('Fetching courses from Anteater API...');
-    const headers = { Authorization: `Bearer ${apiKey}` };
     const courses: Course[] = [];
     for (let skip = 0; skip < MAX_COURSES; skip += 100) {
-        const data = await fetchAnteaterAPIData<{ data: Course[] }>(
+        const data = await fetchAnteaterAPI<{ data: Course[] }>(
             `https://anteaterapi.com/v2/rest/courses?take=100&skip=${skip}`,
-            headers
+            { isApiKeyRequired: true }
         );
         courses.push(...data.data);
     }

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -2,7 +2,12 @@ import { access, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { Course, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
+import type {
+    Course,
+    CourseSearchResult,
+    DepartmentSearchResult,
+    CoursesFilteredAPIResult,
+} from '@packages/antalmanac-types';
 
 import { fetchAnteaterAPI, queryGraphQL } from '../src/backend/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
@@ -26,7 +31,7 @@ async function main() {
     console.log('Fetching courses from Anteater API...');
     const courses: Course[] = [];
     for (let skip = 0; skip < MAX_COURSES; skip += 100) {
-        const data = await fetchAnteaterAPI<{ data: Course[] }>(
+        const data = await fetchAnteaterAPI<CoursesFilteredAPIResult>(
             `https://anteaterapi.com/v2/rest/courses?take=100&skip=${skip}`,
             { isApiKeyRequired: true }
         );

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { Course, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 
-import { queryGraphQL } from '../src/backend/lib/helpers';
+import { fetchAnteaterAPIData, queryGraphQL } from '../src/backend/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
 
 import 'dotenv/config';
@@ -30,9 +30,11 @@ async function main() {
     const headers = { Authorization: `Bearer ${apiKey}` };
     const courses: Course[] = [];
     for (let skip = 0; skip < MAX_COURSES; skip += 100) {
-        await fetch(`https://anteaterapi.com/v2/rest/courses?take=100&skip=${skip}`, { headers })
-            .then((x) => x.json())
-            .then((x) => courses.push(...(x.data as Course[])));
+        const data = await fetchAnteaterAPIData<{ data: Course[] }>(
+            `https://anteaterapi.com/v2/rest/courses?take=100&skip=${skip}`,
+            headers
+        );
+        courses.push(...data.data);
     }
     console.log(`Fetched ${courses.length} courses.`);
     const courseMap = new Map<string, CourseSearchResult & { id: string }>();

--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 import 'dotenv/config';
 import { WebsocSchool, WebsocTerm } from '@packages/antalmanac-types';
 
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const TERMS_URL = 'https://anteaterapi.com/v2/rest/websoc/terms';
@@ -18,18 +20,15 @@ interface DeployedTermsData {
     reason?: string;
 }
 
-async function getSectionCount(term: WebsocTerm, headers: Record<string, string>) {
+async function getSectionCount(term: WebsocTerm) {
     const [year, quarter] = term.shortName.split(' ');
     console.log(`Checking section count for ${year} ${quarter} from ${WEBSOC_URL}...`);
 
     const params = new URLSearchParams({ year, quarter });
-    const res = await fetch(`${WEBSOC_URL}?${params.toString()}`, { headers });
+    const json = await fetchAnteaterAPI<{ data: { schools: WebsocSchool[] } }>(`${WEBSOC_URL}?${params.toString()}`, {
+        isApiKeyRequired: true,
+    });
 
-    if (!res.ok) {
-        throw new Error(`API error: ${res.status}`);
-    }
-
-    const json = (await res.json()) as { data: { schools: WebsocSchool[] } };
     let count = 0;
     for (const school of json.data.schools) {
         for (const dept of school.departments) {
@@ -43,19 +42,9 @@ async function getSectionCount(term: WebsocTerm, headers: Record<string, string>
 
 async function updateTerms() {
     try {
-        const apiKey = process.env.ANTEATER_API_KEY;
-        if (!apiKey) throw new Error('ANTEATER_API_KEY is required');
-
-        const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
-
         console.log(`Fetching terms from ${TERMS_URL}...`);
-        const termsRes = await fetch(TERMS_URL, { headers });
+        const termsJson = await fetchAnteaterAPI<{ data: WebsocTerm[] }>(TERMS_URL, { isApiKeyRequired: true });
 
-        if (!termsRes.ok) {
-            throw new Error(`API returned ${termsRes.status}: ${termsRes.statusText}`);
-        }
-
-        const termsJson = (await termsRes.json()) as { data: WebsocTerm[] };
         const data = termsJson.data;
 
         if (!data || data.length === 0) {
@@ -63,7 +52,7 @@ async function updateTerms() {
         }
 
         const latestTerm = data[0].longName;
-        const currentCount = await getSectionCount(data[0], headers);
+        const currentCount = await getSectionCount(data[0]);
 
         console.log(`Latest term from API: ${latestTerm}`);
         console.log(`Total sections from API: ${currentCount}`);

--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import 'dotenv/config';
-import { WebsocSchool, WebsocTerm } from '@packages/antalmanac-types';
+import { WebsocAPIResult, WebsocTerm, WebsocTermsAPIResult } from '@packages/antalmanac-types';
 
 import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
@@ -25,7 +25,7 @@ async function getSectionCount(term: WebsocTerm) {
     console.log(`Checking section count for ${year} ${quarter} from ${WEBSOC_URL}...`);
 
     const params = new URLSearchParams({ year, quarter });
-    const json = await fetchAnteaterAPI<{ data: { schools: WebsocSchool[] } }>(`${WEBSOC_URL}?${params.toString()}`, {
+    const json = await fetchAnteaterAPI<WebsocAPIResult>(`${WEBSOC_URL}?${params.toString()}`, {
         isApiKeyRequired: true,
     });
 
@@ -43,7 +43,7 @@ async function getSectionCount(term: WebsocTerm) {
 async function updateTerms() {
     try {
         console.log(`Fetching terms from ${TERMS_URL}...`);
-        const termsJson = await fetchAnteaterAPI<{ data: WebsocTerm[] }>(TERMS_URL, { isApiKeyRequired: true });
+        const termsJson = await fetchAnteaterAPI<WebsocTermsAPIResult>(TERMS_URL, { isApiKeyRequired: true });
 
         const data = termsJson.data;
 

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -1,3 +1,29 @@
+import { TRPCError } from '@trpc/server';
+
+export async function fetchAnteaterAPI(url: string): Promise<Response> {
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            headers: {
+                ...(process.env.ANTEATER_API_KEY && { Authorization: `Bearer ${process.env.ANTEATER_API_KEY}` }),
+            },
+        });
+    } catch (err) {
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to reach the Anteater API: ${err}`,
+        });
+    }
+
+    if (!response.ok) {
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
+        });
+    }
+    return response;
+}
+
 export async function queryGraphQL<PromiseReturnType>(queryString: string): Promise<PromiseReturnType | null> {
     const query = JSON.stringify({
         query: queryString,

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -1,20 +1,39 @@
 import { TRPCError } from '@trpc/server';
 
-export async function fetchAnteaterAPI(
+interface FetchAAPIOptions {
+    isApiKeyRequired?: boolean;
+    invalidResponseCallback?: null | ((response: Response) => void);
+    headers?: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null;
+}
+
+/**
+ * Fetches AAPI data and throws errors with descriptive messages.
+ *
+ * @param url AAPI url to fetch from.
+ * @param options.isApiKeyRequired Throw an error if AAPI API key is invalid?
+ * @param options.invalidResponseCallback Function that is called when a response is invalid.
+ *        If provided and an error should be thrown, throw the error in the callback.
+ *        An error will not be thrown automatically.
+ * @param options.headers Headers to pass in addition or to replace default headers.
+ * @returns The response's data.
+ */
+export async function fetchAnteaterAPI<DataType>(
     url: string,
-    headersOverride: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null = null
-): Promise<Response> {
+    { isApiKeyRequired = false, invalidResponseCallback = null, headers = null }: FetchAAPIOptions = {}
+) {
+    if (isApiKeyRequired && !process.env.ANTEATER_API_KEY) {
+        throw new Error('ANTEATER_API_KEY is required');
+    }
+
     let response: Response;
     try {
         response = await fetch(url, {
-            headers:
-                headersOverride === null
-                    ? {
-                          ...(process.env.ANTEATER_API_KEY && {
-                              Authorization: `Bearer ${process.env.ANTEATER_API_KEY}`,
-                          }),
-                      }
-                    : headersOverride,
+            headers: {
+                ...(process.env.ANTEATER_API_KEY && {
+                    Authorization: `Bearer ${process.env.ANTEATER_API_KEY}`,
+                }),
+                ...headers,
+            },
         });
     } catch (err) {
         throw new TRPCError({
@@ -24,22 +43,18 @@ export async function fetchAnteaterAPI(
     }
 
     if (!response.ok) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
-        });
+        if (invalidResponseCallback !== null) {
+            invalidResponseCallback(response);
+        } else {
+            throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
+            });
+        }
     }
-    return response;
-}
-
-export async function fetchAnteaterAPIData<Data>(
-    url: string,
-    headersOverride: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null = null
-): Promise<Data> {
-    const response = await fetchAnteaterAPI(url, headersOverride);
 
     try {
-        return await response.json();
+        return (await response.json()) as DataType;
     } catch (err) {
         throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -12,8 +12,7 @@ interface FetchAAPIOptions {
  * @param url AAPI url to fetch from.
  * @param options.isApiKeyRequired Throw an error if AAPI API key is invalid?
  * @param options.invalidResponseCallback Function that is called when a response is invalid.
- *        If provided and an error should be thrown, throw the error in the callback.
- *        An error will not be thrown automatically.
+ *        If this callback does not throw an error, one with a generic message will be thrown automatically.
  * @param options.headers Headers to pass in addition or to replace default headers.
  * @returns The response's data.
  */
@@ -45,12 +44,11 @@ export async function fetchAnteaterAPI<DataType>(
     if (!response.ok) {
         if (invalidResponseCallback !== null) {
             invalidResponseCallback(response);
-        } else {
-            throw new TRPCError({
-                code: 'INTERNAL_SERVER_ERROR',
-                message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
-            });
         }
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
+        });
     }
 
     try {

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -24,6 +24,19 @@ export async function fetchAnteaterAPI(url: string): Promise<Response> {
     return response;
 }
 
+export async function fetchAnteaterAPIData<Data>(url: string): Promise<Data> {
+    const response = await fetchAnteaterAPI(url);
+
+    try {
+        return await response.json();
+    } catch (err) {
+        throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to parse Anteater API response: ${err}`,
+        });
+    }
+}
+
 export async function queryGraphQL<PromiseReturnType>(queryString: string): Promise<PromiseReturnType | null> {
     const query = JSON.stringify({
         query: queryString,

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -1,12 +1,20 @@
 import { TRPCError } from '@trpc/server';
 
-export async function fetchAnteaterAPI(url: string): Promise<Response> {
+export async function fetchAnteaterAPI(
+    url: string,
+    headersOverride: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null = null
+): Promise<Response> {
     let response: Response;
     try {
         response = await fetch(url, {
-            headers: {
-                ...(process.env.ANTEATER_API_KEY && { Authorization: `Bearer ${process.env.ANTEATER_API_KEY}` }),
-            },
+            headers:
+                headersOverride === null
+                    ? {
+                          ...(process.env.ANTEATER_API_KEY && {
+                              Authorization: `Bearer ${process.env.ANTEATER_API_KEY}`,
+                          }),
+                      }
+                    : headersOverride,
         });
     } catch (err) {
         throw new TRPCError({
@@ -24,8 +32,11 @@ export async function fetchAnteaterAPI(url: string): Promise<Response> {
     return response;
 }
 
-export async function fetchAnteaterAPIData<Data>(url: string): Promise<Data> {
-    const response = await fetchAnteaterAPI(url);
+export async function fetchAnteaterAPIData<Data>(
+    url: string,
+    headersOverride: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null = null
+): Promise<Data> {
+    const response = await fetchAnteaterAPI(url, headersOverride);
 
     try {
         return await response.json();

--- a/apps/antalmanac/src/backend/lib/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/helpers.ts
@@ -4,6 +4,7 @@ interface FetchAAPIOptions {
     isApiKeyRequired?: boolean;
     invalidResponseCallback?: null | ((response: Response) => void);
     headers?: NonNullable<Parameters<typeof fetch>[1]>['headers'] | null;
+    errorType?: 'base' | 'trpc';
 }
 
 /**
@@ -14,14 +15,20 @@ interface FetchAAPIOptions {
  * @param options.invalidResponseCallback Function that is called when a response is invalid.
  *        If this callback does not throw an error, one with a generic message will be thrown automatically.
  * @param options.headers Headers to pass in addition or to replace default headers.
+ * @param options.errorType The type of error to throw. Defaults to `base`.
  * @returns The response's data.
  */
 export async function fetchAnteaterAPI<DataType>(
     url: string,
-    { isApiKeyRequired = false, invalidResponseCallback = null, headers = null }: FetchAAPIOptions = {}
+    {
+        isApiKeyRequired = false,
+        invalidResponseCallback = null,
+        headers = null,
+        errorType = 'base',
+    }: FetchAAPIOptions = {}
 ) {
     if (isApiKeyRequired && !process.env.ANTEATER_API_KEY) {
-        throw new Error('ANTEATER_API_KEY is required');
+        throw getErrorByType(errorType, 'ANTEATER_API_KEY is required');
     }
 
     let response: Response;
@@ -35,29 +42,33 @@ export async function fetchAnteaterAPI<DataType>(
             },
         });
     } catch (err) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to reach the Anteater API: ${err}`,
-        });
+        throw getErrorByType(errorType, `Failed to reach the Anteater API: ${err}`);
     }
 
     if (!response.ok) {
         if (invalidResponseCallback !== null) {
             invalidResponseCallback(response);
         }
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
-        });
+        throw getErrorByType(errorType, `Anteater API returned an error: ${response.status} ${response.statusText}`);
     }
 
     try {
         return (await response.json()) as DataType;
     } catch (err) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to parse Anteater API response: ${err}`,
-        });
+        throw getErrorByType(errorType, `Failed to parse Anteater API response: ${err}`);
+    }
+}
+
+export function getErrorByType(errorType: FetchAAPIOptions['errorType'], message: string) {
+    switch (errorType) {
+        case 'trpc':
+            return new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: message,
+            });
+        case 'base':
+        default:
+            return new Error(message);
     }
 }
 

--- a/apps/antalmanac/src/backend/routers/course.ts
+++ b/apps/antalmanac/src/backend/routers/course.ts
@@ -3,11 +3,11 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
 const courseRouter = router({
     get: procedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
-        const data = await fetchAnteaterAPIData<CourseByIdAPIResult>(
+        const data = await fetchAnteaterAPI<CourseByIdAPIResult>(
             `https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`
         );
         return data.ok ? data.data : null;

--- a/apps/antalmanac/src/backend/routers/course.ts
+++ b/apps/antalmanac/src/backend/routers/course.ts
@@ -10,7 +10,7 @@ const courseRouter = router({
         const data = await fetchAnteaterAPI<CourseByIdAPIResult>(
             `https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`
         );
-        return data.ok ? data.data : null;
+        return data.data;
     }),
 });
 

--- a/apps/antalmanac/src/backend/routers/course.ts
+++ b/apps/antalmanac/src/backend/routers/course.ts
@@ -1,17 +1,16 @@
-import type { Course } from '@packages/antalmanac-types';
+import type { CourseByIdAPIResult } from '@packages/antalmanac-types';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
+import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+
 const courseRouter = router({
     get: procedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
-        return await fetch(`https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`, {
-            headers: {
-                ...(process.env.ANTEATER_API_KEY && { Authorization: `Bearer ${process.env.ANTEATER_API_KEY}` }),
-            },
-        })
-            .then((data) => data.json())
-            .then((data) => (data.ok ? (data.data as Course) : null));
+        const data = await fetchAnteaterAPIData<CourseByIdAPIResult>(
+            `https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`
+        );
+        return data.ok ? data.data : null;
     }),
 });
 

--- a/apps/antalmanac/src/backend/routers/course.ts
+++ b/apps/antalmanac/src/backend/routers/course.ts
@@ -8,7 +8,8 @@ import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 const courseRouter = router({
     get: procedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
         const data = await fetchAnteaterAPI<CourseByIdAPIResult>(
-            `https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`
+            `https://anteaterapi.com/v2/rest/courses/${encodeURIComponent(input.id)}`,
+            { errorType: 'trpc' }
         );
         return data.data;
     }),

--- a/apps/antalmanac/src/backend/routers/enrollHist.ts
+++ b/apps/antalmanac/src/backend/routers/enrollHist.ts
@@ -1,20 +1,19 @@
-import { EnrollmentHistory } from '@packages/antalmanac-types';
+import { EnrollmentHistoryAPIResult } from '@packages/antalmanac-types';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
+import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+
 const enrollHistRouter = router({
-    get: procedure.input(z.object({ department: z.string(), courseNumber: z.string(), sectionType: z.string() })).query(
-        async ({ input }) =>
-            await fetch(`https://anteaterapi.com/v2/rest/enrollmentHistory?${new URLSearchParams(input)}`, {
-                headers: {
-                    ...(process.env.ANTEATER_API_KEY && { Authorization: `Bearer ${process.env.ANTEATER_API_KEY}` }),
-                },
-            })
-                .then((x) => x.json())
-                .then((x) => x.data as EnrollmentHistory)
-                .then((xs) => xs.filter((x) => x.dates.length)) // FIXME remove this shim once this is fixed on the API end
-    ),
+    get: procedure
+        .input(z.object({ department: z.string(), courseNumber: z.string(), sectionType: z.string() }))
+        .query(async ({ input }) => {
+            const result = await fetchAnteaterAPIData<EnrollmentHistoryAPIResult>(
+                `https://anteaterapi.com/v2/rest/enrollmentHistory?${new URLSearchParams(input)}`
+            );
+            return result.data.filter((x) => x.dates.length); // FIXME remove this shim once this is fixed on the API end
+        }),
 });
 
 export default enrollHistRouter;

--- a/apps/antalmanac/src/backend/routers/enrollHist.ts
+++ b/apps/antalmanac/src/backend/routers/enrollHist.ts
@@ -3,13 +3,13 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
 const enrollHistRouter = router({
     get: procedure
         .input(z.object({ department: z.string(), courseNumber: z.string(), sectionType: z.string() }))
         .query(async ({ input }) => {
-            const result = await fetchAnteaterAPIData<EnrollmentHistoryAPIResult>(
+            const result = await fetchAnteaterAPI<EnrollmentHistoryAPIResult>(
                 `https://anteaterapi.com/v2/rest/enrollmentHistory?${new URLSearchParams(input)}`
             );
             return result.data.filter((x) => x.dates.length); // FIXME remove this shim once this is fixed on the API end

--- a/apps/antalmanac/src/backend/routers/enrollHist.ts
+++ b/apps/antalmanac/src/backend/routers/enrollHist.ts
@@ -10,7 +10,8 @@ const enrollHistRouter = router({
         .input(z.object({ department: z.string(), courseNumber: z.string(), sectionType: z.string() }))
         .query(async ({ input }) => {
             const result = await fetchAnteaterAPI<EnrollmentHistoryAPIResult>(
-                `https://anteaterapi.com/v2/rest/enrollmentHistory?${new URLSearchParams(input)}`
+                `https://anteaterapi.com/v2/rest/enrollmentHistory?${new URLSearchParams(input)}`,
+                { errorType: 'trpc' }
             );
             return result.data.filter((x) => x.dates.length); // FIXME remove this shim once this is fixed on the API end
         }),

--- a/apps/antalmanac/src/backend/routers/grades.ts
+++ b/apps/antalmanac/src/backend/routers/grades.ts
@@ -1,7 +1,9 @@
-import type { AggregateGrades, AggregateGradesByOffering } from '@packages/antalmanac-types';
+import type { AggregateGradesAPIResult, AggregateGradesByOfferingAPIResult } from '@packages/antalmanac-types';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
+
+import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
 
 const gradesRouter = router({
     aggregateGrades: procedure
@@ -13,18 +15,12 @@ const gradesRouter = router({
                 ge: z.string().optional(),
             })
         )
-        .query(
-            async ({ input }) =>
-                await fetch(`https://anteaterapi.com/v2/rest/grades/aggregate?${new URLSearchParams(input)}`, {
-                    headers: {
-                        ...(process.env.ANTEATER_API_KEY && {
-                            Authorization: `Bearer ${process.env.ANTEATER_API_KEY}`,
-                        }),
-                    },
-                })
-                    .then((x) => x.json())
-                    .then((x) => x.data as AggregateGrades)
-        ),
+        .query(async ({ input }) => {
+            const result = await fetchAnteaterAPIData<AggregateGradesAPIResult>(
+                `https://anteaterapi.com/v2/rest/grades/aggregate?${new URLSearchParams(input)}`
+            );
+            return result.data;
+        }),
     // This is a "mutation" because we don't want tRPC to batch it with the query for WebSoc data.
     aggregateByOffering: procedure
         .input(
@@ -40,23 +36,14 @@ const gradesRouter = router({
                     return ge === undefined ? { department: dept, ...rest } : { department: dept, ge, ...rest };
                 })
         )
-        .mutation(
-            async ({ input }) =>
-                await fetch(
-                    `https://anteaterapi.com/v2/rest/grades/aggregateByOffering?${new URLSearchParams(
-                        input as Record<string, string>
-                    )}`,
-                    {
-                        headers: {
-                            ...(process.env.ANTEATER_API_KEY && {
-                                Authorization: `Bearer ${process.env.ANTEATER_API_KEY}`,
-                            }),
-                        },
-                    }
-                )
-                    .then((x) => x.json())
-                    .then((x) => x.data as AggregateGradesByOffering)
-        ),
+        .mutation(async ({ input }) => {
+            const result = await fetchAnteaterAPIData<AggregateGradesByOfferingAPIResult>(
+                `https://anteaterapi.com/v2/rest/grades/aggregateByOffering?${new URLSearchParams(
+                    input as Record<string, string>
+                )}`
+            );
+            return result.data;
+        }),
 });
 
 export default gradesRouter;

--- a/apps/antalmanac/src/backend/routers/grades.ts
+++ b/apps/antalmanac/src/backend/routers/grades.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
 const gradesRouter = router({
     aggregateGrades: procedure
@@ -16,7 +16,7 @@ const gradesRouter = router({
             })
         )
         .query(async ({ input }) => {
-            const result = await fetchAnteaterAPIData<AggregateGradesAPIResult>(
+            const result = await fetchAnteaterAPI<AggregateGradesAPIResult>(
                 `https://anteaterapi.com/v2/rest/grades/aggregate?${new URLSearchParams(input)}`
             );
             return result.data;
@@ -37,7 +37,7 @@ const gradesRouter = router({
                 })
         )
         .mutation(async ({ input }) => {
-            const result = await fetchAnteaterAPIData<AggregateGradesByOfferingAPIResult>(
+            const result = await fetchAnteaterAPI<AggregateGradesByOfferingAPIResult>(
                 `https://anteaterapi.com/v2/rest/grades/aggregateByOffering?${new URLSearchParams(
                     input as Record<string, string>
                 )}`

--- a/apps/antalmanac/src/backend/routers/grades.ts
+++ b/apps/antalmanac/src/backend/routers/grades.ts
@@ -17,7 +17,8 @@ const gradesRouter = router({
         )
         .query(async ({ input }) => {
             const result = await fetchAnteaterAPI<AggregateGradesAPIResult>(
-                `https://anteaterapi.com/v2/rest/grades/aggregate?${new URLSearchParams(input)}`
+                `https://anteaterapi.com/v2/rest/grades/aggregate?${new URLSearchParams(input)}`,
+                { errorType: 'trpc' }
             );
             return result.data;
         }),
@@ -40,7 +41,8 @@ const gradesRouter = router({
             const result = await fetchAnteaterAPI<AggregateGradesByOfferingAPIResult>(
                 `https://anteaterapi.com/v2/rest/grades/aggregateByOffering?${new URLSearchParams(
                     input as Record<string, string>
-                )}`
+                )}`,
+                { errorType: 'trpc' }
             );
             return result.data;
         }),

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
+import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
 
 const DEPARTMENT_YEAR_RANGE = 10;
 
@@ -76,17 +76,7 @@ const queryWebSoc = async ({ input }: { input: Record<string, string> }) => {
     const url = `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams(sanitizeSearchParams(input))}`;
     console.log('queryWebSoc', url);
 
-    const response = await fetchAnteaterAPI(url);
-
-    let data: WebsocAPIResult;
-    try {
-        data = await response.json();
-    } catch (err) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to parse Anteater API response: ${err}`,
-        });
-    }
+    const data = await fetchAnteaterAPIData<WebsocAPIResult>(url);
     console.log('queryWebSoc', data);
 
     if (!data?.ok || !data?.data) {
@@ -102,17 +92,7 @@ const queryWebSocDepartments = async () => {
     const minYear = new Date().getFullYear() - DEPARTMENT_YEAR_RANGE;
     const url = `https://anteaterapi.com/v2/rest/websoc/departments?since=${minYear}`;
 
-    const response = await fetchAnteaterAPI(url);
-
-    let data: WebsocDepartmentsAPIResult;
-    try {
-        data = await response.json();
-    } catch (err) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to parse Anteater API response: ${err}`,
-        });
-    }
+    const data = await fetchAnteaterAPIData<WebsocDepartmentsAPIResult>(url);
 
     if (!data?.ok || !data?.data) {
         throw new TRPCError({

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -79,7 +79,7 @@ const queryWebSoc = async ({ input }: { input: Record<string, string> }) => {
     const data = await fetchAnteaterAPI<WebsocAPIResult>(url);
     console.log('queryWebSoc', data);
 
-    if (!data?.ok || !data?.data) {
+    if (!data?.data) {
         throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Anteater API returned an unexpected response shape',
@@ -94,7 +94,7 @@ const queryWebSocDepartments = async () => {
 
     const data = await fetchAnteaterAPI<WebsocDepartmentsAPIResult>(url);
 
-    if (!data?.ok || !data?.data) {
+    if (!data?.data) {
         throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Departments API returned no data',

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -76,7 +76,7 @@ const queryWebSoc = async ({ input }: { input: Record<string, string> }) => {
     const url = `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams(sanitizeSearchParams(input))}`;
     console.log('queryWebSoc', url);
 
-    const data = await fetchAnteaterAPI<WebsocAPIResult>(url);
+    const data = await fetchAnteaterAPI<WebsocAPIResult>(url, { errorType: 'trpc' });
     console.log('queryWebSoc', data);
 
     if (!data?.data) {
@@ -92,7 +92,7 @@ const queryWebSocDepartments = async () => {
     const minYear = new Date().getFullYear() - DEPARTMENT_YEAR_RANGE;
     const url = `https://anteaterapi.com/v2/rest/websoc/departments?since=${minYear}`;
 
-    const data = await fetchAnteaterAPI<WebsocDepartmentsAPIResult>(url);
+    const data = await fetchAnteaterAPI<WebsocDepartmentsAPIResult>(url, { errorType: 'trpc' });
 
     if (!data?.data) {
         throw new TRPCError({

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
+
 const DEPARTMENT_YEAR_RANGE = 10;
 
 function sanitizeSearchParams(params: Record<string, string>) {
@@ -66,30 +68,6 @@ function sortWebsocResponse(response: WebsocAPIResponse) {
                 );
             }
         }
-    }
-    return response;
-}
-
-async function fetchAnteaterAPI(url: string): Promise<Response> {
-    let response: Response;
-    try {
-        response = await fetch(url, {
-            headers: {
-                ...(process.env.ANTEATER_API_KEY && { Authorization: `Bearer ${process.env.ANTEATER_API_KEY}` }),
-            },
-        });
-    } catch (err) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to reach the Anteater API: ${err}`,
-        });
-    }
-
-    if (!response.ok) {
-        throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Anteater API returned an error: ${response.status} ${response.statusText}`,
-        });
     }
     return response;
 }

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-import { fetchAnteaterAPIData } from '$src/backend/lib/helpers';
+import { fetchAnteaterAPI } from '$src/backend/lib/helpers';
 
 const DEPARTMENT_YEAR_RANGE = 10;
 
@@ -76,7 +76,7 @@ const queryWebSoc = async ({ input }: { input: Record<string, string> }) => {
     const url = `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams(sanitizeSearchParams(input))}`;
     console.log('queryWebSoc', url);
 
-    const data = await fetchAnteaterAPIData<WebsocAPIResult>(url);
+    const data = await fetchAnteaterAPI<WebsocAPIResult>(url);
     console.log('queryWebSoc', data);
 
     if (!data?.ok || !data?.data) {
@@ -92,7 +92,7 @@ const queryWebSocDepartments = async () => {
     const minYear = new Date().getFullYear() - DEPARTMENT_YEAR_RANGE;
     const url = `https://anteaterapi.com/v2/rest/websoc/departments?since=${minYear}`;
 
-    const data = await fetchAnteaterAPIData<WebsocDepartmentsAPIResult>(url);
+    const data = await fetchAnteaterAPI<WebsocDepartmentsAPIResult>(url);
 
     if (!data?.ok || !data?.data) {
         throw new TRPCError({

--- a/packages/anteater-api-types/src/calendar.ts
+++ b/packages/anteater-api-types/src/calendar.ts
@@ -1,3 +1,6 @@
 import { paths } from './generated/anteater-api-types';
 
+export type CalendarAllAPIResult =
+    paths['/v2/rest/calendar/all']['get']['responses'][200]['content']['application/json'];
+
 export type CalendarTerm = paths['/v2/rest/calendar']['get']['responses'][200]['content']['application/json']['data'];

--- a/packages/anteater-api-types/src/courses.ts
+++ b/packages/anteater-api-types/src/courses.ts
@@ -1,6 +1,9 @@
 import { components, paths } from './generated/anteater-api-types';
 
-export type Course = paths['/v2/rest/courses/{id}']['get']['responses'][200]['content']['application/json']['data'];
+export type CourseByIdAPIResult =
+    paths['/v2/rest/courses/{id}']['get']['responses'][200]['content']['application/json'];
+
+export type Course = CourseByIdAPIResult['data'];
 
 export type Prerequisite = components['schemas']['prereq'];
 

--- a/packages/anteater-api-types/src/courses.ts
+++ b/packages/anteater-api-types/src/courses.ts
@@ -5,6 +5,9 @@ export type CourseByIdAPIResult =
 
 export type Course = CourseByIdAPIResult['data'];
 
+export type CoursesFilteredAPIResult =
+    paths['/v2/rest/courses']['get']['responses'][200]['content']['application/json'];
+
 export type Prerequisite = components['schemas']['prereq'];
 
 export type PrerequisiteTree = components['schemas']['prereqTree'];

--- a/packages/anteater-api-types/src/enrollHist.ts
+++ b/packages/anteater-api-types/src/enrollHist.ts
@@ -1,4 +1,6 @@
 import { paths } from './generated/anteater-api-types';
 
-export type EnrollmentHistory =
-    paths['/v2/rest/enrollmentHistory']['get']['responses'][200]['content']['application/json']['data'];
+export type EnrollmentHistoryAPIResult =
+    paths['/v2/rest/enrollmentHistory']['get']['responses'][200]['content']['application/json'];
+
+export type EnrollmentHistory = EnrollmentHistoryAPIResult['data'];

--- a/packages/anteater-api-types/src/grades.ts
+++ b/packages/anteater-api-types/src/grades.ts
@@ -2,8 +2,12 @@ import { paths } from './generated/anteater-api-types';
 
 export type GE = NonNullable<NonNullable<paths['/v2/rest/grades/raw']['get']['parameters']['query']>['ge']>;
 
-export type AggregateGrades =
-    paths['/v2/rest/grades/aggregate']['get']['responses']['200']['content']['application/json']['data'];
+export type AggregateGradesAPIResult =
+    paths['/v2/rest/grades/aggregate']['get']['responses']['200']['content']['application/json'];
 
-export type AggregateGradesByOffering =
-    paths['/v2/rest/grades/aggregateByOffering']['get']['responses']['200']['content']['application/json']['data'];
+export type AggregateGrades = AggregateGradesAPIResult['data'];
+
+export type AggregateGradesByOfferingAPIResult =
+    paths['/v2/rest/grades/aggregateByOffering']['get']['responses']['200']['content']['application/json'];
+
+export type AggregateGradesByOffering = AggregateGradesByOfferingAPIResult['data'];

--- a/packages/anteater-api-types/src/websoc.ts
+++ b/packages/anteater-api-types/src/websoc.ts
@@ -1,15 +1,13 @@
 import { paths } from './generated/anteater-api-types';
 
-export type WebsocAPIResponse =
-    paths['/v2/rest/websoc']['get']['responses'][200]['content']['application/json']['data'];
-
 export type WebsocAPIResult = paths['/v2/rest/websoc']['get']['responses'][200]['content']['application/json'];
 
-export type WebsocAPIDepartmentsResponse =
-    paths['/v2/rest/websoc/departments']['get']['responses'][200]['content']['application/json']['data'];
+export type WebsocAPIResponse = WebsocAPIResult['data'];
 
 export type WebsocDepartmentsAPIResult =
     paths['/v2/rest/websoc/departments']['get']['responses'][200]['content']['application/json'];
+
+export type WebsocAPIDepartmentsResponse = WebsocDepartmentsAPIResult['data'];
 
 export type WebsocSchool = WebsocAPIResponse['schools'][number];
 
@@ -31,5 +29,7 @@ export type WebsocSectionType = WebsocCourse['sections'][number]['sectionType'];
 
 export type WebsocSectionStatus = WebsocCourse['sections'][number]['status'];
 
-export type WebsocTerm =
-    paths['/v2/rest/websoc/terms']['get']['responses'][200]['content']['application/json']['data'][number];
+export type WebsocTermsAPIResult =
+    paths['/v2/rest/websoc/terms']['get']['responses'][200]['content']['application/json'];
+
+export type WebsocTerm = WebsocTermsAPIResult['data'][number];


### PR DESCRIPTION
## Summary

Wrap all Anteater API calls in `fetchAnteaterAPI` to catch errors.

## Test Plan

1. All AAPI features should work as before
2. Any errors when calling AAPI should be caught and a TRPC error should be thrown

## Issues

Closes #1570

<!-- [Optional]
## Future Followup
-->
