### PR TITLE
fix: use recommended db settings

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,7 +9,6 @@ const pool = new Pool({
     max: 10,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 5000,
-    allowExitOnIdle: true,
 });
 
 export const db = drizzle(pool, { schema });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,8 +6,10 @@ import * as schema from './schema/index';
 
 const pool = new Pool({
     connectionString: process.env.DB_URL,
-    max: 3,
-    idleTimeoutMillis: 5,
+    max: 10,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 5000,
+    allowExitOnIdle: true,
 });
 
 export const db = drizzle(pool, { schema });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `pg` `Pool` configuration in `packages/db/src/index.ts` to use sensible, documentation-recommended values instead of the current problematic settings.

### What changed

| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `max` | `3` | `10` | Restores the `pg` default. 3 was unnecessarily restrictive for a Next.js app that may serve concurrent requests. 10 is the library author's recommended default for most workloads, including auto-scaling/Lambda environments. |
| `idleTimeoutMillis` | `5` (5 ms) | `10000` (10 s) | 5 ms is aggressively short — it destroys connections almost immediately after release, negating the benefit of pooling. The `pg` default of 10 s lets connections be reused across nearby requests while still cleaning up. |
| `connectionTimeoutMillis` | *not set* (0 = no timeout) | `5000` (5 s) | Without this, a `pool.connect()` call hangs **indefinitely** if the database is unreachable or the pool is exhausted. 5 s provides a reasonable fail-fast boundary. |

### Rationale (from `node-postgres` docs)

- **Pool sizing guide** ([node-postgres.com/guides/pool-sizing](https://node-postgres.com/guides/pool-sizing)): The library author recommends leaving `max` at the default of `10` for most cases, including auto-scaling and Lambda environments.
- **`idleTimeoutMillis`** ([node-postgres.com/apis/pool](https://node-postgres.com/apis/pool)): Default is 10,000 ms. The previous value of `5` ms meant connections were torn down and recreated on virtually every request.
- **`connectionTimeoutMillis`**: Default is `0` (no timeout). Without it, `pool.connect()` hangs forever if the DB is unreachable or connections aren't released. With 5 s, the request fails with a clear timeout error instead.

## Test Plan

- These are the `pg` library's own recommended defaults (except `connectionTimeoutMillis`, which is an opt-in safety net). No behavioral change to queries — only connection lifecycle management.
- Existing integration and unit tests should pass unchanged.

## Issues

N/A

<!-- [Optional]
## Future Followup

- Consider whether the AANTS Lambda should instantiate its own pool (with `max: 1` and per-invocation `pool.end()`) rather than sharing the singleton from `@packages/db`, since Lambda's freeze/thaw cycle can leave stale TCP connections.
- Consider adding `maxLifetimeSeconds` (e.g. 300) to rotate connections through any upstream proxies or load balancers.
-->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-105f9ab9-313f-4aad-8f7b-9ab8ff92f7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-105f9ab9-313f-4aad-8f7b-9ab8ff92f7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

