### PR TITLE
Fix staging-shared deploying on every /deploy command

### DIFF
--- a/.github/workflows/deploy_staging_shared.yml
+++ b/.github/workflows/deploy_staging_shared.yml
@@ -24,6 +24,10 @@ env:
 
 jobs:
     deploy-staging-shared:
+        if: >-
+            github.event_name == 'push' ||
+            github.event.client_payload.pull_request.head.ref == 'staging-shared' ||
+            github.event.client_payload.pull_request.head.ref == 'scheduler'
         runs-on: ubuntu-latest
         env:
             SST_STAGE: staging-shared


### PR DESCRIPTION
## Summary
- `/deploy` on any PR was triggering a staging-shared deployment because `deploy_staging_shared.yml` had no `if` guard on the `repository_dispatch` trigger
- Added a condition so the job only runs on `push` events or `/deploy` from `staging-shared`/`scheduler` PRs

Made with [Cursor](https://cursor.com)