### PR TITLE
feat: add server-rendered SEO content for search engine indexing

### DIFF
--- a/apps/antalmanac/src/app/[[...slug]]/page.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/page.tsx
@@ -1,9 +1,15 @@
-import { ClientOnly } from './client';
+import { ClientOnly } from '$src/app/[[...slug]]/client';
+import { SeoContent } from '$src/app/[[...slug]]/seo-content';
 
 export function generateStaticParams() {
     return [{ slug: [] }, { slug: ['added'] }, { slug: ['map'] }];
 }
 
 export default function Page() {
-    return <ClientOnly />;
+    return (
+        <>
+            <SeoContent />
+            <ClientOnly />
+        </>
+    );
 }

--- a/apps/antalmanac/src/app/[[...slug]]/seo-content.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/seo-content.tsx
@@ -1,0 +1,70 @@
+/**
+ * Server-rendered content for search engine indexing and screen readers.
+ *
+ * This component is visually hidden (sr-only) but present in the initial HTML,
+ * giving crawlers real text content to index and screen readers a page summary.
+ * Without this, the body is empty because the app renders entirely client-side.
+ */
+export function SeoContent() {
+    return (
+        <div className="sr-only" role="complementary" aria-label="About AntAlmanac">
+            <h1>AntAlmanac — Free UCI Schedule Planner</h1>
+
+            <p>
+                AntAlmanac is a free schedule planner for UC Irvine students. Search UCI courses by department, course
+                number, or GE category. Build your weekly class schedule, view locations on an interactive campus map,
+                and explore grade distributions and enrollment history.
+            </p>
+
+            <h2>Search UCI Courses</h2>
+            <p>
+                Browse courses across 140+ UCI departments including Computer Science, Informatics, Engineering,
+                Biological Sciences, Mathematics, Economics, Psychology, Political Science, and more. Filter by General
+                Education category — from Lower Division Writing to Multicultural Studies — or search by course number,
+                title, or instructor.
+            </p>
+
+            <h2>Schedule Builder</h2>
+            <p>
+                Add UCI courses to a weekly calendar. AntAlmanac detects time conflicts, tracks your unit count, and
+                lets you save multiple schedule variations to compare before enrolling.
+            </p>
+
+            <h2>Interactive Campus Map</h2>
+            <p>
+                See where your classes meet on a map of UCI. Get walking directions between buildings and plan your
+                route between back-to-back classes.
+            </p>
+
+            <h2>Grade Distributions</h2>
+            <p>
+                View historical grade distributions for UCI courses and instructors. See past enrollment data to help
+                decide which sections to take.
+            </p>
+
+            <nav aria-label="AntAlmanac sections">
+                <ul>
+                    <li>
+                        <a href="/">Course Search</a>
+                    </li>
+                    <li>
+                        <a href="/added">My Schedule</a>
+                    </li>
+                    <li>
+                        <a href="/map">Campus Map</a>
+                    </li>
+                    <li>
+                        <a href="/feedback">Feedback</a>
+                    </li>
+                </ul>
+            </nav>
+
+            <footer>
+                <p>
+                    AntAlmanac is a free, open-source project by{' '}
+                    <a href="https://github.com/icssc">ICS Student Council</a> at the University of California, Irvine.
+                </p>
+            </footer>
+        </div>
+    );
+}

--- a/apps/antalmanac/src/app/globals.css
+++ b/apps/antalmanac/src/app/globals.css
@@ -5,3 +5,15 @@ html {
 body {
     overflow: hidden;
 }
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}

--- a/apps/antalmanac/src/app/robots.ts
+++ b/apps/antalmanac/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: { userAgent: '*', allow: '/' },
+        sitemap: 'https://antalmanac.com/sitemap.xml',
+    };
+}

--- a/apps/antalmanac/src/app/sitemap.ts
+++ b/apps/antalmanac/src/app/sitemap.ts
@@ -1,0 +1,5 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return [{ url: 'https://antalmanac.com', lastModified: new Date(), changeFrequency: 'weekly', priority: 1.0 }];
+}


### PR DESCRIPTION
## Problem

Right now, Googlebot sees an essentially **empty `<body>`** when it crawls antalmanac.com:

```html
<div hidden=""><!--$--><!--/$--></div>
<noscript>You need to enable JavaScript to run this app.</noscript>
<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"></template>
```

The `<head>` metadata (title, description, OG tags) is fine, but Google ranks pages based on **body content**, not just metadata. This is a major reason we underperform competitors like ZotCourse in search results despite having a better domain — ZotCourse serves ~200 lines of keyword-rich, server-rendered HTML (department names, headings, instructions) that Google can immediately index.

Additionally, `/robots.txt` and `/sitemap.xml` were caught by the `[[...slug]]` catch-all route and returned the app shell instead of valid responses.

## Solution

**Server-rendered SEO content** — Add a `<SeoContent />` Server Component to the page that provides real, indexable HTML in the initial response. The content is visually hidden using the standard `sr-only` accessibility pattern (same as Tailwind/Bootstrap) so it does not affect the UI, but it gives crawlers and screen readers actual text to work with:

- **`<h1>`** with "UCI Schedule Planner" (Google heavily weights heading tags)
- **Keyword-rich paragraphs** describing features: course search, schedule builder, campus map, grade distributions
- **Department and GE category mentions** woven into natural prose
- **Internal `<nav>` links** to `/added`, `/map`, `/feedback` (Google can now discover these routes without executing JS)
- **Footer** with ICSSC attribution and link

**`robots.txt` and `sitemap.xml`** — Add Next.js metadata file conventions so these URLs return proper responses instead of the app shell.

## Changes

- **`seo-content.tsx`** (new): Server Component with sr-only content for crawlers and screen readers
- **`robots.ts`** (new): Generates `/robots.txt` allowing all crawlers, pointing to sitemap
- **`sitemap.ts`** (new): Generates `/sitemap.xml` listing the homepage
- **`page.tsx`**: Renders `<SeoContent />` above `<ClientOnly />`; switched to absolute imports
- **`globals.css`**: Added `.sr-only` utility class