### PR TITLE
fix: stabilize QueryClient — stop recreating on every render

### DIFF
--- a/apps/antalmanac/src/providers/Query.tsx
+++ b/apps/antalmanac/src/providers/Query.tsx
@@ -1,11 +1,24 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 
 interface Props {
     children?: React.ReactNode;
 }
 
 export default function AppQueryProvider(props: Props) {
-    const queryClient = new QueryClient();
+    const [queryClient] = useState(
+        () =>
+            new QueryClient({
+                defaultOptions: {
+                    queries: {
+                        staleTime: 5 * 60 * 1000,
+                        cacheTime: 10 * 60 * 1000,
+                        refetchOnWindowFocus: false,
+                        retry: 1,
+                    },
+                },
+            })
+    );
 
     return <QueryClientProvider client={queryClient}>{props.children}</QueryClientProvider>;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the critical bug where `new QueryClient()` was called directly in the `AppQueryProvider` component body, causing the **entire React Query cache to be thrown away on every render**. This broke deduplication, stale-time, caching — essentially all of React Query's value.

### The fix

Wrap the `QueryClient` instantiation in `useState(() => ...)` so it's created once and reused across renders:

```tsx
const [queryClient] = useState(
    () =>
        new QueryClient({
            defaultOptions: {
                queries: {
                    staleTime: 5 * 60 * 1000,
                    cacheTime: 10 * 60 * 1000,
                    refetchOnWindowFocus: false,
                    retry: 1,
                },
            },
        })
);
```

Also configures sensible defaults:
- **`staleTime: 5 min`** — matches the existing hand-rolled WebSOC cache TTL
- **`cacheTime: 10 min`** — keeps inactive queries in memory a bit longer than stale
- **`refetchOnWindowFocus: false`** — this app expects explicit user refreshes
- **`retry: 1`** — single retry for transient failures

### Investigation: React Query usage & `queryMultiple` caching

A full codebase audit revealed that **React Query is not actually used for data fetching yet**. The `QueryClientProvider` is mounted in `App.tsx`, but there are zero `useQuery`/`useMutation`/`useInfiniteQuery` calls anywhere. All data fetching goes through:

1. **tRPC vanilla client** (`createTRPCProxyClient`) — not integrated with React Query
2. **Hand-rolled caches** in singleton classes:
   - `WebSOC` (`src/lib/websoc.ts`): 5-minute in-memory TTL cache for `query()`, but **`queryMultiple()` has no caching at all** — it calls `trpc.websoc.getMany.query()` directly every time
   - `Grades` (`src/lib/grades.ts`): manual `gradesCache` + `cachedQueries` Set
   - `DepartmentEnrollmentHistory` (`src/lib/enrollmentHistory.ts`): static `enrollmentHistoryCache` object

### Recommendations for follow-up work

The current architecture has hand-rolled caching that duplicates what React Query provides. Here's what idiomatic React Query adoption would look like:

1. **Migrate tRPC to `@trpc/react-query`** — this integrates tRPC with React Query natively, giving you `trpc.websoc.getOne.useQuery(...)` hooks with automatic caching, deduplication, and loading/error states. This is the single highest-impact change.

2. **Replace the `WebSOC` singleton cache** — the hand-rolled 5-min TTL cache becomes redundant once React Query's `staleTime` handles it. The `queryMultiple` no-caching bug goes away for free.

3. **Replace the `Grades` singleton cache** — `populateGradesCache` / `queryGrades` can become `useQuery` calls with appropriate query keys like `['grades', { department, ge }]`.

4. **Replace `DepartmentEnrollmentHistory` cache** — `enrollmentHistoryCache` becomes `useQuery(['enrollmentHistory', department, courseNumber])`.

5. **Convert imperative fetching patterns to declarative hooks** — Components like `CourseRenderPane` and `GEDataFetchProvider` currently use `useEffect` + `useState` for data fetching, which is exactly what `useQuery` replaces with better loading states, error handling, and cache management.

6. **Add `@tanstack/react-query-devtools`** — invaluable for debugging cache behavior during development.

## Test Plan

- Verified lint passes (`eslint src/providers/Query.tsx --max-warnings=0`)
- Verified no new type errors in `Query.tsx` (`tsc --noEmit`)
- The change is minimal and mechanical: `new QueryClient()` → `useState(() => new QueryClient({...}))`

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48dd6d36-3ed0-40c6-a123-fd76eee578c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48dd6d36-3ed0-40c6-a123-fd76eee578c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

