### PR TITLE
refactor: address PR #1648 review comments

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -60,6 +60,53 @@ const CALENDAR_COMPONENTS: Components<CalendarEvent, object> = {
 const BASE_DATE = new Date(2018, 0, 1);
 const CALENDAR_MAX_DATE = new Date(2018, 0, 1, 23);
 
+interface SkeletonBlueprint {
+    dayOffset: number;
+    startHour: number;
+    startMinute: number;
+    endHour: number;
+    endMinute: number;
+}
+
+function blueprintToSkeletonEvent(blueprint: SkeletonBlueprint): SkeletonEvent {
+    const start = new Date(BASE_DATE);
+    start.setDate(start.getDate() + blueprint.dayOffset);
+    start.setHours(blueprint.startHour, blueprint.startMinute, 0, 0);
+
+    const end = new Date(start);
+    end.setHours(blueprint.endHour, blueprint.endMinute, 0, 0);
+
+    return {
+        color: '#6d6d6d',
+        start,
+        end,
+        title: '',
+        isSkeletonEvent: true,
+    } as SkeletonEvent;
+}
+
+function createSkeletonEvents(): SkeletonEvent[] {
+    const savedDataString = getLocalStorageSkeletonBlueprint();
+
+    let skeletonBlueprints: SkeletonBlueprint[] | null = null;
+
+    if (savedDataString) {
+        const parsedData = JSON.parse(savedDataString);
+        if (Array.isArray(parsedData) && parsedData.length > 0) {
+            skeletonBlueprints = parsedData;
+        }
+    }
+
+    if (skeletonBlueprints) {
+        return skeletonBlueprints.map(blueprintToSkeletonEvent);
+    }
+
+    const randomIndex = Math.floor(Math.random() * skeletonBlueprintVariations.length);
+    const fallbackBlueprints = skeletonBlueprintVariations[randomIndex];
+
+    return fallbackBlueprints.map(blueprintToSkeletonEvent);
+}
+
 export const ScheduleCalendar = memo(() => {
     const [showFinalsSchedule, setShowFinalsSchedule] = useState(false);
     const [eventsInCalendar, setEventsInCalendar] = useState(() => AppStore.getEventsInCalendar());
@@ -127,63 +174,9 @@ export const ScheduleCalendar = memo(() => {
         }
     }, [eventsInCalendar, loadingSchedule]);
 
-    const blueprintToSkeletonEvent = useCallback(
-        (blueprint: {
-            dayOffset: number;
-            startHour: number;
-            startMinute: number;
-            endHour: number;
-            endMinute: number;
-        }): SkeletonEvent => {
-            const start = new Date(BASE_DATE);
-            start.setDate(start.getDate() + blueprint.dayOffset);
-            start.setHours(blueprint.startHour, blueprint.startMinute, 0, 0);
-
-            const end = new Date(start);
-            end.setHours(blueprint.endHour, blueprint.endMinute, 0, 0);
-
-            return {
-                color: '#6d6d6d',
-                start,
-                end,
-                title: '',
-                isSkeletonEvent: true,
-            } as SkeletonEvent;
-        },
-        []
-    );
-
-    const createSkeletonEvents = useCallback((): SkeletonEvent[] => {
-        const savedDataString = getLocalStorageSkeletonBlueprint();
-
-        let skeletonBlueprints: Array<{
-            dayOffset: number;
-            startHour: number;
-            startMinute: number;
-            endHour: number;
-            endMinute: number;
-        }> | null = null;
-
-        if (savedDataString) {
-            const parsedData = JSON.parse(savedDataString);
-            if (Array.isArray(parsedData) && parsedData.length > 0) {
-                skeletonBlueprints = parsedData;
-            }
-        }
-
-        if (skeletonBlueprints) {
-            return skeletonBlueprints.map(blueprintToSkeletonEvent);
-        }
-
-        const randomIndex = Math.floor(Math.random() * skeletonBlueprintVariations.length);
-        const fallbackBlueprints = skeletonBlueprintVariations[randomIndex];
-
-        return fallbackBlueprints.map(blueprintToSkeletonEvent);
-    }, [blueprintToSkeletonEvent]);
-
     const events = useMemo(
         () => (loadingSchedule ? createSkeletonEvents() : getEventsForCalendar()),
-        [loadingSchedule, createSkeletonEvents, getEventsForCalendar]
+        [loadingSchedule, getEventsForCalendar]
     );
 
     const toggleDisplayFinalsSchedule = useCallback(() => {

--- a/apps/antalmanac/src/providers/PostHog.tsx
+++ b/apps/antalmanac/src/providers/PostHog.tsx
@@ -22,7 +22,7 @@ if (typeof window !== 'undefined') {
 
 export default function AppPostHogProvider(props: Props) {
     if (!POSTHOG_KEY) {
-        return <>{props.children}</>;
+        return props.children;
     }
 
     return <PostHogProvider client={posthog}>{props.children}</PostHogProvider>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses review feedback on #1648:

- **`PostHog.tsx`**: Replace `return <>{props.children}</>` with `return props.children;` since the fragment was unnecessary (React 19 is fine returning children directly).
- **`CalendarRoot.tsx`**: Hoist `blueprintToSkeletonEvent` and `createSkeletonEvents` out of the `ScheduleCalendar` component. They do not close over any component state/props, so there's no reason for them to be re-created (even when wrapped in `useCallback`) on every render. Also extracted a `SkeletonBlueprint` interface to deduplicate the inline type.

The third review item (zustand shallow-select convention) was noted as optional ("not a big issue") by the reviewer and is intentionally left for a follow-up so the convention can be applied repo-wide in a single, focused change rather than piecemeal here.

## Test Plan

- `pnpm lint` passes with 0 warnings/errors
- Hoisted helpers retain identical behavior; they were already pure with respect to component state (only depended on module-level `BASE_DATE` and `skeletonBlueprintVariations`)

## Issues

Follow-up to review on #1648

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caa3c84d-c3bb-4575-9d9e-9f960054ce62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caa3c84d-c3bb-4575-9d9e-9f960054ce62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

