### PR TITLE
fix: restore fixed table layout so section table column weights are respected

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,7 +1,3 @@
-import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
-import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
-import { useMemo } from 'react';
-
 import { CourseInfoBar } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoBar';
 import { CourseInfoButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoButton';
 import { CourseInfoSearchButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton';
@@ -15,6 +11,9 @@ import analyticsEnum from '$lib/analytics/analytics';
 import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
+import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
+import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { useMemo } from 'react';
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
@@ -22,6 +21,8 @@ interface TableHeaderColumnDetails {
     label: string;
     weight: number;
 }
+
+const ACTION_COLUMN_WEIGHT = 5;
 
 const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHeaderColumnDetails> = {
     sectionCode: { label: 'Code', weight: 5 },
@@ -156,23 +157,41 @@ function SectionTable(props: SectionTableProps) {
                 >
                     <TableHead>
                         <TableRow>
-                            <TableCell sx={{ padding: 0 }} />
                             {(() => {
                                 const visible = tableHeaderColumnEntries.filter(([column]) =>
                                     activeColumns.includes(column as SectionTableColumn)
                                 );
-                                const totalWeight = visible.reduce((sum, [, { weight }]) => sum + weight, 0);
-                                return visible.map(([column, { label, weight }]) => (
-                                    <TableCell
-                                        key={column}
-                                        sx={{
-                                            width: `${(weight / totalWeight) * 100}%`,
-                                            padding: 0,
-                                        }}
-                                    >
-                                        {label === 'Enrollment' ? <EnrollmentColumnHeader label={label} /> : label}
-                                    </TableCell>
-                                ));
+                                const hasAction = activeColumns.includes('action');
+                                const totalWeight =
+                                    visible.reduce((sum, [, { weight }]) => sum + weight, 0) +
+                                    (hasAction ? ACTION_COLUMN_WEIGHT : 0);
+                                return (
+                                    <>
+                                        {hasAction && (
+                                            <TableCell
+                                                sx={{
+                                                    width: `${(ACTION_COLUMN_WEIGHT / totalWeight) * 100}%`,
+                                                    padding: 0,
+                                                }}
+                                            />
+                                        )}
+                                        {visible.map(([column, { label, weight }]) => (
+                                            <TableCell
+                                                key={column}
+                                                sx={{
+                                                    width: `${(weight / totalWeight) * 100}%`,
+                                                    padding: 0,
+                                                }}
+                                            >
+                                                {label === 'Enrollment' ? (
+                                                    <EnrollmentColumnHeader label={label} />
+                                                ) : (
+                                                    label
+                                                )}
+                                            </TableCell>
+                                        ))}
+                                    </>
+                                );
                             })()}
                         </TableRow>
                     </TableHead>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -23,8 +23,15 @@ const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
  */
 type TableHeaderColumnDetails = { label: string; weight: number } | { label: string; width: string };
 
+/**
+ * Sized to exactly fit the icon buttons rendered in ActionCell:
+ * - Each IconButton: 20px icon (fontSize="small") + 2 * 4px padding (p: 0.5) = 28px
+ * - Cell horizontal padding: 2 * 8px (desktop) / 2 * 4px (mobile)
+ * - Desktop shows 3 icons: 3 * 28 + 16 = 100px
+ * - Mobile shows 2 icons:  2 * 28 + 8  = 64px
+ */
 const ACTION_COLUMN_WIDTH_DESKTOP = '100px';
-const ACTION_COLUMN_WIDTH_MOBILE = '72px';
+const ACTION_COLUMN_WIDTH_MOBILE = '64px';
 
 function getTableHeaderColumns(isMobile: boolean): Record<SectionTableColumn, TableHeaderColumnDetails> {
     return {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -26,12 +26,12 @@ type TableHeaderColumnDetails = { label: string; weight: number } | { label: str
 /**
  * Sized to exactly fit the icon buttons rendered in ActionCell:
  * - Each IconButton: 20px icon (fontSize="small") + 2 * 4px padding (p: 0.5) = 28px
- * - Cell horizontal padding: 2 * 8px (desktop) / 2 * 4px (mobile)
- * - Desktop shows 3 icons: 3 * 28 + 16 = 100px
- * - Mobile shows 2 icons:  2 * 28 + 8  = 64px
+ * - Cell padding (inherited from TableBodyCellContainer): 0 left, 4px right
+ * - Desktop shows 3 icons: 3 * 28 + 4 = 88px
+ * - Mobile shows 2 icons:  2 * 28 + 4 = 60px
  */
-const ACTION_COLUMN_WIDTH_DESKTOP = '100px';
-const ACTION_COLUMN_WIDTH_MOBILE = '64px';
+const ACTION_COLUMN_WIDTH_DESKTOP = '88px';
+const ACTION_COLUMN_WIDTH_MOBILE = '60px';
 
 function getTableHeaderColumns(isMobile: boolean): Record<SectionTableColumn, TableHeaderColumnDetails> {
     return {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -22,9 +22,8 @@ interface TableHeaderColumnDetails {
     weight: number;
 }
 
-const ACTION_COLUMN_WEIGHT = 5;
-
-const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHeaderColumnDetails> = {
+const tableHeaderColumns: Record<SectionTableColumn, TableHeaderColumnDetails> = {
+    action: { label: '', weight: 5 },
     sectionCode: { label: 'Code', weight: 5 },
     sectionDetails: { label: 'Type', weight: 5 },
     instructors: { label: 'Instructors', weight: 7 },
@@ -36,7 +35,9 @@ const tableHeaderColumns: Record<Exclude<SectionTableColumn, 'action'>, TableHea
     restrictions: { label: 'Restr', weight: 5 },
     syllabus: { label: 'Syllabus', weight: 5 },
 };
-const tableHeaderColumnEntries = Object.entries(tableHeaderColumns);
+const tableHeaderColumnEntries = Object.entries(tableHeaderColumns) as Array<
+    [SectionTableColumn, TableHeaderColumnDetails]
+>;
 
 function SectionTable(props: SectionTableProps) {
     const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory, missingSections = [] } = props;
@@ -159,39 +160,20 @@ function SectionTable(props: SectionTableProps) {
                         <TableRow>
                             {(() => {
                                 const visible = tableHeaderColumnEntries.filter(([column]) =>
-                                    activeColumns.includes(column as SectionTableColumn)
+                                    activeColumns.includes(column)
                                 );
-                                const hasAction = activeColumns.includes('action');
-                                const totalWeight =
-                                    visible.reduce((sum, [, { weight }]) => sum + weight, 0) +
-                                    (hasAction ? ACTION_COLUMN_WEIGHT : 0);
-                                return (
-                                    <>
-                                        {hasAction && (
-                                            <TableCell
-                                                sx={{
-                                                    width: `${(ACTION_COLUMN_WEIGHT / totalWeight) * 100}%`,
-                                                    padding: 0,
-                                                }}
-                                            />
-                                        )}
-                                        {visible.map(([column, { label, weight }]) => (
-                                            <TableCell
-                                                key={column}
-                                                sx={{
-                                                    width: `${(weight / totalWeight) * 100}%`,
-                                                    padding: 0,
-                                                }}
-                                            >
-                                                {label === 'Enrollment' ? (
-                                                    <EnrollmentColumnHeader label={label} />
-                                                ) : (
-                                                    label
-                                                )}
-                                            </TableCell>
-                                        ))}
-                                    </>
-                                );
+                                const totalWeight = visible.reduce((sum, [, { weight }]) => sum + weight, 0);
+                                return visible.map(([column, { label, weight }]) => (
+                                    <TableCell
+                                        key={column}
+                                        sx={{
+                                            width: `${(weight / totalWeight) * 100}%`,
+                                            padding: 0,
+                                        }}
+                                    >
+                                        {label === 'Enrollment' ? <EnrollmentColumnHeader label={label} /> : label}
+                                    </TableCell>
+                                ));
                             })()}
                         </TableRow>
                     </TableHead>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -36,7 +36,7 @@ const ACTION_COLUMN_WIDTH_MOBILE = '60px';
 function getTableHeaderColumns(isMobile: boolean): Record<SectionTableColumn, TableHeaderColumnDetails> {
     return {
         action: { label: '', width: isMobile ? ACTION_COLUMN_WIDTH_MOBILE : ACTION_COLUMN_WIDTH_DESKTOP },
-        sectionCode: { label: 'Code', weight: 5 },
+        sectionCode: { label: 'Code', weight: 3 },
         sectionDetails: { label: 'Type', weight: 5 },
         instructors: { label: 'Instructors', weight: 7 },
         gpa: { label: 'GPA', weight: 5 },

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -17,27 +17,30 @@ import { useMemo } from 'react';
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
-interface TableHeaderColumnDetails {
-    label: string;
-    weight: number;
-}
+/**
+ * Columns either claim a fixed pixel width (`width`) or a share of the remaining
+ * table width proportional to their `weight` relative to other weighted columns.
+ */
+type TableHeaderColumnDetails = { label: string; weight: number } | { label: string; width: string };
 
-const tableHeaderColumns: Record<SectionTableColumn, TableHeaderColumnDetails> = {
-    action: { label: '', weight: 5 },
-    sectionCode: { label: 'Code', weight: 5 },
-    sectionDetails: { label: 'Type', weight: 5 },
-    instructors: { label: 'Instructors', weight: 7 },
-    gpa: { label: 'GPA', weight: 5 },
-    dayAndTime: { label: 'Times', weight: 12 },
-    location: { label: 'Places', weight: 7 },
-    sectionEnrollment: { label: 'Enrollment', weight: 7 },
-    status: { label: 'Status', weight: 5 },
-    restrictions: { label: 'Restr', weight: 5 },
-    syllabus: { label: 'Syllabus', weight: 5 },
-};
-const tableHeaderColumnEntries = Object.entries(tableHeaderColumns) as Array<
-    [SectionTableColumn, TableHeaderColumnDetails]
->;
+const ACTION_COLUMN_WIDTH_DESKTOP = '100px';
+const ACTION_COLUMN_WIDTH_MOBILE = '72px';
+
+function getTableHeaderColumns(isMobile: boolean): Record<SectionTableColumn, TableHeaderColumnDetails> {
+    return {
+        action: { label: '', width: isMobile ? ACTION_COLUMN_WIDTH_MOBILE : ACTION_COLUMN_WIDTH_DESKTOP },
+        sectionCode: { label: 'Code', weight: 5 },
+        sectionDetails: { label: 'Type', weight: 5 },
+        instructors: { label: 'Instructors', weight: 7 },
+        gpa: { label: 'GPA', weight: 5 },
+        dayAndTime: { label: 'Times', weight: 12 },
+        location: { label: 'Places', weight: 7 },
+        sectionEnrollment: { label: 'Enrollment', weight: 7 },
+        status: { label: 'Status', weight: 5 },
+        restrictions: { label: 'Restr', weight: 5 },
+        syllabus: { label: 'Syllabus', weight: 5 },
+    };
+}
 
 function SectionTable(props: SectionTableProps) {
     const { courseDetails, term, allowHighlight, scheduleNames, analyticsCategory, missingSections = [] } = props;
@@ -71,6 +74,32 @@ function SectionTable(props: SectionTableProps) {
         const numActiveColumns = activeColumns.length;
         return (width * numActiveColumns) / TOTAL_NUM_COLUMNS;
     }, [activeColumns]);
+
+    /**
+     * Header cells to render, with their resolved CSS `width`.
+     *
+     * Columns that declare an explicit pixel `width` (e.g. the action column)
+     * keep that width verbatim. The remaining table width is split among the
+     * weighted columns proportional to each column's `weight`.
+     */
+    const visibleHeaderCells = useMemo(() => {
+        const tableHeaderColumns = getTableHeaderColumns(isMobile);
+        const visible = (
+            Object.entries(tableHeaderColumns) as Array<[SectionTableColumn, TableHeaderColumnDetails]>
+        ).filter(([column]) => activeColumns.includes(column));
+
+        const fixedWidths = visible
+            .map(([, details]) => ('width' in details ? details.width : null))
+            .filter((w): w is string => w !== null);
+        const remainingWidthExpr = fixedWidths.length > 0 ? `calc(100% - ${fixedWidths.join(' - ')})` : '100%';
+        const totalWeight = visible.reduce((sum, [, details]) => sum + ('weight' in details ? details.weight : 0), 0);
+
+        return visible.map(([column, details]) => {
+            const width =
+                'width' in details ? details.width : `calc(${remainingWidthExpr} * ${details.weight / totalWeight})`;
+            return { column, label: details.label, width };
+        });
+    }, [activeColumns, isMobile]);
 
     return (
         <>
@@ -158,23 +187,17 @@ function SectionTable(props: SectionTableProps) {
                 >
                     <TableHead>
                         <TableRow>
-                            {(() => {
-                                const visible = tableHeaderColumnEntries.filter(([column]) =>
-                                    activeColumns.includes(column)
-                                );
-                                const totalWeight = visible.reduce((sum, [, { weight }]) => sum + weight, 0);
-                                return visible.map(([column, { label, weight }]) => (
-                                    <TableCell
-                                        key={column}
-                                        sx={{
-                                            width: `${(weight / totalWeight) * 100}%`,
-                                            padding: 0,
-                                        }}
-                                    >
-                                        {label === 'Enrollment' ? <EnrollmentColumnHeader label={label} /> : label}
-                                    </TableCell>
-                                ));
-                            })()}
+                            {visibleHeaderCells.map(({ column, label, width }) => (
+                                <TableCell
+                                    key={column}
+                                    sx={{
+                                        width,
+                                        padding: 0,
+                                    }}
+                                >
+                                    {label === 'Enrollment' ? <EnrollmentColumnHeader label={label} /> : label}
+                                </TableCell>
+                            ))}
                         </TableRow>
                     </TableHead>
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -151,7 +151,7 @@ function SectionTable(props: SectionTableProps) {
                     sx={{
                         minWidth: `${tableMinWidth}px`,
                         width: '100%',
-                        tableLayout: 'auto',
+                        tableLayout: 'fixed',
                     }}
                 >
                     <TableHead>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer.tsx
@@ -7,7 +7,15 @@ interface TableBodyCellContainerProps extends TableCellProps {
 
 export function TableBodyCellContainer({ sx, children, ...rest }: TableBodyCellContainerProps) {
     return (
-        <TableCell sx={{ padding: 0, wordBreak: 'break-word', ...sx }} {...rest}>
+        <TableCell
+            sx={{
+                padding: 0,
+                paddingRight: 0.5,
+                wordBreak: 'break-word',
+                ...sx,
+            }}
+            {...rest}
+        >
             {children}
         </TableCell>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer.tsx
@@ -7,7 +7,7 @@ interface TableBodyCellContainerProps extends TableCellProps {
 
 export function TableBodyCellContainer({ sx, children, ...rest }: TableBodyCellContainerProps) {
     return (
-        <TableCell sx={{ padding: 0, ...sx }} {...rest}>
+        <TableCell sx={{ padding: 0, wordBreak: 'break-word', ...sx }} {...rest}>
             {children}
         </TableCell>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -51,7 +51,7 @@ export const ActionCell = memo(
         }, [updateColor]);
 
         return (
-            <TableBodyCellContainer sx={{ paddingX: isMobile ? 0.5 : 1 }}>
+            <TableBodyCellContainer>
                 <Box
                     sx={{
                         display: 'flex',

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -79,8 +79,8 @@ export const ActionCell = memo(
                             courseNumber={courseDetails.courseNumber}
                         />
                     ) : (
-                        <IconButton disabled size="small" sx={{ p: 1 }}>
-                            <CircularProgress size={15} />
+                        <IconButton disabled size="small" sx={{ p: 0.5 }}>
+                            <CircularProgress size={20} />
                         </IconButton>
                     )}
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -1,19 +1,18 @@
-import { Box, CircularProgress, IconButton } from '@mui/material';
-import { AASection, CourseDetails } from '@packages/antalmanac-types';
-import { memo, useCallback, useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-
 import ColorPicker from '$components/ColorPicker';
-import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { AddButton } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/AddButton';
 import { DeleteButton } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteButton';
 import { NotificationsMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu';
 import { SectionActionMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/SectionActionMenu';
+import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum from '$lib/analytics/analytics';
 import { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useNotificationStore } from '$stores/NotificationStore';
+import { Box, CircularProgress, IconButton } from '@mui/material';
+import { AASection, CourseDetails } from '@packages/antalmanac-types';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 interface ActionCellProps {
     section: AASection;
@@ -28,81 +27,84 @@ function getSectionColor(sectionCode: string, term: string): string {
     return AppStore.schedule.getExistingCourseInSchedule(sectionCode, term)?.section.color ?? '#5ec8e0';
 }
 
-export const ActionCell = memo(({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
-    const initialized = useNotificationStore(useShallow((state) => state.initialized));
-    const isMobile = useIsMobile();
+export const ActionCell = memo(
+    ({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
+        const initialized = useNotificationStore(useShallow((state) => state.initialized));
+        const isMobile = useIsMobile();
 
-    const [sectionColor, setSectionColor] = useState(() => getSectionColor(section.sectionCode, term));
+        const [sectionColor, setSectionColor] = useState(() => getSectionColor(section.sectionCode, term));
 
-    const updateColor = useCallback(() => {
-        setSectionColor(getSectionColor(section.sectionCode, term));
-    }, [section.sectionCode, term]);
+        const updateColor = useCallback(() => {
+            setSectionColor(getSectionColor(section.sectionCode, term));
+        }, [section.sectionCode, term]);
 
-    useEffect(() => {
-        AppStore.on('addedCoursesChange', updateColor);
-        AppStore.on('colorChange', updateColor);
-        AppStore.on('currentScheduleIndexChange', updateColor);
+        useEffect(() => {
+            AppStore.on('addedCoursesChange', updateColor);
+            AppStore.on('colorChange', updateColor);
+            AppStore.on('currentScheduleIndexChange', updateColor);
 
-        return () => {
-            AppStore.removeListener('addedCoursesChange', updateColor);
-            AppStore.removeListener('colorChange', updateColor);
-            AppStore.removeListener('currentScheduleIndexChange', updateColor);
-        };
-    }, [updateColor]);
+            return () => {
+                AppStore.removeListener('addedCoursesChange', updateColor);
+                AppStore.removeListener('colorChange', updateColor);
+                AppStore.removeListener('currentScheduleIndexChange', updateColor);
+            };
+        }, [updateColor]);
 
-    return (
-        <TableBodyCellContainer sx={{ paddingX: isMobile ? 0.5 : 1 }}>
-            <Box
-                sx={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                }}
-            >
-                {addedCourse ? (
-                    <DeleteButton sectionCode={section.sectionCode} term={term} />
-                ) : (
-                    <AddButton
-                        section={section}
-                        courseDetails={courseDetails}
-                        term={term}
-                        scheduleConflict={scheduleConflict}
-                    />
-                )}
-
-                {initialized ? (
-                    <NotificationsMenu
-                        section={section}
-                        term={term}
-                        courseTitle={courseDetails.courseTitle}
-                        deptCode={courseDetails.deptCode}
-                        courseNumber={courseDetails.courseNumber}
-                    />
-                ) : (
-                    <IconButton disabled size="small" sx={{ p: 1 }}>
-                        <CircularProgress size={15} />
-                    </IconButton>
-                )}
-
-                {!isMobile &&
-                    (addedCourse ? (
-                        <ColorPicker
-                            color={sectionColor}
-                            analyticsCategory={analyticsEnum.addedClasses}
-                            isCustomEvent={false}
-                            term={term}
-                            sectionCode={section.sectionCode}
-                        />
+        return (
+            <TableBodyCellContainer sx={{ paddingX: isMobile ? 0.5 : 1 }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                >
+                    {addedCourse ? (
+                        <DeleteButton sectionCode={section.sectionCode} term={term} />
                     ) : (
-                        <SectionActionMenu
+                        <AddButton
                             section={section}
                             courseDetails={courseDetails}
                             term={term}
-                            scheduleNames={scheduleNames}
+                            scheduleConflict={scheduleConflict}
                         />
-                    ))}
-            </Box>
-        </TableBodyCellContainer>
-    );
-});
+                    )}
+
+                    {initialized ? (
+                        <NotificationsMenu
+                            section={section}
+                            term={term}
+                            courseTitle={courseDetails.courseTitle}
+                            deptCode={courseDetails.deptCode}
+                            courseNumber={courseDetails.courseNumber}
+                        />
+                    ) : (
+                        <IconButton disabled size="small" sx={{ p: 1 }}>
+                            <CircularProgress size={15} />
+                        </IconButton>
+                    )}
+
+                    {!isMobile &&
+                        (addedCourse ? (
+                            <ColorPicker
+                                color={sectionColor}
+                                analyticsCategory={analyticsEnum.addedClasses}
+                                isCustomEvent={false}
+                                term={term}
+                                sectionCode={section.sectionCode}
+                            />
+                        ) : (
+                            <SectionActionMenu
+                                section={section}
+                                courseDetails={courseDetails}
+                                term={term}
+                                scheduleNames={scheduleNames}
+                            />
+                        ))}
+                </Box>
+            </TableBodyCellContainer>
+        );
+    }
+);
 
 ActionCell.displayName = 'ActionCell';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the recent section table restyle (#1592), long cell contents (instructor names, building codes, restriction strings, etc.) were visibly exceeding their column weights and squeezing neighboring columns.

The root cause was that the `Table` was switched from `tableLayout: 'fixed'` to `tableLayout: 'auto'` in that PR, while the header cells still declared weight-based percentage widths. Under `auto` layout, those widths are only suggestions — the widest row content wins — so columns with long content grew past their weights and the ellipsis in `InstructorsCell` stopped working (no fixed width to truncate against).

This PR:

1. Flips the section table back to `tableLayout: 'fixed'` so header widths are authoritative and the existing `overflow: hidden; text-overflow: ellipsis` on instructor names works again.
2. Unifies `action` into the header-column map so there is a single source of truth for widths, matching the body-cell map 1:1.
3. Extends `TableHeaderColumnDetails` into a union: a column can declare either a `weight` (share of the remaining width) or a fixed pixel `width`.
4. Applies a uniform `paddingRight: 0.5` (4px) to every body cell via `TableBodyCellContainer`, and drops the action cell's bespoke horizontal padding so it inherits the same rule. This makes the action column tighter and consistent with the rest of the row.
5. Sizes the action column to exactly fit its icons with the new padding:
   - Desktop (3 icons): `3 * 28px + 4px = 88px`
   - Mobile (2 icons): `2 * 28px + 4px = 60px`
   
   where each `IconButton` is `20px (fontSize="small") + 2 * 4px padding = 28px`.
6. Drops the `sectionCode` column weight from `5` to `3` — the content (a 5-digit code) never needs more than that and the freed room benefits wider columns.
7. Centers the action cell contents via `display: flex; justifyContent: center`, and aligns the notifications-loading placeholder button (`p: 0.5`, `CircularProgress size={20}`) with the real buttons so the cell doesn't shift when notifications initialize.
8. Adds `wordBreak: 'break-word'` to `TableBodyCellContainer` so unusually long single tokens wrap instead of overflowing under fixed layout.

Weighted columns split `calc(100% - actionWidth)` proportional to their weights — same relative proportions as before, just of the remainder.

## Test Plan

- Local visual check of a course with long instructor names, long building codes, and long restriction strings to confirm columns stay at their weighted widths and long instructor names ellipsize.
- Confirm the action column is snug around its icons on desktop and mobile, icons are centered, and the cell doesn't change size when notifications initialize.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55d660d8-8c46-4578-b370-9ab5e72dd38a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55d660d8-8c46-4578-b370-9ab5e72dd38a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

