### PR TITLE
FIx mobile notification snackbar blocking navigation bug

### DIFF
--- a/apps/antalmanac/src/App.css
+++ b/apps/antalmanac/src/App.css
@@ -21,10 +21,3 @@
         scrollbar-width: none;
     }
 }
-
-/* Ensure snackbars sit above the mobile navigation tabs */
-@media (max-width: 799px) {
-    .notification-snackbar-container {
-        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 64px) !important;
-    }
-}

--- a/apps/antalmanac/src/components/NotificationSnackbar.tsx
+++ b/apps/antalmanac/src/components/NotificationSnackbar.tsx
@@ -3,10 +3,13 @@
 import { Alert, Snackbar, SnackbarCloseReason } from '@mui/material';
 import { mergeSx } from '@mui/x-date-pickers/internals';
 
+import { useIsMobile } from '$hooks/useIsMobile';
 import { useSnackbarStore } from '$stores/SnackbarStore';
 
 export const NotificationSnackbar = () => {
     const { open, snackbarClosed, message, severity, durationSeconds, position, style } = useSnackbarStore();
+
+    const isMobile = useIsMobile();
 
     const snackbarKey = open ? Date.now() : null;
 
@@ -25,8 +28,14 @@ export const NotificationSnackbar = () => {
             autoHideDuration={durationSeconds * 1000}
             anchorOrigin={position}
             onClose={handleClose}
-            sx={mergeSx((theme) => ({ [theme.breakpoints.up('sm')]: { minWidth: '288px' } }), style)}
-            className="notification-snackbar-container"
+            sx={mergeSx(
+                (theme) => ({
+                    /* Ensure snackbars sit above the mobile navigation tabs */
+                    marginBottom: isMobile ? 'calc(env(safe-area-inset-bottom, 0px) + 64px)' : undefined,
+                    [theme.breakpoints.up('sm')]: { minWidth: '288px' },
+                }),
+                style
+            )}
         >
             <Alert
                 severity={severity}


### PR DESCRIPTION
## Summary

Fixes a bug where the mobile navigation buttons are blocked when a snackbar is active. Also changes the breakpoint at which the snackbar is spaced to be consistent with other mobile breakpoints.

## Test Plan

1. Make a snackbar appear, like reloading the page while logged in, and confirm that the navigation buttons on mobile aren't blocked

## Issues

Closes #1593

<!-- [Optional]
## Future Followup
-->
