### PR TITLE
fix: use transaction object (tx) instead of root db client in upsertUserData

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -231,7 +231,7 @@ export class RDS {
     ): Promise<{ userId: string; scheduleIdMap: Record<string, string> }> {
         return db.transaction(async (tx) => {
             const account = await this.registerUserAccount(
-                db,
+                tx,
                 'OIDC',
                 userData.id,
                 userData.name,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`upsertUserData` wraps its operations in `db.transaction(async (tx) => { ... })`, but `registerUserAccount` was being called with the root `db` client instead of the `tx` transaction object. This meant account creation was committed independently of the transaction, breaking atomicity: if a subsequent operation (schedule sync, course upsert, or schedule index update) failed, the transaction would roll back those changes but the account row would already be persisted.

The fix is a single-character change: `db` → `tx` in the `registerUserAccount` call, consistent with all other operations inside the same transaction block.

## Test Plan

- The change is a one-line substitution (`db` → `tx`) in a call that already accepts `DatabaseOrTransaction`.
- `registerUserAccount` signature is `(db: DatabaseOrTransaction, ...)`, so passing `tx` is type-safe.
- All other calls inside the same transaction block already use `tx` (`upsertSchedulesAndContents`, `tx.update`), confirming the intended pattern.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13fd1955-7fe2-4884-9150-8ffba1f7f181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13fd1955-7fe2-4884-9150-8ffba1f7f181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

