### PR TITLE
fix: use fixed table layout to respect column weights

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -45,6 +45,13 @@ function SectionTable(props: SectionTableProps) {
     const [activeTab] = useTabStore((store) => [store.activeTab]);
     const isMobile = useIsMobile();
 
+    /**
+     * Width reserved for the action column (add/delete, notifications, color/menu).
+     * With `table-layout: fixed`, this pixel width is honored first, and the
+     * remaining columns split what's left according to their percentage weights.
+     */
+    const actionColumnWidth = isMobile ? 64 : 100;
+
     const courseId = useMemo(() => {
         return courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     }, [courseDetails.deptCode, courseDetails.courseNumber]);
@@ -156,7 +163,7 @@ function SectionTable(props: SectionTableProps) {
                 >
                     <TableHead>
                         <TableRow>
-                            <TableCell sx={{ padding: 0 }} />
+                            <TableCell sx={{ padding: 0, width: `${actionColumnWidth}px` }} />
                             {(() => {
                                 const visible = tableHeaderColumnEntries.filter(([column]) =>
                                     activeColumns.includes(column as SectionTableColumn)

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -45,12 +45,7 @@ function SectionTable(props: SectionTableProps) {
     const [activeTab] = useTabStore((store) => [store.activeTab]);
     const isMobile = useIsMobile();
 
-    /**
-     * Width reserved for the action column (add/delete, notifications, color/menu).
-     * With `table-layout: fixed`, this pixel width is honored first, and the
-     * remaining columns split what's left according to their percentage weights.
-     */
-    const actionColumnWidth = isMobile ? 64 : 100;
+    const actionColumnWidth = isMobile ? 60 : 88;
 
     const courseId = useMemo(() => {
         return courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -1,20 +1,19 @@
-import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
-import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
-import { useMemo } from 'react';
-
 import { CourseInfoBar } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoBar';
 import { CourseInfoButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoButton';
 import { CourseInfoSearchButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton';
 import { EnrollmentColumnHeader } from '$components/RightPane/SectionTable/EnrollmentColumnHeader';
 import { EnrollmentHistoryPopup } from '$components/RightPane/SectionTable/EnrollmentHistoryPopup';
 import GradesPopup from '$components/RightPane/SectionTable/GradesPopup';
-import { SectionTableProps } from '$components/RightPane/SectionTable/SectionTable.types';
+import type { SectionTableProps } from '$components/RightPane/SectionTable/SectionTable.types';
 import { SectionTableBody } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBody';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum from '$lib/analytics/analytics';
-import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
+import { SECTION_TABLE_COLUMNS, type SectionTableColumn, useColumnStore } from '$stores/ColumnStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
+import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
+import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { useMemo } from 'react';
 
 const TOTAL_NUM_COLUMNS = SECTION_TABLE_COLUMNS.length;
 
@@ -45,21 +44,29 @@ function SectionTable(props: SectionTableProps) {
     const [activeTab] = useTabStore((store) => [store.activeTab]);
     const isMobile = useIsMobile();
 
-    const actionColumnWidth = isMobile ? 60 : 88;
+    const actionColumnWidth = isMobile ? 54 : 85;
 
     const courseId = useMemo(() => {
         return courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     }, [courseDetails.deptCode, courseDetails.courseNumber]);
 
     const formattedTime = useMemo(() => {
-        if (!courseDetails.updatedAt) return null;
+        if (!courseDetails.updatedAt) {
+            return null;
+        }
+
         const date = new Date(courseDetails.updatedAt);
-        if (isNaN(date.getTime())) return null;
+
+        if (Number.isNaN(date.getTime())) {
+            return null;
+        }
+
         const timeString = date.toLocaleTimeString(undefined, {
             hour: '2-digit',
             minute: '2-digit',
             hour12: !isMilitaryTime,
         });
+
         return timeString.replace(/^0(\d)/, '$1');
     }, [courseDetails.updatedAt, isMilitaryTime]);
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -151,7 +151,7 @@ function SectionTable(props: SectionTableProps) {
                     sx={{
                         minWidth: `${tableMinWidth}px`,
                         width: '100%',
-                        tableLayout: 'auto',
+                        tableLayout: 'fixed',
                     }}
                 >
                     <TableHead>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -1,19 +1,18 @@
-import { Box, CircularProgress, IconButton } from '@mui/material';
-import { AASection, CourseDetails } from '@packages/antalmanac-types';
-import { memo, useCallback, useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-
 import ColorPicker from '$components/ColorPicker';
-import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { AddButton } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/AddButton';
 import { DeleteButton } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/DeleteButton';
 import { NotificationsMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu';
 import { SectionActionMenu } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/SectionActionMenu';
+import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum from '$lib/analytics/analytics';
-import { Term } from '$lib/termData';
+import type { Term } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { useNotificationStore } from '$stores/NotificationStore';
+import { Box, CircularProgress, IconButton } from '@mui/material';
+import type { AASection, CourseDetails } from '@packages/antalmanac-types';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 interface ActionCellProps {
     section: AASection;
@@ -28,81 +27,83 @@ function getSectionColor(sectionCode: string, term: string): string {
     return AppStore.schedule.getExistingCourseInSchedule(sectionCode, term)?.section.color ?? '#5ec8e0';
 }
 
-export const ActionCell = memo(({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
-    const initialized = useNotificationStore(useShallow((state) => state.initialized));
-    const isMobile = useIsMobile();
+export const ActionCell = memo(
+    ({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
+        const initialized = useNotificationStore(useShallow((state) => state.initialized));
+        const isMobile = useIsMobile();
 
-    const [sectionColor, setSectionColor] = useState(() => getSectionColor(section.sectionCode, term));
+        const [sectionColor, setSectionColor] = useState(() => getSectionColor(section.sectionCode, term));
 
-    const updateColor = useCallback(() => {
-        setSectionColor(getSectionColor(section.sectionCode, term));
-    }, [section.sectionCode, term]);
+        const updateColor = useCallback(() => {
+            setSectionColor(getSectionColor(section.sectionCode, term));
+        }, [section.sectionCode, term]);
 
-    useEffect(() => {
-        AppStore.on('addedCoursesChange', updateColor);
-        AppStore.on('colorChange', updateColor);
-        AppStore.on('currentScheduleIndexChange', updateColor);
+        useEffect(() => {
+            AppStore.on('addedCoursesChange', updateColor);
+            AppStore.on('colorChange', updateColor);
+            AppStore.on('currentScheduleIndexChange', updateColor);
 
-        return () => {
-            AppStore.removeListener('addedCoursesChange', updateColor);
-            AppStore.removeListener('colorChange', updateColor);
-            AppStore.removeListener('currentScheduleIndexChange', updateColor);
-        };
-    }, [updateColor]);
+            return () => {
+                AppStore.removeListener('addedCoursesChange', updateColor);
+                AppStore.removeListener('colorChange', updateColor);
+                AppStore.removeListener('currentScheduleIndexChange', updateColor);
+            };
+        }, [updateColor]);
 
-    return (
-        <TableBodyCellContainer sx={{ paddingX: isMobile ? 0.5 : 1 }}>
-            <Box
-                sx={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                }}
-            >
-                {addedCourse ? (
-                    <DeleteButton sectionCode={section.sectionCode} term={term} />
-                ) : (
-                    <AddButton
-                        section={section}
-                        courseDetails={courseDetails}
-                        term={term}
-                        scheduleConflict={scheduleConflict}
-                    />
-                )}
-
-                {initialized ? (
-                    <NotificationsMenu
-                        section={section}
-                        term={term}
-                        courseTitle={courseDetails.courseTitle}
-                        deptCode={courseDetails.deptCode}
-                        courseNumber={courseDetails.courseNumber}
-                    />
-                ) : (
-                    <IconButton disabled size="small" sx={{ p: 1 }}>
-                        <CircularProgress size={15} />
-                    </IconButton>
-                )}
-
-                {!isMobile &&
-                    (addedCourse ? (
-                        <ColorPicker
-                            color={sectionColor}
-                            analyticsCategory={analyticsEnum.addedClasses}
-                            isCustomEvent={false}
-                            term={term}
-                            sectionCode={section.sectionCode}
-                        />
+        return (
+            <TableBodyCellContainer sx={{ paddingX: isMobile ? 0.5 : 1 }}>
+                <Box
+                    sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                    }}
+                >
+                    {addedCourse ? (
+                        <DeleteButton sectionCode={section.sectionCode} term={term} />
                     ) : (
-                        <SectionActionMenu
+                        <AddButton
                             section={section}
                             courseDetails={courseDetails}
                             term={term}
-                            scheduleNames={scheduleNames}
+                            scheduleConflict={scheduleConflict}
                         />
-                    ))}
-            </Box>
-        </TableBodyCellContainer>
-    );
-});
+                    )}
+
+                    {initialized ? (
+                        <NotificationsMenu
+                            section={section}
+                            term={term}
+                            courseTitle={courseDetails.courseTitle}
+                            deptCode={courseDetails.deptCode}
+                            courseNumber={courseDetails.courseNumber}
+                        />
+                    ) : (
+                        <IconButton disabled size="small" sx={{ p: 0.5 }}>
+                            <CircularProgress size={15} />
+                        </IconButton>
+                    )}
+
+                    {!isMobile &&
+                        (addedCourse ? (
+                            <ColorPicker
+                                color={sectionColor}
+                                analyticsCategory={analyticsEnum.addedClasses}
+                                isCustomEvent={false}
+                                term={term}
+                                sectionCode={section.sectionCode}
+                            />
+                        ) : (
+                            <SectionActionMenu
+                                section={section}
+                                courseDetails={courseDetails}
+                                term={term}
+                                scheduleNames={scheduleNames}
+                            />
+                        ))}
+                </Box>
+            </TableBodyCellContainer>
+        );
+    }
+);
 
 ActionCell.displayName = 'ActionCell';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Switches the section table back to `table-layout: fixed` so the weighted percentage widths on each header cell are actually honored (auto layout grows columns to fit content, ignoring them). The action column is given explicit (magic) pixel widths so it sits outside the percentage pool and doesn't collapse.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c5f3510-0267-4e87-a3ba-774076987aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c5f3510-0267-4e87-a3ba-774076987aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
