### PR TITLE
Bump mobile padding to 1 on action cell buttons

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/AddButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/AddButton.tsx
@@ -4,6 +4,7 @@ import { AASection, CourseDetails } from '@packages/antalmanac-types';
 import { useCallback } from 'react';
 
 import { addCourse } from '$actions/AppStoreActions';
+import { useIsMobile } from '$hooks/useIsMobile';
 import { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { openSnackbar } from '$stores/SnackbarStore';
@@ -16,6 +17,8 @@ interface AddButtonProps {
 }
 
 export function AddButton({ section, courseDetails, term, scheduleConflict }: AddButtonProps) {
+    const isMobile = useIsMobile();
+
     const handleClick = useCallback(() => {
         for (const meeting of section.meetings) {
             if (meeting.timeIsTBA) {
@@ -27,7 +30,7 @@ export function AddButton({ section, courseDetails, term, scheduleConflict }: Ad
     }, [section, courseDetails, term]);
 
     const button = (
-        <IconButton onClick={handleClick} size="small" sx={{ p: 0.5 }}>
+        <IconButton onClick={handleClick} size="small" sx={{ p: isMobile ? 1 : 0.5 }}>
             <Add fontSize="small" />
         </IconButton>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteButton.tsx
@@ -5,6 +5,7 @@ import { usePostHog } from 'posthog-js/react';
 import { memo, useCallback } from 'react';
 
 import { deleteCourse } from '$actions/AppStoreActions';
+import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
@@ -15,6 +16,7 @@ interface DeleteButtonProps {
 }
 
 export const DeleteButton = memo(function DeleteButton({ sectionCode, term }: DeleteButtonProps) {
+    const isMobile = useIsMobile();
     const postHog = usePostHog();
 
     const handleClick = useCallback(() => {
@@ -27,7 +29,7 @@ export const DeleteButton = memo(function DeleteButton({ sectionCode, term }: De
     }, [postHog, term, sectionCode]);
 
     return (
-        <IconButton onClick={handleClick} size="small" sx={{ p: 0.5 }}>
+        <IconButton onClick={handleClick} size="small" sx={{ p: isMobile ? 1 : 0.5 }}>
             <Delete fontSize="small" />
         </IconButton>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 import { NotificationEmailTooltip } from '$components/RightPane/AddedCourses/Notifications/NotificationEmailTooltip';
 import { SignInDialog } from '$components/dialogs/SignInDialog';
+import { useIsMobile } from '$hooks/useIsMobile';
 import { canTermEnrollmentChange, Term } from '$lib/termData';
 import { type NotifyOn, useNotificationStore } from '$stores/NotificationStore';
 import { useSessionStore } from '$stores/SessionStore';
@@ -28,6 +29,7 @@ interface NotificationsMenuProps {
 
 export const NotificationsMenu = memo(
     ({ section, term, courseTitle, deptCode, courseNumber }: NotificationsMenuProps) => {
+        const isMobile = useIsMobile();
         const notificationKey = section.sectionCode + ' ' + term;
         const [notification, setNotifications] = useNotificationStore(
             useShallow((store) => [store.notifications[notificationKey], store.setNotifications])
@@ -99,7 +101,7 @@ export const NotificationsMenu = memo(
             <>
                 <Tooltip title={tooltipText}>
                     <span>
-                        <IconButton onClick={handleNotificationClick} disabled={!isTermCurrent} sx={{ p: 0.5 }}>
+                        <IconButton onClick={handleNotificationClick} disabled={!isTermCurrent} sx={{ p: isMobile ? 1 : 0.5 }}>
                             {isGoogleUser ? (
                                 hasNotifications ? (
                                     <EditNotifications fontSize="small" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the padding on action cell buttons (Add, Delete, Notifications) from `0.5` to `1` on mobile to make them easier to tap.

Each button now uses `useIsMobile()` to conditionally apply `p: isMobile ? 1 : 0.5`, leaving the desktop padding unchanged.

## Test Plan

Visual check on mobile viewport — action cell buttons should have more breathing room.

## Issues


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7eca09-ff2a-4b91-8321-32e76a648eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7eca09-ff2a-4b91-8321-32e76a648eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

