### PR TITLE
Calendar skeleton dayOffset calculation breaks for Sunday courses

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -23,7 +23,7 @@ import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
 import { CalendarMonth } from '@mui/icons-material';
 import { Box, Backdrop, useTheme } from '@mui/material';
-import { format, getDay, startOfWeek, type Locale } from 'date-fns';
+import { differenceInCalendarDays, format, getDay, startOfWeek, type Locale } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Calendar, Components, DateLocalizer, dateFnsLocalizer, Views, ViewsProps } from 'react-big-calendar';
@@ -97,7 +97,7 @@ export const ScheduleCalendar = memo(() => {
                 hasHadEventsRef.current = true;
                 const skeletonBlueprint = eventsInCalendar
                     .map((event) => {
-                        const dayOffset = event.start.getDay() - 1;
+                        const dayOffset = differenceInCalendarDays(event.start, BASE_DATE);
                         return {
                             dayOffset,
                             startHour: event.start.getHours(),

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -97,7 +97,7 @@ export const ScheduleCalendar = memo(() => {
                 hasHadEventsRef.current = true;
                 const skeletonBlueprint = eventsInCalendar
                     .map((event) => {
-                        const dayOffset = event.start.getDate() - BASE_DATE.getDate();
+                        const dayOffset = event.start.getDay() - 1;
                         return {
                             dayOffset,
                             startHour: event.start.getHours(),
@@ -106,7 +106,7 @@ export const ScheduleCalendar = memo(() => {
                             endMinute: event.end.getMinutes(),
                         };
                     })
-                    .filter((blueprint) => blueprint.dayOffset >= 0 && blueprint.dayOffset <= 6);
+                    .filter((blueprint) => blueprint.dayOffset >= -1 && blueprint.dayOffset <= 5);
 
                 if (skeletonBlueprint.length > 0) {
                     setLocalStorageSkeletonBlueprint(JSON.stringify(skeletonBlueprint));


### PR DESCRIPTION
## Summary
- Sunday courses are stored on new Date(2018, 0, 0) = Dec 31, 2017 in calendarizeHelpers.ts                                
- The old skeleton blueprint calculation used event.start.getDate() - BASE_DATE.getDate() which returned 31 - 1 = 30 for Sunday events, failing the >= 0 && <= 6 filter and dropping Sunday entirely from the saved skeleton                        
- Fixed by using event.start.getDay() - 1 instead (Sun→-1, Mon→0, …, Sat→5) and updating the filter bounds to >= -1 && <= 5

<img width="682" height="761" alt="image" src="https://github.com/user-attachments/assets/02d94ae3-857b-459a-b6e9-f9ba736c869d" />

## Test Plan
- Add a Sunday course to your schedule                                                                                     
- Reload the page — the loading skeleton should show an event in the Sunday column
- Verify Mon–Sat courses still render correctly in the skeleton

## Issues

Closes #1631 

<!-- [Optional]
## Future Followup
-->
