### PR TITLE
feat: update notification text: "Section is" -> "Section becomes"

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -12,9 +12,9 @@ import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';
 
 const MENU_ITEMS: { status: keyof NotifyOn; label: string }[] = [
-    { status: 'notifyOnOpen', label: 'Section is OPEN' },
-    { status: 'notifyOnWaitlist', label: 'Section is WAITLIST' },
-    { status: 'notifyOnFull', label: 'Section is FULL' },
+    { status: 'notifyOnOpen', label: 'Section becomes OPEN' },
+    { status: 'notifyOnWaitlist', label: 'Section becomes WAITLIST' },
+    { status: 'notifyOnFull', label: 'Section becomes FULL' },
     { status: 'notifyOnRestriction', label: 'Restriction Codes have Changed' },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the notification menu item labels from "Section is OPEN/WAITLIST/FULL" to "Section becomes OPEN/WAITLIST/FULL" for clearer wording.

## Test Plan

Visual change only. Verified the three affected labels in `NotificationsMenu.tsx` now read "Section becomes ..." instead of "Section is ...".

## Issues


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b01d0139-758f-4ec1-af01-f82d45162b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b01d0139-758f-4ec1-af01-f82d45162b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

