### PR TITLE
fix: drop broken exportScheduleData/importScheduleData trpc procedures

### DIFF
--- a/apps/antalmanac/src/backend/routers/userData.ts
+++ b/apps/antalmanac/src/backend/routers/userData.ts
@@ -4,7 +4,7 @@ import { oauth } from '$src/backend/lib/auth/oauth';
 import { mangleDuplicateScheduleNames } from '$src/backend/lib/formatting';
 import { RDS } from '$src/backend/lib/rds';
 import { procedure, protectedProcedure, router } from '$src/backend/trpc';
-import { type User, type ScheduleSaveState, ScheduleSaveStateSchema } from '@packages/antalmanac-types';
+import { type ScheduleSaveState } from '@packages/antalmanac-types';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { CodeChallengeMethod, decodeIdToken, generateCodeVerifier, generateState, type OAuth2Tokens } from 'arctic';
@@ -295,113 +295,6 @@ const userDataRouter = router({
             logoutUrl: oidcLogoutUrl.toString(),
         };
     }),
-
-    /**
-     * Exports schedule data for a user as JSON.
-     * This allows users to export their schedule data to transfer between environments (prod/staging).
-     * @param input - An object containing the user ID.
-     * @returns The schedule data in JSON format.
-     */
-    exportScheduleData: procedure.input(userInputSchema.assert).query(async ({ input }) => {
-        if ('userId' in input) {
-            const userData = await RDS.getUserDataByUid(db, input.userId);
-            if (!userData) {
-                throw new TRPCError({
-                    code: 'NOT_FOUND',
-                    message: 'User not found',
-                });
-            }
-            return userData.userData;
-        } else {
-            throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message: 'Invalid input: userId is required',
-            });
-        }
-    }),
-
-    /**
-     * Imports schedule data from JSON.
-     * Validates the imported data before saving to prevent invalid data from being stored.
-     * @param input - An object containing the user ID and the schedule data to import.
-     * @returns Success status.
-     */
-    importScheduleData: procedure
-        .input(
-            z.object({
-                userId: z.string(),
-                scheduleData: z.unknown(),
-            })
-        )
-        .mutation(async ({ input }) => {
-            let validatedScheduleData: ScheduleSaveState;
-            try {
-                validatedScheduleData = ScheduleSaveStateSchema.assert(input.scheduleData);
-            } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : 'Unknown validation error';
-                throw new TRPCError({
-                    code: 'BAD_REQUEST',
-                    message: `Invalid schedule data format: ${errorMessage}`,
-                });
-            }
-
-            if (
-                validatedScheduleData.scheduleIndex < 0 ||
-                validatedScheduleData.scheduleIndex >= validatedScheduleData.schedules.length
-            ) {
-                validatedScheduleData.scheduleIndex =
-                    validatedScheduleData.schedules.length > 0 ? validatedScheduleData.schedules.length - 1 : 0;
-            }
-
-            for (const schedule of validatedScheduleData.schedules) {
-                for (const course of schedule.courses) {
-                    if (typeof course.sectionCode !== 'string' || isNaN(parseInt(course.sectionCode))) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid section code: ${course.sectionCode}`,
-                        });
-                    }
-                    if (typeof course.term !== 'string' || course.term.length === 0) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid term: ${course.term}`,
-                        });
-                    }
-                    if (typeof course.color !== 'string') {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid color: ${course.color}`,
-                        });
-                    }
-                }
-
-                for (const event of schedule.customEvents) {
-                    if (event.days.length !== 7) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: 'Invalid custom event days: must be an array of 7 booleans',
-                        });
-                    }
-                }
-            }
-
-            validatedScheduleData.schedules = mangleDuplicateScheduleNames(validatedScheduleData.schedules);
-
-            const userData: User = {
-                id: input.userId,
-                userData: validatedScheduleData,
-            };
-
-            await RDS.upsertUserData(db, userData).catch((error) => {
-                console.error('RDS Failed to import user data:', error);
-                throw new TRPCError({
-                    code: 'INTERNAL_SERVER_ERROR',
-                    message: 'Failed to import schedule data',
-                });
-            });
-
-            return { success: true };
-        }),
 });
 
 export default userDataRouter;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the build error reported on `kwu/protect-remaining-procedures-0863`:

```
./src/backend/routers/userData.ts:305:41
Type error: Cannot find name 'userInputSchema'. Did you mean 'saveInputSchema'?

  305 |     exportScheduleData: procedure.input(userInputSchema.assert).query(async ({ input }) => {
      |                                         ^
Next.js build worker exited with code: 1 and signal: null
```

`exportScheduleData` and `importScheduleData` were introduced in the Dev mode PR (#1565) and merged onto this branch, but they reference several symbols that were already gone:

- `userInputSchema` was deleted in `46c48f3b` ("refactor: rename guest-only endpoints...") after being flagged as unused; `exportScheduleData` is the only caller that came back via the `chore: merge main` merge. This is what the build is failing on.
- `exportScheduleData` also calls `RDS.getUserDataByUid`, which no longer exists — it was renamed to `getGuestScheduleByUsername` in `b77e859d` with a different signature and return shape.
- `importScheduleData` calls `RDS.upsertUserData(db, userData)` with the wrong arity; the current signature is `(db, userId, saveState)` after `d7c1d8aa` / `69120e62`.

Both procedures are also unused by the frontend:

- The Dev mode Import/Export UI (`apps/antalmanac/src/components/Header/Import.tsx`, `Export.tsx`) does JSON download/upload entirely client-side against `AppStore`. A repo-wide grep for `exportScheduleData` / `importScheduleData` turns up only the router definition itself.

And the shape they had is inconsistent with the goal of this branch:

- Both take a client-supplied `userId` to read or write arbitrary users' schedules — exactly the cross-user access pattern that `kwu/protect-remaining-procedures-0863` is removing everywhere else (`getUserByUid`, `saveUserData`, `flagImportedSchedule`, etc.).

Given all of the above, the cleanest fix is to remove the two dead-on-arrival endpoints and the now-unused imports. The Dev mode JSON import/export feature itself is unaffected, since it was never wired up through trpc to begin with.

## Test Plan

- `tsc --noEmit -p apps/antalmanac` no longer reports errors in `src/backend/routers/userData.ts` (the `userInputSchema` error is gone; remaining errors in the repo are pre-existing missing-asset issues — `$generated/searchData`, `loading.gif`, etc. — that require the `ANTEATER_API_KEY` secret to regenerate and are unrelated to this change).
- Full `next build` still fails later on those same missing generated assets, but gets past the type-check phase that was blocking us here.
- Verified no frontend callers of `trpc.userData.exportScheduleData` or `trpc.userData.importScheduleData` exist.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b64248b1-e06d-4c43-a4d6-0783936583a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b64248b1-e06d-4c43-a4d6-0783936583a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

