### PR TITLE
refactor: replace moment with date-fns for calendar localizer

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -56,7 +56,7 @@
         "leaflet": "^1.9.3",
         "leaflet-routing-machine": "^3.2.12",
         "leaflet.locatecontrol": "^0.79.0",
-        "moment": "^2.29.4",
+
         "next": "16.0.10",
         "next-pwa": "^5.6.0",
         "pg": "^8.16.3",

--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -56,7 +56,6 @@
         "leaflet": "^1.9.3",
         "leaflet-routing-machine": "^3.2.12",
         "leaflet.locatecontrol": "^0.79.0",
-
         "next": "16.0.10",
         "next-pwa": "^5.6.0",
         "pg": "^8.16.3",

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -23,35 +23,26 @@ import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
 import { CalendarMonth } from '@mui/icons-material';
 import { Box, Backdrop, useTheme } from '@mui/material';
-import moment from 'moment';
+import { format, getDay, startOfWeek, type Locale } from 'date-fns';
+import { enUS } from 'date-fns/locale';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Calendar, Components, DateLocalizer, momentLocalizer, Views, ViewsProps } from 'react-big-calendar';
+import { Calendar, Components, DateLocalizer, dateFnsLocalizer, Views, ViewsProps } from 'react-big-calendar';
 import { useShallow } from 'zustand/react/shallow';
 
 /*
-//  * Always start week on Saturday for finals potentially on weekends.
-//  * CALENDAR_VIEWS will set the correct day range
  * Start week on Sunday so Saturday appears after Friday.
  * This ensures the standard week layout: Su, M, Tu, W, Th, F, Sa
  * Normal schedules: Su ... Sa (Sa rightmost)
+ *
+ * Finals locale: week starts Saturday (Sa ... Fr)
  */
-// eslint-disable-next-line import/no-named-as-default-member
-moment.defineLocale('en-us', {
-    parentLocale: 'en',
-    week: {
-        dow: 0, // Sunday = 0, Monday = 1, ..., Saturday = 6
-    },
-});
+const enUSSunday: Locale = { ...enUS, options: { ...enUS.options, weekStartsOn: 0 } };
+const enUSFinals: Locale = { ...enUS, options: { ...enUS.options, weekStartsOn: 6 } };
 
-// Finals locale: week starts Saturday (Sa ... Fr)
-// eslint-disable-next-line import/no-named-as-default-member
-moment.defineLocale('en-us-finals', {
-    parentLocale: 'en-us',
-    week: { dow: 6 },
-});
-
-// eslint-disable-next-line import/no-named-as-default-member
-moment.locale('en-us');
+const locales: Record<string, Locale> = {
+    'en-us': enUSSunday,
+    'en-us-finals': enUSFinals,
+};
 const CALENDAR_VIEWS: ViewsProps<CalendarEvent, object> = [Views.WEEK, Views.WORK_WEEK];
 const CALENDAR_COMPONENTS: Components<CalendarEvent, object> = {
     event: CalendarCourseEvent,
@@ -257,8 +248,8 @@ export const ScheduleCalendar = memo(() => {
     );
 
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
-    const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
-    const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h A';
+    const calendarTimeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm a';
+    const calendarGutterTimeFormat = isMilitaryTime ? 'HH:mm' : 'h a';
 
     const finalsDate = hoveredCalendarizedFinal
         ? getFinalsStartDateForTerm(hoveredCalendarizedFinal.term)
@@ -270,11 +261,7 @@ export const ScheduleCalendar = memo(() => {
 
     const culture = finalsStartsOnSaturday ? 'en-us-finals' : 'en-us';
 
-    const calendarLocalizer = useMemo(() => {
-        // eslint-disable-next-line import/no-named-as-default-member
-        moment.locale(culture);
-        return momentLocalizer(moment);
-    }, [culture]);
+    const calendarLocalizer = useMemo(() => dateFnsLocalizer({ format, getDay, startOfWeek, locales }), []);
 
     // Check if there are any finals on weekends (else only display M-F)
     const hasWeekendFinals =
@@ -286,14 +273,14 @@ export const ScheduleCalendar = memo(() => {
     const shouldShowWeekView = showFinalsSchedule ? hasWeekendFinals : hasWeekendCourse;
     const calendarView = shouldShowWeekView ? Views.WEEK : Views.WORK_WEEK;
 
-    const finalsDateFormat = isMobile ? 'M/DD' : 'ddd M/DD';
+    const finalsDateFormat = isMobile ? 'M/dd' : 'eee M/dd';
     const date = showFinalsSchedule ? finalsDate : new Date(2018, 0, 1);
 
     const formats = useMemo(
         () => ({
             timeGutterFormat: (date: Date, culture?: string, localizer?: DateLocalizer) =>
                 date.getMinutes() > 0 || !localizer ? '' : localizer.format(date, calendarGutterTimeFormat, culture),
-            dayFormat: showFinalsSchedule ? finalsDateFormat : 'ddd',
+            dayFormat: showFinalsSchedule ? finalsDateFormat : 'eee',
             eventTimeRangeFormat: (range: { start: Date; end: Date }, culture?: string, localizer?: DateLocalizer) =>
                 localizer
                     ? `${localizer.format(range.start, calendarTimeFormat, culture)} - ${localizer.format(

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -1,7 +1,7 @@
 import { Delete } from '@mui/icons-material';
 import { Box, Card, CardActions, CardHeader, IconButton, Tooltip } from '@mui/material';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import moment from 'moment';
+import { format, set } from 'date-fns';
 import { useEffect, useState } from 'react';
 
 import { deleteCustomEvent } from '$actions/AppStoreActions';
@@ -37,12 +37,13 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
     }, []);
 
     const readableDateAndTimeFormat = (start: string, end: string, days: boolean[]) => {
-        const startTime = moment({
+        const baseDate = new Date(2000, 0, 1);
+        const startTime = set(baseDate, {
             hours: parseInt(start.slice(0, 2)),
             minutes: parseInt(start.slice(3, 5)),
         });
 
-        const endTime = moment({
+        const endTime = set(baseDate, {
             hours: parseInt(end.slice(0, 2)),
             minutes: parseInt(end.slice(3, 5)),
         });
@@ -50,9 +51,9 @@ const CustomEventDetailView = (props: CustomEventDetailViewProps) => {
         const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         const daysString = days.map((includeDate, index) => (includeDate ? dayAbbreviations[index] : '')).join(' ');
 
-        const timeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm A';
+        const timeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm a';
 
-        return `${startTime.format(timeFormat)} — ${endTime.format(timeFormat)} • ${daysString}`;
+        return `${format(startTime, timeFormat)} — ${format(endTime, timeFormat)} • ${daysString}`;
     };
 
     return (

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -1,4 +1,4 @@
-import { addWeeks, differenceInWeeks, isAfter, setDay } from 'date-fns';
+import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { terms } from '$generated/termData';
@@ -120,7 +120,7 @@ function isTermEnrollmentOpen(term: Term): boolean {
     }
 
     const dropDeadline = setDay(addWeeks(term.startDate, weeksUntilDropDeadline), 5);
-    return !isAfter(new Date(), dropDeadline);
+    return new Date() <= dropDeadline;
 }
 
 export { defaultTerm, getDefaultTerm, termData, getDefaultFinalsStartDate, getFinalsStartDateForTerm, getCurrentTerm };

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -1,4 +1,4 @@
-import { addWeeks, differenceInWeeks, isBefore, setDay } from 'date-fns';
+import { addWeeks, differenceInWeeks, isAfter, setDay } from 'date-fns';
 
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { terms } from '$generated/termData';
@@ -120,7 +120,7 @@ function isTermEnrollmentOpen(term: Term): boolean {
     }
 
     const dropDeadline = setDay(addWeeks(term.startDate, weeksUntilDropDeadline), 5);
-    return isBefore(new Date(), dropDeadline);
+    return !isAfter(new Date(), dropDeadline);
 }
 
 export { defaultTerm, getDefaultTerm, termData, getDefaultFinalsStartDate, getFinalsStartDateForTerm, getCurrentTerm };

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { addWeeks, differenceInWeeks, isBefore, setDay } from 'date-fns';
 
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import { terms } from '$generated/termData';
@@ -108,8 +108,7 @@ function getOpenEnrollmentTerms() {
  * See {@link canTermEnrollmentChange} docs.
  */
 function isTermEnrollmentOpen(term: Term): boolean {
-    const instructionStartDate = moment(term.startDate);
-    const isTermShort = moment(term.finalsStartDate).diff(instructionStartDate, 'week') < 9;
+    const isTermShort = differenceInWeeks(term.finalsStartDate, term.startDate) < 9;
     const hasWeekZero = term.startDate.getDay() !== 1;
 
     let weeksUntilDropDeadline = 1;
@@ -120,7 +119,8 @@ function isTermEnrollmentOpen(term: Term): boolean {
         weeksUntilDropDeadline++;
     }
 
-    return moment() <= instructionStartDate.add(weeksUntilDropDeadline, 'week').day(5);
+    const dropDeadline = setDay(addWeeks(term.startDate, weeksUntilDropDeadline), 5);
+    return isBefore(new Date(), dropDeadline);
 }
 
 export { defaultTerm, getDefaultTerm, termData, getDefaultFinalsStartDate, getFinalsStartDateForTerm, getCurrentTerm };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,9 +242,6 @@ importers:
       leaflet.locatecontrol:
         specifier: ^0.79.0
         version: 0.79.0
-      moment:
-        specifier: ^2.29.4
-        version: 2.30.1
       next:
         specifier: 16.0.10
         version: 16.0.10(@babel/core@7.26.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace `moment` (~300kB minified) with `date-fns` (already in the project) across all three files that imported it:

**CalendarRoot.tsx** — the primary change:
- Switch from `momentLocalizer` to `dateFnsLocalizer` from `react-big-calendar`
- Replace `moment.defineLocale()` calls with date-fns `Locale` objects that set `weekStartsOn` (0 for normal schedules, 6 for finals)
- Convert moment format tokens to date-fns equivalents (`'h:mm A'` → `'h:mm a'`, `'ddd'` → `'eee'`, `'M/DD'` → `'M/dd'`)

**termData.ts** — enrollment deadline calculation:
- Replace `moment().diff(..., 'week')` with `differenceInWeeks()`
- Replace `moment().add().day()` chain with `addWeeks()` + `setDay()`
- Replace `moment() <=` with native `new Date() <=` to preserve the original inclusive semantics

**CustomEventDetailView.tsx** — time display formatting:
- Replace `moment({ hours, minutes }).format()` with `set()` + `format()` from date-fns

**package.json** — remove `moment` from dependencies.

## Test Plan

- Verified TypeScript compilation produces no new errors (all errors are pre-existing)
- Verified linter produces no new errors or warnings
- Calendar week start behavior preserved: Sunday (dow=0) for normal view, Saturday (dow=6) for finals
- Time format strings produce equivalent output (12h/24h toggle)
- The `culture` prop on `<Calendar>` selects the correct locale from the `locales` map at render time

## Issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2067d2b4-a7e5-44b1-91a0-a00b7d41e253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2067d2b4-a7e5-44b1-91a0-a00b7d41e253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

