### PR TITLE
fix: loading screen text and color

### DIFF
--- a/apps/antalmanac/src/components/LoadingScreen.tsx
+++ b/apps/antalmanac/src/components/LoadingScreen.tsx
@@ -6,7 +6,7 @@ import { Logo } from './Header/Logo';
 import { BLUE } from '$src/globals';
 
 const FUN_FACTS = [
-    'Did you know? Antalmanac is maintained by the ICS Student Council at UCI!',
+    'Did you know? AntAlmanac is maintained by the ICS Student Council at UCI!',
     'AntAlmanac was created in 2018 by a small group of students under the leadership of @the-rango.',
     'Did you know you can search for classes by pressing "CTRL/CMD" + clicking on your schedule item!',
     'Need a 4 year plan? Check out AntAlmanac Planner!',
@@ -47,7 +47,15 @@ export function LoadingScreen(props: LoadingScreenProps) {
                         flexDirection="column"
                         alignItems="center"
                     >
-                        <LinearProgress sx={{ width: { default: '100%', md: '50%' } }} />
+                        <LinearProgress
+                            sx={{
+                                width: { default: '100%', md: '50%' },
+                                backgroundColor: 'rgba(255, 255, 255, 0.3)',
+                                '& .MuiLinearProgress-bar': {
+                                    backgroundColor: 'white',
+                                },
+                            }}
+                        />
                         <Box fontStyle="italic" color="white" fontSize="h6.fontSize" sx={{ textAlign: 'center' }}>
                             {randomFact}
                         </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two fixes to the loading screen (`LoadingScreen.tsx`):

1. **Fixed "AntAlmanac" capitalization** in the first fun fact blurb — was "Antalmanac" (lowercase 'a' in almanac), now correctly "AntAlmanac".
2. **Made the loading progress bar visible** — the `LinearProgress` bar was using the default primary color (`#305db7`), which is the same as the dialog background color (`BLUE`), making the bar invisible. Changed the bar to white with a semi-transparent white track so it stands out against the blue background.

## Test Plan

- Open the app and observe the loading screen
- Verify the progress bar is now visible (white bar on blue background)
- Verify the blurb text cycles correctly and "AntAlmanac" is properly capitalized in all instances

## Issues


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c95112-96da-4621-a77c-3710c0d70c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c95112-96da-4621-a77c-3710c0d70c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

