### PR TITLE
fix: multiple auto-save bugs breaking save functionality

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -1,13 +1,12 @@
 import { EventEmitter } from 'events';
 
-import type { CustomEventId, RepeatingCustomEvent, ScheduleCourse } from '@packages/antalmanac-types';
-
 import { autoSaveSchedule } from '$actions/AppStoreActions';
 import trpc from '$lib/api/trpc';
 import { getLocalStorageAutoSave } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
+import type { CustomEventId, RepeatingCustomEvent, ScheduleCourse } from '@packages/antalmanac-types';
 
 export interface UndoRedoAction {
     type: 'undoRedoAction';
@@ -90,6 +89,12 @@ export interface ChangeCourseColorAction {
     newColor: string;
 }
 
+export interface UpdateScheduleNoteAction {
+    type: 'updateScheduleNote';
+    newScheduleNote: string;
+    scheduleIndex: number;
+}
+
 export type ActionType =
     | AddCourseAction
     | DeleteCourseAction
@@ -104,6 +109,7 @@ export type ActionType =
     | CopyScheduleAction
     | ReorderScheduleAction
     | ChangeCourseColorAction
+    | UpdateScheduleNoteAction
     | UndoRedoAction;
 
 class ActionTypesStore extends EventEmitter {
@@ -129,9 +135,12 @@ class ActionTypesStore extends EventEmitter {
 
             if (accounts.providerAccountId) {
                 this.emit('autoSaveStart');
-                await autoSaveSchedule(accounts.providerAccountId, { userInfo: users });
-                AppStore.unsavedChanges = false;
-                this.emit('autoSaveEnd');
+                try {
+                    await autoSaveSchedule(accounts.providerAccountId, { userInfo: users });
+                    AppStore.unsavedChanges = false;
+                } finally {
+                    this.emit('autoSaveEnd');
+                }
             }
         }
     }

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -17,7 +17,6 @@ import type {
     WebsocSection,
 } from '@packages/antalmanac-types';
 import { TRPCClientError } from '@trpc/client';
-import { TRPCError } from '@trpc/server';
 import { PostHog } from 'posthog-js/react';
 export interface CopyScheduleOptions {
     onSuccess: (scheduleName: string) => unknown;
@@ -134,11 +133,11 @@ export const saveSchedule = async (
                 deleteTempSaveData();
                 AppStore.saveSchedule();
             } catch (e) {
-                if (e instanceof TRPCError) {
+                if (e instanceof TRPCClientError) {
                     if (useSessionStore.getState().sessionIsValid) {
                         openSnackbar('error', `Schedule could not be saved`);
                     } else {
-                        openSnackbar('error', `Schedule could not be saved under username "${providerId}`);
+                        openSnackbar('error', `Schedule could not be saved under username "${providerId}"`);
                     }
                 } else {
                     openSnackbar('error', 'Network error or server is down.');
@@ -157,7 +156,7 @@ export async function autoSaveSchedule(providerID: string, options: AutoSaveSche
     });
     if (providerID == null) return;
     providerID = providerID.replace(/\s+/g, '');
-    if (providerID.length < 0) return;
+    if (providerID.length === 0) return;
 
     const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
     try {
@@ -179,8 +178,8 @@ export async function autoSaveSchedule(providerID: string, options: AutoSaveSche
         deleteTempSaveData();
         AppStore.saveSchedule();
     } catch (e) {
-        if (e instanceof TRPCError) {
-            openSnackbar('error', `Schedule could not be auto-saved under username "${providerID}`);
+        if (e instanceof TRPCClientError) {
+            openSnackbar('error', `Schedule could not be auto-saved under username "${providerID}"`);
         } else {
             openSnackbar('error', 'Network error or server is down.');
         }

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -1,12 +1,5 @@
 import { EventEmitter } from 'events';
 
-import type {
-    ScheduleCourse,
-    ScheduleSaveState,
-    RepeatingCustomEvent,
-    CustomEventId,
-} from '@packages/antalmanac-types';
-
 import actionTypesStore from '$actions/ActionTypesStore';
 import type {
     AddCourseAction,
@@ -21,13 +14,20 @@ import type {
     DeleteScheduleAction,
     ReorderScheduleAction,
     ChangeCourseColorAction,
+    UpdateScheduleNoteAction,
     UndoRedoAction,
     AddScheduleAction,
 } from '$actions/ActionTypesStore';
 import type { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
+import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
 import { Schedules } from '$stores/Schedules';
 import { useTabStore } from '$stores/TabStore';
-import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
+import type {
+    ScheduleCourse,
+    ScheduleSaveState,
+    RepeatingCustomEvent,
+    CustomEventId,
+} from '@packages/antalmanac-types';
 
 class AppStore extends EventEmitter {
     schedule: Schedules;
@@ -437,6 +437,13 @@ class AppStore extends EventEmitter {
 
     updateScheduleNote(newScheduleNote: string, scheduleIndex: number) {
         this.schedule.updateScheduleNote(newScheduleNote, scheduleIndex);
+        this.unsavedChanges = true;
+        const action: UpdateScheduleNoteAction = {
+            type: 'updateScheduleNote',
+            newScheduleNote: newScheduleNote,
+            scheduleIndex: scheduleIndex,
+        };
+        actionTypesStore.autoSaveSchedule(action);
         this.emit('scheduleNotesChange');
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes multiple bugs in the auto-save pipeline that could cause auto-save to silently fail, show incorrect error messages, or leave the UI in a stuck state.

### Bugs found and fixed:

1. **Dead guard in `autoSaveSchedule`** (`AppStoreActions.ts:160`): `providerID.length < 0` can never be true for a string — changed to `=== 0`. This meant auto-save would never early-return on empty provider IDs after trimming whitespace, allowing saves to proceed with empty strings which would fail server-side.

2. **Wrong error class in catch blocks** (`AppStoreActions.ts:136,181`): Both `saveSchedule` and `autoSaveSchedule` used `e instanceof TRPCError` (a server-side class from `@trpc/server`) instead of `TRPCClientError` (from `@trpc/client`). Since `TRPCError` is never instantiated in the browser, this check always evaluated to `false`, causing every tRPC error to fall through to the generic "Network error or server is down" message. The actual structured error info from the server was silently discarded. Removed the now-unused `@trpc/server` import.

3. **Unclosed string literals in error snackbar messages** (`AppStoreActions.ts:141,183`): Template literals like `` `Schedule could not be saved under username "${providerId}` `` were missing the closing `"` before the backtick, producing malformed user-facing error messages.

4. **`autoSaveEnd` event not emitted on failure** (`ActionTypesStore.ts:131-134`): If the `autoSaveSchedule()` call threw an exception, the `autoSaveEnd` event was never emitted. The `Save` component listens for this event to clear its loading/disabled state, so a single failed auto-save would permanently lock the Save button in a spinning state until page reload. Wrapped in `try/finally` to guarantee the event fires.

5. **`updateScheduleNote` not participating in auto-save** (`AppStore.ts:438-441`): This was the only mutating method in `AppStore` that neither set `unsavedChanges = true` nor called `actionTypesStore.autoSaveSchedule()`. Schedule note edits were silently lost unless the user also made another change or manually saved. Added the dirty flag, action type (`UpdateScheduleNoteAction`), and auto-save trigger to match all other mutations.

## Test Plan

- Verified all pre-existing TypeScript errors are in unrelated files (26 errors across 9 files like `termData.ts`, `search.ts`, etc.) — no new type errors introduced.
- Lint passes cleanly on all changed files (oxlint + lint-staged with format).
- The changes are minimal and follow the exact same patterns used by every other mutation in the codebase.

## Issues

Closes #

<!-- [Optional]
## Future Followup

- `ExperimentalMenu.handleAutoSaveChange` uses `getLocalStorageUserId()` for its initial one-shot save when the toggle is enabled, while the normal auto-save path uses the session's `accounts.providerAccountId`. If the localStorage userId is stale from a legacy flow, this could target the wrong account. Consider unifying to always use the session-based provider ID.
- Auto-save has no debouncing — rapid mutations (e.g. color changes, quick edits) each trigger an independent save. Consider adding a debounce/throttle.
-->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c812f491-284b-4602-acf2-032a84607abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c812f491-284b-4602-acf2-032a84607abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

