### PR TITLE
fix: prevent scrolling to the bottom when loading calendar

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -397,6 +397,7 @@ export const ScheduleCalendar = memo(() => {
                     }}
                     min={getStartTime()}
                     max={CALENDAR_MAX_DATE}
+                    scrollToTime={getStartTime()}
                     events={events}
                     eventPropGetter={eventStyleGetter}
                     dayPropGetter={dayStyleGetter}


### PR DESCRIPTION
## Summary
Before replacing `moment` with `date-fns`, loading AntAlmanac would position the calendar at the top (7am), but after it would by default lock the calendar to the bottom (10pm).

While minor, I think it makes more sense (from a web perspective) to scroll down to see more instead of scrolling up.

## Test Plan
- Load AntAlmanac on any resolution that requires the calendar to scroll to view all events.

## Issues
regression from https://github.com/icssc/AntAlmanac/pull/1615


https://github.com/user-attachments/assets/8af69f0d-0052-43a4-aa25-dacf952ad6e3