### PR TITLE
fix: double encode & in trpc query urls for cloudfront compatibility

### DIFF
--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -8,7 +8,10 @@ const trpc = createTRPCProxyClient<AppRouter>({
         httpBatchLink({
             url: '/api/trpc',
             fetch(url, options) {
-                return fetch(url, {
+                // Double-encode %26 so CloudFront's URL decoding produces
+                // the correct %26 for the origin server instead of a bare &.
+                const fixedUrl = typeof url === 'string' ? url.replaceAll('%26', '%2526') : url;
+                return fetch(fixedUrl, {
                     ...options,
                     credentials: 'include', // Send cookies with requests
                 });

--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -9,7 +9,7 @@ const trpc = createTRPCProxyClient<AppRouter>({
             url: '/api/trpc',
             fetch(url, options) {
                 // Double-encode %26 so CloudFront's URL decoding produces
-                // the correct %26 for the origin server instead of a bare &.
+                // the correct %26 for the origin server instead of a bare &. FIX ME
                 const fixedUrl = typeof url === 'string' ? url.replaceAll('%26', '%2526') : url;
                 return fetch(fixedUrl, {
                     ...options,


### PR DESCRIPTION
## Summary
- CloudFront (a CDN server that sits infront of our nextjs server and receives client requests) decodes `%26` to `&` in query strings before forwarding to the nextjs server, which breaks JSON parsing for department codes containing `&` (e.g. `I&C SCI`). By the time it reaches the server, tRPC will parse the request and see `{"department":"I` instead of `{"department":"I&C SCI` since it read the `&` in the received URL as a query parameter separator.
- Double-encodes `%26` as `%2526` in the tRPC client fetch so that after CloudFront's decode, the origin receives the correct `%26`

## Context
This has been broken since the SST migration introduced CloudFront (Dec 2025). Any search for `I&C SCI` courses (via fuzzy search or manual department dropdown) returns "We ran into an error while looking up class info" because the tRPC input JSON gets truncated at the `&`.

## Test plan
- [ ] Search "ICS" in quick search, click an I&C SCI course → should load sections
- [ ] Search "ICS" in quick search, click the I&C SCI department → should load all courses
- [ ] Search for COMPSCI courses → should still work (regression check)
- [ ] Manual search with I&C SCI department dropdown → should work