### PR TITLE
Prevent entire home page from rerendering when switching between root and tab routes

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -33,13 +33,15 @@ function RouteLayout() {
 
 const OUTAGE = false;
 
+const HOME_PAGE = <Home />;
+
 const BROWSER_ROUTER = createBrowserRouter([
     {
         element: <RouteLayout />,
         children: [
             {
                 path: '/',
-                element: <Home />,
+                element: HOME_PAGE,
                 errorElement: <ErrorPage />,
             },
             {
@@ -49,7 +51,7 @@ const BROWSER_ROUTER = createBrowserRouter([
             },
             {
                 path: '/:tab',
-                element: <Home />,
+                element: HOME_PAGE,
                 errorElement: <ErrorPage />,
             },
             {


### PR DESCRIPTION
## Summary

Share a home component between / and /:tab routes

## Test Plan

1. Make a snackbar appear and confirm that switching between the search and added tabs doesn't make the snackbar reopen/rerender

## Issues

Closes #1595

<!-- [Optional]
## Future Followup
-->
