### PR TITLE
fix: misc bug fixes

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -157,7 +157,7 @@ export async function autoSaveSchedule(providerID: string, options: AutoSaveSche
     });
     if (providerID == null) return;
     providerID = providerID.replace(/\s+/g, '');
-    if (providerID.length < 0) return;
+    if (providerID.length <= 0) return;
 
     const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
     try {

--- a/apps/antalmanac/src/backend/routers/auth.ts
+++ b/apps/antalmanac/src/backend/routers/auth.ts
@@ -30,8 +30,8 @@ const authRouter = router({
      */
     getSessionUserId: procedure.input(z.object({ token: z.string() })).query(async ({ input }) => {
         if (input.token === '') return '';
-        const session = (await RDS.getCurrentSession(db, input.token)) ?? '';
-        return session.userId;
+        const session = await RDS.getCurrentSession(db, input.token);
+        return session?.userId ?? '';
     }),
 });
 

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -73,10 +73,8 @@ function sortWebsocResponse(response: WebsocAPIResponse) {
 
 const queryWebSoc = async ({ input }: { input: Record<string, string> }) => {
     const url = `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams(sanitizeSearchParams(input))}`;
-    console.log('queryWebSoc', url);
 
     const data = await fetchAnteaterAPI<WebsocAPIResult>(url, { errorType: 'trpc' });
-    console.log('queryWebSoc', data);
 
     if (!data?.data) {
         throw new TRPCError({

--- a/apps/antalmanac/src/components/Calendar/CalendarCourseEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarCourseEvent.tsx
@@ -7,7 +7,7 @@ import locationIds from '$lib/locations/locations';
 
 export const CalendarCourseEvent = memo(({ event }: { event: CalendarEvent }) => {
     if (isSkeletonEvent(event)) {
-        return;
+        return null;
     }
 
     if (event.isCustomEvent) {

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -391,7 +391,7 @@ export class Schedules {
         for (const scheduleIndex of scheduleIndices) {
             const customEvents = this.schedules[scheduleIndex].customEvents;
             const index = customEvents.findIndex((customEvent) => customEvent.customEventID === customEventId);
-            if (index !== undefined) {
+            if (index !== -1) {
                 customEvents.splice(index, 1);
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Five unrelated, self-contained bug fixes found while reading through the codebase. Each is a one-line change.

- **`actions/AppStoreActions.ts`** — `autoSaveSchedule` guard `providerID.length < 0` can never fire; changed to `<= 0` so empty strings short-circuit as intended.
- **`backend/routers/auth.ts`** — `getSessionUserId` did `(session ?? '').userId`, which reads `.userId` off the empty string and returns `undefined` when the session lookup misses. Null-check instead.
- **`backend/routers/websoc.ts`** — removed two leftover `console.log('queryWebSoc', …)` debug lines from the hot WebSoc path.
- **`components/Calendar/CalendarCourseEvent.tsx`** — component used a bare `return;` for skeleton events, which resolves to `undefined` and trips React 18's "Nothing was returned from render". Return `null`.
- **`stores/Schedules.ts`** — `deleteCustomEvent` compared `findIndex` against `undefined`, but `findIndex` returns `-1` on miss. When the event didn't exist in a given schedule, `splice(-1, 1)` removed the last custom event instead of skipping.

## Test Plan

- Type-check and lint pass locally.
- Manual smoke: deleting a custom event that only exists in one of several schedules no longer nukes an unrelated event from the other schedules.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ed140eb-6b37-482d-a320-f44d1f522a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ed140eb-6b37-482d-a320-f44d1f522a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

