### PR TITLE
Fix: App switcher stuck on loading on ctrl + click

### DIFF
--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -59,7 +59,7 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
             appStore.unsavedChanges = false;
         }
 
-        if (!event.ctrlKey) {
+        if (!event.ctrlKey && !event.metaKey) {
             setPlannerLoading(true);
         }
     };

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -1,3 +1,11 @@
+import {
+    SETTINGS_POPOVER_BG,
+    SETTINGS_POPOVER_MENU_HOVER_BG,
+    SETTINGS_POPOVER_MENU_SELECTED_BG,
+} from '$components/Header/headerStyles';
+import { Logo } from '$components/Header/Logo';
+import { BLUE, PLANNER_LINK } from '$src/globals';
+import appStore from '$stores/AppStore';
 import { EventNote, Route, UnfoldMore } from '@mui/icons-material';
 import {
     Button,
@@ -13,15 +21,6 @@ import {
 import { useTheme } from '@mui/material/styles';
 import { useEffect, useState } from 'react';
 import type { MouseEventHandler } from 'react';
-
-import { Logo } from '$components/Header/Logo';
-import {
-    SETTINGS_POPOVER_BG,
-    SETTINGS_POPOVER_MENU_HOVER_BG,
-    SETTINGS_POPOVER_MENU_SELECTED_BG,
-} from '$components/Header/headerStyles';
-import { BLUE, PLANNER_LINK } from '$src/globals';
-import appStore from '$stores/AppStore';
 
 type AppSwitcherProps = {
     isMobile: boolean;
@@ -60,7 +59,9 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
             appStore.unsavedChanges = false;
         }
 
-        setPlannerLoading(true);
+        if (!event.ctrlKey) {
+            setPlannerLoading(true);
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

Fix app switcher being stuck on loading if ctrl + clicked to open in a new tab.

## Test Plan

1. Control click on the planner button and confirm that it doesn't enter loading state

## Issues

Closes #1626

<!-- [Optional]
## Future Followup
-->
