### PR TITLE
feat: New GPA Display

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -136,18 +136,6 @@ function GradesPopup(props: GradesPopupProps) {
 
     return (
         <Box sx={{ padding: '4px' }}>
-            {instructor && (
-                <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '.5rem' }}>
-                    <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
-                        <ToggleButton value="instructor" sx={{ textTransform: 'none', paddingX: 1.5 }}>
-                            {instructor}
-                        </ToggleButton>
-                        <ToggleButton value="overall" sx={{ textTransform: 'none', paddingX: 1.5 }}>
-                            Overall
-                        </ToggleButton>
-                    </ToggleButtonGroup>
-                </Box>
-            )}
             <Typography
                 sx={{
                     marginTop: '.5rem',
@@ -158,6 +146,18 @@ function GradesPopup(props: GradesPopupProps) {
                     marginBottom: '.5rem',
                 }}
             >
+                {instructor && (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '.5rem' }}>
+                        <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
+                            <ToggleButton value="instructor" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                                {instructor}
+                            </ToggleButton>
+                            <ToggleButton value="overall" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                                Overall
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    </Box>
+                )}
                 {graphTitle}
             </Typography>
             <Link

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -80,9 +80,10 @@ function GradesPopup(props: GradesPopupProps) {
             return `${deptCode} ${courseNumber}${instructorLabel}`;
         }
         // GPA is `null` if the class is pass/no-pass only.
-        return `${deptCode} ${courseNumber}${instructorLabel} | Average GPA: ${
-            activeData.courseGrades.averageGPA?.toFixed(2) ?? 'n/a'
-        }`;
+        const courseLabel = `${deptCode} ${courseNumber}${instructorLabel}`;
+        const instructorGPA = activeData.courseGrades.averageGPA?.toFixed(2) ?? 'n/a';
+
+        return `${courseLabel} | Average GPA: ${instructorGPA}`;
     }, [activeData, view, deptCode, courseNumber, instructor]);
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -146,19 +146,38 @@ function GradesPopup(props: GradesPopupProps) {
                     marginBottom: '.5rem',
                 }}
             >
+                {graphTitle}
+
                 {instructor && (
                     <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '.5rem' }}>
                         <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
-                            <ToggleButton value="instructor" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                            <ToggleButton
+                                value="instructor"
+                                sx={{
+                                    textTransform: 'none',
+                                    paddingX: 1,
+                                    paddingY: 0.25,
+                                    fontSize: '0.75rem',
+                                    minHeight: '24px',
+                                }}
+                            >
                                 {instructor}
                             </ToggleButton>
-                            <ToggleButton value="overall" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                            <ToggleButton
+                                value="overall"
+                                sx={{
+                                    textTransform: 'none',
+                                    paddingX: 1,
+                                    paddingY: 0.25,
+                                    fontSize: '0.75rem',
+                                    minHeight: '24px',
+                                }}
+                            >
                                 Overall
                             </ToggleButton>
                         </ToggleButtonGroup>
                     </Box>
                 )}
-                {graphTitle}
             </Typography>
             <Link
                 href={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${encodedDept}&classNum=${courseNumber}&code=&submit=Submit`}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -74,6 +74,10 @@ function GradesPopup(props: GradesPopupProps) {
 
     const activeData = view === 'instructor' ? instructorData : overallData;
 
+    const hasData = useMemo(() => {
+        return activeData?.grades.some((g) => g.all > 0);
+    }, [activeData]);
+
     const graphTitle = useMemo(() => {
         const instructorLabel = view === 'instructor' && instructor ? ` — ${instructor}` : '';
         if (!activeData) {
@@ -177,7 +181,7 @@ function GradesPopup(props: GradesPopupProps) {
                     </ToggleButtonGroup>
                 </Box>
             )}
-            {activeData ? (
+            {activeData && hasData ? (
                 <Link
                     href={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${encodedDept}&classNum=${courseNumber}&code=&submit=Submit`}
                     target="_blank"

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -75,10 +75,10 @@ function GradesPopup(props: GradesPopupProps) {
     const activeData = view === 'instructor' ? instructorData : overallData;
 
     const graphTitle = useMemo(() => {
-        if (!activeData) {
-            return 'Grades are not available for this class.';
-        }
         const instructorLabel = view === 'instructor' && instructor ? ` — ${instructor}` : '';
+        if (!activeData) {
+            return `${deptCode} ${courseNumber}${instructorLabel}`;
+        }
         // GPA is `null` if the class is pass/no-pass only.
         return `${deptCode} ${courseNumber}${instructorLabel} | Average GPA: ${
             activeData.courseGrades.averageGPA?.toFixed(2) ?? 'n/a'
@@ -121,7 +121,7 @@ function GradesPopup(props: GradesPopupProps) {
         );
     }
 
-    if (!activeData) {
+    if (!instructorData && !overallData) {
         return (
             <Box padding={1}>
                 <Typography variant="body1" align="center">
@@ -147,64 +147,83 @@ function GradesPopup(props: GradesPopupProps) {
                 }}
             >
                 {graphTitle}
-
-                {instructor && (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '.5rem' }}>
-                        <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
-                            <ToggleButton
-                                value="instructor"
-                                sx={{
-                                    textTransform: 'none',
-                                    paddingX: 1,
-                                    paddingY: 0.25,
-                                    fontSize: '0.75rem',
-                                    minHeight: '24px',
-                                }}
-                            >
-                                {instructor}
-                            </ToggleButton>
-                            <ToggleButton
-                                value="overall"
-                                sx={{
-                                    textTransform: 'none',
-                                    paddingX: 1,
-                                    paddingY: 0.25,
-                                    fontSize: '0.75rem',
-                                    minHeight: '24px',
-                                }}
-                            >
-                                Overall
-                            </ToggleButton>
-                        </ToggleButtonGroup>
-                    </Box>
-                )}
             </Typography>
-            <Link
-                href={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${encodedDept}&classNum=${courseNumber}&code=&submit=Submit`}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={{ display: 'flex', height, width }}
-            >
-                <ResponsiveContainer width="95%" height="95%">
-                    <BarChart data={activeData.grades} style={{ cursor: 'pointer' }}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="name" tick={{ fontSize: 12, fill: axisColor }} />
-                        <YAxis tick={{ fontSize: 12, fill: axisColor }} width={40} unit="%" />
-                        <Tooltip
-                            content={({ active, payload, label }) => (
-                                <GradeTooltip
-                                    active={active ?? false}
-                                    payload={(payload as Array<Payload>) ?? null}
-                                    label={label ?? ''}
-                                />
-                            )}
-                            position={{ y: 100 }}
-                            offset={-5}
-                        />
-                        <Bar dataKey="all" fill="#5182ed" />
-                    </BarChart>
-                </ResponsiveContainer>
-            </Link>
+            {instructor && (
+                <Box sx={{ display: 'flex', justifyContent: 'center', marginBottom: '.5rem' }}>
+                    <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
+                        <ToggleButton
+                            value="instructor"
+                            sx={{
+                                textTransform: 'none',
+                                paddingX: 1,
+                                paddingY: 0.25,
+                                fontSize: '0.75rem',
+                                minHeight: '24px',
+                            }}
+                        >
+                            {instructor}
+                        </ToggleButton>
+                        <ToggleButton
+                            value="overall"
+                            sx={{
+                                textTransform: 'none',
+                                paddingX: 1,
+                                paddingY: 0.25,
+                                fontSize: '0.75rem',
+                                minHeight: '24px',
+                            }}
+                        >
+                            Overall
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                </Box>
+            )}
+            {activeData ? (
+                <Link
+                    href={`https://zotistics.com/?&selectQuarter=&selectYear=&selectDep=${encodedDept}&classNum=${courseNumber}&code=&submit=Submit`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ display: 'flex', height, width }}
+                >
+                    <ResponsiveContainer width="95%" height="95%">
+                        <BarChart data={activeData.grades} style={{ cursor: 'pointer' }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="name" tick={{ fontSize: 12, fill: axisColor }} />
+                            <YAxis tick={{ fontSize: 12, fill: axisColor }} width={40} unit="%" />
+                            <Tooltip
+                                content={({ active, payload, label }) => (
+                                    <GradeTooltip
+                                        active={active ?? false}
+                                        payload={(payload as Array<Payload>) ?? null}
+                                        label={label ?? ''}
+                                    />
+                                )}
+                                position={{ y: 100 }}
+                                offset={-5}
+                            />
+                            <Bar dataKey="all" fill="#5182ed" />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </Link>
+            ) : (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        height,
+                        width,
+                        padding: 2,
+                        boxSizing: 'border-box',
+                    }}
+                >
+                    <Typography variant="body2" align="center" color="text.secondary">
+                        {view === 'instructor'
+                            ? "This instructor doesn't have a specific GPA for this course."
+                            : 'No data available.'}
+                    </Typography>
+                </Box>
+            )}
         </Box>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -1,9 +1,11 @@
-import { Box, Link, Typography, Skeleton } from '@mui/material';
+import { Grades, type GradesProps } from '$lib/grades';
+import { useThemeStore } from '$stores/SettingsStore';
+import { Box, Link, ToggleButton, ToggleButtonGroup, Typography, Skeleton } from '@mui/material';
 import { useState, useEffect, useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-import { Grades, type GradesProps } from '$lib/grades';
-import { useThemeStore } from '$stores/SettingsStore';
+type GradeView = 'instructor' | 'overall';
+
 export interface GradeData {
     grades: {
         name: string;
@@ -62,40 +64,54 @@ function GradesPopup(props: GradesPopupProps) {
 
     const [loading, setLoading] = useState(true);
 
-    const [gradeData, setGradeData] = useState<GradeData>();
+    const [instructorData, setInstructorData] = useState<GradeData>();
+    const [overallData, setOverallData] = useState<GradeData>();
+    const [view, setView] = useState<GradeView>(instructor ? 'instructor' : 'overall');
 
     const width = useMemo(() => (isMobile ? 250 : 400), [isMobile]);
 
     const height = useMemo(() => (isMobile ? 150 : 200), [isMobile]);
 
-    const graphTitle = useMemo(() => {
-        return gradeData
-            ? `${deptCode} ${courseNumber}${
-                  instructor ? ` — ${instructor}` : ''
-                  // GPA is `null` if the class is pass/no-pass only.
-                  // This is more correct compared to returning a zero GPA,
-                  // which so far has not happened, but is entirely possible.
-              } | Average GPA: ${gradeData.courseGrades.averageGPA?.toFixed(2) ?? 'n/a'}`
-            : 'Grades are not available for this class.';
-    }, [gradeData, deptCode, courseNumber, instructor]);
+    const activeData = view === 'instructor' ? instructorData : overallData;
 
-    // const gpaString = useMemo(
-    //     () => (gradeData ? `Average GPA: ${gradeData.courseGrades.averageGPA.toFixed(2)}` : ''),
-    //     [gradeData]
-    // );
+    const graphTitle = useMemo(() => {
+        if (!activeData) {
+            return 'Grades are not available for this class.';
+        }
+        const instructorLabel = view === 'instructor' && instructor ? ` — ${instructor}` : '';
+        // GPA is `null` if the class is pass/no-pass only.
+        return `${deptCode} ${courseNumber}${instructorLabel} | Average GPA: ${
+            activeData.courseGrades.averageGPA?.toFixed(2) ?? 'n/a'
+        }`;
+    }, [activeData, view, deptCode, courseNumber, instructor]);
 
     useEffect(() => {
         if (loading === false) {
             return;
         }
 
-        getGradeData(deptCode, courseNumber, instructor).then((result) => {
-            if (result) {
-                setGradeData(result);
-            }
-            setLoading(false);
-        });
+        const fetches: Promise<unknown>[] = [
+            getGradeData(deptCode, courseNumber, '').then((result) => {
+                if (result) setOverallData(result);
+            }),
+        ];
+
+        if (instructor) {
+            fetches.push(
+                getGradeData(deptCode, courseNumber, instructor).then((result) => {
+                    if (result) setInstructorData(result);
+                })
+            );
+        }
+
+        Promise.all(fetches).finally(() => setLoading(false));
     }, [loading, deptCode, courseNumber, instructor]);
+
+    const handleViewChange = (_event: React.MouseEvent<HTMLElement>, newView: GradeView | null) => {
+        if (newView !== null) {
+            setView(newView);
+        }
+    };
 
     if (loading) {
         return (
@@ -105,7 +121,7 @@ function GradesPopup(props: GradesPopupProps) {
         );
     }
 
-    if (!gradeData) {
+    if (!activeData) {
         return (
             <Box padding={1}>
                 <Typography variant="body1" align="center">
@@ -120,6 +136,18 @@ function GradesPopup(props: GradesPopupProps) {
 
     return (
         <Box sx={{ padding: '4px' }}>
+            {instructor && (
+                <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '.5rem' }}>
+                    <ToggleButtonGroup value={view} exclusive onChange={handleViewChange} size="small">
+                        <ToggleButton value="instructor" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                            {instructor}
+                        </ToggleButton>
+                        <ToggleButton value="overall" sx={{ textTransform: 'none', paddingX: 1.5 }}>
+                            Overall
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                </Box>
+            )}
             <Typography
                 sx={{
                     marginTop: '.5rem',
@@ -139,7 +167,7 @@ function GradesPopup(props: GradesPopupProps) {
                 sx={{ display: 'flex', height, width }}
             >
                 <ResponsiveContainer width="95%" height="95%">
-                    <BarChart data={gradeData.grades} style={{ cursor: 'pointer' }}>
+                    <BarChart data={activeData.grades} style={{ cursor: 'pointer' }}>
                         <CartesianGrid strokeDasharray="3 3" />
                         <XAxis dataKey="name" tick={{ fontSize: 12, fill: axisColor }} />
                         <YAxis tick={{ fontSize: 12, fill: axisColor }} width={40} unit="%" />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -158,7 +158,6 @@ function GradesPopup(props: GradesPopupProps) {
                                 paddingX: 1,
                                 paddingY: 0.25,
                                 fontSize: '0.75rem',
-                                minHeight: '24px',
                             }}
                         >
                             {instructor}
@@ -170,7 +169,6 @@ function GradesPopup(props: GradesPopupProps) {
                                 paddingX: 1,
                                 paddingY: 0.25,
                                 fontSize: '0.75rem',
-                                minHeight: '24px',
                             }}
                         >
                             Overall

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -3,7 +3,6 @@ import { CourseInfoButton } from '$components/RightPane/SectionTable/CourseInfo/
 import { CourseInfoSearchButton } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoSearchButton';
 import { EnrollmentColumnHeader } from '$components/RightPane/SectionTable/EnrollmentColumnHeader';
 import { EnrollmentHistoryPopup } from '$components/RightPane/SectionTable/EnrollmentHistoryPopup';
-import GradesPopup from '$components/RightPane/SectionTable/GradesPopup';
 import type { SectionTableProps } from '$components/RightPane/SectionTable/SectionTable.types';
 import { SectionTableBody } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBody';
 import { useIsMobile } from '$hooks/useIsMobile';
@@ -11,7 +10,7 @@ import analyticsEnum from '$lib/analytics/analytics';
 import { SECTION_TABLE_COLUMNS, type SectionTableColumn, useColumnStore } from '$stores/ColumnStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
-import { Assessment, Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
+import { Route, ShowChart as ShowChartIcon } from '@mui/icons-material';
 import { Alert, Box, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useMemo } from 'react';
 
@@ -105,20 +104,6 @@ function SectionTable(props: SectionTableProps) {
                     text="Planner"
                     icon={<Route />}
                     redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
-                />
-
-                <CourseInfoButton
-                    analyticsCategory={analyticsCategory}
-                    analyticsAction={analyticsEnum.classSearch.actions.CLICK_ZOTISTICS}
-                    text="Zotistics"
-                    icon={<Assessment />}
-                    popupContent={
-                        <GradesPopup
-                            deptCode={courseDetails.deptCode}
-                            courseNumber={courseDetails.courseNumber}
-                            isMobile={isMobile}
-                        />
-                    }
                 />
 
                 <CourseInfoButton

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -20,6 +20,10 @@ async function getGpaData(deptCode: string, courseNumber: string, instructors: s
         }
     }
 
+    if (namedInstructors.length > 0) {
+        return { gpa: '', instructor: namedInstructors[0] };
+    }
+
     return undefined;
 }
 
@@ -62,7 +66,7 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
                 sx={{ fontFamily: 'inherit', fontSize: 'unset', color: secondaryColor, fontWeight: 700 }}
                 onClick={handleClick}
             >
-                {gpa}
+                {gpa || (instructor ? 'GPA' : '')}
             </ButtonBase>
 
             <Popover

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -1,11 +1,10 @@
-import { Button, Popover } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
-
 import GradesPopup from '$components/RightPane/SectionTable/GradesPopup';
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useSecondaryColor } from '$hooks/useSecondaryColor';
 import { Grades } from '$lib/grades';
+import { ButtonBase, Popover } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
 
 async function getGpaData(deptCode: string, courseNumber: string, instructors: string[]) {
     const namedInstructors = instructors.filter((instructor) => instructor !== 'STAFF');
@@ -59,20 +58,13 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
 
     return (
         <TableBodyCellContainer>
-            <Button
-                sx={{
-                    paddingX: 0,
-                    paddingY: 0,
-                    minWidth: 0,
-                    fontWeight: 400,
-                    fontSize: '1rem',
-                    color: secondaryColor,
-                }}
+            <ButtonBase
+                sx={{ fontFamily: 'inherit', fontSize: 'unset', color: secondaryColor, fontWeight: 700 }}
                 onClick={handleClick}
-                variant="text"
             >
                 {gpa}
-            </Button>
+            </ButtonBase>
+
             <Popover
                 open={Boolean(anchorEl)}
                 onClose={hideDistribution}
@@ -85,6 +77,7 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
                     instructor={instructor}
                     isMobile={isMobile}
                 />
+                <GradesPopup deptCode={deptCode} courseNumber={courseNumber} isMobile={isMobile} />
             </Popover>
         </TableBodyCellContainer>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -77,7 +77,6 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
                     instructor={instructor}
                     isMobile={isMobile}
                 />
-                <GradesPopup deptCode={deptCode} courseNumber={courseNumber} isMobile={isMobile} />
             </Popover>
         </TableBodyCellContainer>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -20,11 +20,10 @@ async function getGpaData(deptCode: string, courseNumber: string, instructors: s
         }
     }
 
-    if (namedInstructors.length > 0) {
-        return { gpa: '', instructor: namedInstructors[0] };
-    }
-
-    return undefined;
+    return {
+        gpa: '',
+        instructor: namedInstructors[0] || '',
+    };
 }
 
 interface GpaCellProps {
@@ -66,7 +65,7 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
                 sx={{ fontFamily: 'inherit', fontSize: 'unset', color: secondaryColor, fontWeight: 700 }}
                 onClick={handleClick}
             >
-                {gpa || (instructor ? 'GPA' : '')}
+                {gpa || 'GPA'}
             </ButtonBase>
 
             <Popover

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -51,10 +51,8 @@ export const GpaCell = ({ deptCode, courseNumber, instructors }: GpaCellProps) =
     useEffect(() => {
         getGpaData(deptCode, courseNumber, instructors)
             .then((data) => {
-                if (data) {
-                    setGpa(data.gpa);
-                    setInstructor(data.instructor);
-                }
+                setGpa(data?.gpa);
+                setInstructor(data?.instructor);
             })
             .catch(console.log);
     }, [deptCode, courseNumber, instructors]);


### PR DESCRIPTION
## Summary
Refactor zotistics GPA analytics and instructor GPA analytics into the section table GPA popover. We can now view both statistic graphs from the same popover. 

<img width="1556" height="1408" alt="image" src="https://github.com/user-attachments/assets/4a934b79-5e4a-45b5-a808-c8a2ac500062" />

## Test Plan
- Check button group toggles for both instructor GPA and course GPA 
- Verify empty graphs for instructors who don't have any GPA stats
- Verify 'GPA' placeholder for instructors who don't have any GPA stats

## Issues

Closes #1586 

<!-- [Optional]
## Future Followup
-->
