### PR TITLE
fix: stabilize QueryClient with useState to prevent recreation every render

### DIFF
--- a/apps/antalmanac/src/providers/Query.tsx
+++ b/apps/antalmanac/src/providers/Query.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 interface Props {
@@ -5,7 +7,7 @@ interface Props {
 }
 
 export default function AppQueryProvider(props: Props) {
-    const queryClient = new QueryClient();
+    const [queryClient] = useState(() => new QueryClient());
 
     return <QueryClientProvider client={queryClient}>{props.children}</QueryClientProvider>;
 }

--- a/apps/antalmanac/src/providers/Query.tsx
+++ b/apps/antalmanac/src/providers/Query.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 
 interface Props {
     children?: React.ReactNode;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`new QueryClient()` was called directly in the `AppQueryProvider` component body (`providers/Query.tsx:8`), which meant a brand-new `QueryClient` — and a brand-new cache — was created on **every render**. This broke:

- Query deduplication (identical queries fired multiple times in parallel)
- `staleTime` / `cacheTime` (cache discarded before it could ever be reused)
- All other cache-dependent React Query behavior

The fix wraps the instantiation in `useState(() => new QueryClient())` so the client is created exactly once per component mount, which is the pattern recommended by TanStack Query's own documentation.

## Test Plan

- Verified the file builds without errors.
- The change is a single-line idiomatic React pattern; no behavioral change other than the cache now persisting correctly across renders.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65d7d992-94ce-45c8-86e5-0613e9d70d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65d7d992-94ce-45c8-86e5-0613e9d70d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

