### PR TITLE
Auth: preserve exact path

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -1,7 +1,7 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
 import { warnMultipleTerms } from '$lib/helpers';
-import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
+import { setLocalStorageUserId, setLocalStorageDataCache, setLocalStorageAuthReturnPath } from '$lib/localStorage';
 import { isNativeIosApp, NATIVE_IOS_REDIRECT_URI } from '$lib/platform';
 import AppStore from '$stores/AppStore';
 import { deleteTempSaveData } from '$stores/localTempSaveDataHelpers';
@@ -389,6 +389,7 @@ export const loginUser = async () => {
         const authUrl = await trpc.userData.getGoogleAuthUrl.query(redirectUri ? { redirectUri } : undefined);
         if (authUrl) {
             cacheSchedule();
+            setLocalStorageAuthReturnPath(window.location.pathname + window.location.search + window.location.hash);
             window.location.href = authUrl.toString();
         }
     } catch (error) {

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -1,7 +1,7 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
 import { warnMultipleTerms } from '$lib/helpers';
-import { setLocalStorageUserId, setLocalStorageDataCache, setLocalStorageAuthReturnPath } from '$lib/localStorage';
+import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
 import { isNativeIosApp, NATIVE_IOS_REDIRECT_URI } from '$lib/platform';
 import AppStore from '$stores/AppStore';
 import { deleteTempSaveData } from '$stores/localTempSaveDataHelpers';
@@ -385,11 +385,13 @@ const cacheSchedule = () => {
 export const loginUser = async () => {
     try {
         const redirectUri = isNativeIosApp() ? NATIVE_IOS_REDIRECT_URI : undefined;
-
-        const authUrl = await trpc.userData.getGoogleAuthUrl.query(redirectUri ? { redirectUri } : undefined);
+        const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+        const authUrl = await trpc.userData.getGoogleAuthUrl.query({
+            ...(redirectUri ? { redirectUri } : {}),
+            returnTo,
+        });
         if (authUrl) {
             cacheSchedule();
-            setLocalStorageAuthReturnPath(window.location.pathname + window.location.search + window.location.hash);
             window.location.href = authUrl.toString();
         }
     } catch (error) {

--- a/apps/antalmanac/src/backend/routers/userData.ts
+++ b/apps/antalmanac/src/backend/routers/userData.ts
@@ -36,6 +36,44 @@ const saveGoogleSchema = type({
     state: 'string',
 });
 
+const getSafeAuthRedirectPath = (redirectUrl: string | null | undefined, requestUrl: string): string => {
+    if (!redirectUrl) {
+        return '/';
+    }
+
+    let requestOrigin: string;
+    try {
+        requestOrigin = new URL(requestUrl).origin;
+    } catch {
+        requestOrigin = new URL(GOOGLE_REDIRECT_URI).origin;
+    }
+
+    const candidates: string[] = [];
+    try {
+        const decodedRedirectUrl = decodeURIComponent(redirectUrl);
+        candidates.push(decodedRedirectUrl);
+    } catch {
+        // Ignore malformed encoding and continue with the raw value.
+    }
+
+    if (!candidates.includes(redirectUrl)) {
+        candidates.push(redirectUrl);
+    }
+
+    for (const candidate of candidates) {
+        try {
+            const parsedRedirectUrl = new URL(candidate, requestOrigin);
+            if (parsedRedirectUrl.origin === requestOrigin) {
+                return `${parsedRedirectUrl.pathname}${parsedRedirectUrl.search}${parsedRedirectUrl.hash}`;
+            }
+        } catch {
+            // Ignore malformed candidate and try next.
+        }
+    }
+
+    return '/';
+};
+
 const userDataRouter = router({
     getUserAndAccountBySessionToken: protectedProcedure.query(async ({ ctx }) => {
         return await RDS.getUserAndAccountBySessionToken(db, ctx.sessionToken);
@@ -118,6 +156,7 @@ const userDataRouter = router({
                 .object({
                     prompt: z.enum(['none', 'consent']).optional(),
                     redirectUri: z.enum(ALLOWED_REDIRECT_URIS).optional(),
+                    returnTo: z.string().optional(),
                 })
                 .optional()
         )
@@ -156,12 +195,11 @@ const userDataRouter = router({
             ctx.resHeaders?.append('Set-Cookie', `oauth_redirect_uri=${redirectUri}; ${cookieOptions}`);
 
             const referer = ctx.req.headers.get('referer');
-            if (referer) {
-                ctx.resHeaders?.append(
-                    'Set-Cookie',
-                    `auth_redirect_url=${encodeURIComponent(referer)}; ${cookieOptions}`
-                );
-            }
+            const redirectUrl = getSafeAuthRedirectPath(input?.returnTo ?? referer, ctx.req.url);
+            ctx.resHeaders?.append(
+                'Set-Cookie',
+                `auth_redirect_url=${encodeURIComponent(redirectUrl)}; ${cookieOptions}`
+            );
 
             return url;
         }),
@@ -185,7 +223,7 @@ const userDataRouter = router({
             const storedState = cookies['oauth_state'] ?? null;
             const codeVerifier = cookies['oauth_code_verifier'] ?? null;
             const pinnedRedirectUri = cookies['oauth_redirect_uri'] ?? null;
-            const redirectUrl = decodeURIComponent(cookies['auth_redirect_url'] ?? '/');
+            const redirectUrl = getSafeAuthRedirectPath(cookies['auth_redirect_url'], ctx.req.url);
 
             // Delete cookies via response headers
             const isProduction = NODE_ENV === 'production';

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -1,4 +1,5 @@
 import trpc from '$lib/api/trpc';
+import { setLocalStorageAuthReturnPath } from '$lib/localStorage';
 import { hasSsoCookie } from '$lib/ssoCookie';
 import { useSessionStore } from '$stores/SessionStore';
 import { useEffect, useRef } from 'react';
@@ -43,6 +44,7 @@ export function AutoSignIn() {
             }
 
             try {
+                setLocalStorageAuthReturnPath(window.location.pathname + window.location.search + window.location.hash);
                 const authUrl = await trpc.userData.getGoogleAuthUrl.query({ prompt: 'none' });
                 window.location.href = authUrl.toString();
             } catch {

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -1,5 +1,4 @@
 import trpc from '$lib/api/trpc';
-import { setLocalStorageAuthReturnPath } from '$lib/localStorage';
 import { hasSsoCookie } from '$lib/ssoCookie';
 import { useSessionStore } from '$stores/SessionStore';
 import { useEffect, useRef } from 'react';
@@ -44,8 +43,8 @@ export function AutoSignIn() {
             }
 
             try {
-                setLocalStorageAuthReturnPath(window.location.pathname + window.location.search + window.location.hash);
-                const authUrl = await trpc.userData.getGoogleAuthUrl.query({ prompt: 'none' });
+                const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+                const authUrl = await trpc.userData.getGoogleAuthUrl.query({ prompt: 'none', returnTo });
                 window.location.href = authUrl.toString();
             } catch {
                 // Silent SSO failed (e.g. backend unavailable). Don't retry.

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -24,7 +24,6 @@ enum LocalStorageKeys {
     newUser = 'newUser',
     importedUser = 'importedUser',
     fromLoading = 'fromLoading',
-    authReturnPath = 'authReturnPath',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
 }
@@ -41,18 +40,6 @@ export function getLocalStorageFromLoading() {
 
 export function removeLocalStorageFromLoading() {
     window.localStorage.removeItem(LSK.fromLoading);
-}
-
-export function setLocalStorageAuthReturnPath(value: string) {
-    window.localStorage.setItem(LSK.authReturnPath, value);
-}
-
-export function getLocalStorageAuthReturnPath() {
-    return window.localStorage.getItem(LSK.authReturnPath);
-}
-
-export function removeLocalStorageAuthReturnPath() {
-    window.localStorage.removeItem(LSK.authReturnPath);
 }
 
 export function setLocalStorageImportedUser(value: string) {

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -24,6 +24,7 @@ enum LocalStorageKeys {
     newUser = 'newUser',
     importedUser = 'importedUser',
     fromLoading = 'fromLoading',
+    authReturnPath = 'authReturnPath',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
 }
@@ -40,6 +41,18 @@ export function getLocalStorageFromLoading() {
 
 export function removeLocalStorageFromLoading() {
     window.localStorage.removeItem(LSK.fromLoading);
+}
+
+export function setLocalStorageAuthReturnPath(value: string) {
+    window.localStorage.setItem(LSK.authReturnPath, value);
+}
+
+export function getLocalStorageAuthReturnPath() {
+    return window.localStorage.getItem(LSK.authReturnPath);
+}
+
+export function removeLocalStorageAuthReturnPath() {
+    window.localStorage.removeItem(LSK.authReturnPath);
 }
 
 export function setLocalStorageImportedUser(value: string) {

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -53,18 +53,23 @@ export function AuthPage() {
             return;
         }
 
+        // Compute (and immediately clear) the return path at the top so that
+        // every exit — success, error, or early-return — uses the same value
+        // and never leaves a stale authReturnPath in localStorage.
+        const returnPath = getSafeReturnPath();
+
         try {
             // Silent SSO returned an error — the auth server has no session.
             if (searchParams.get('error') === 'login_required') {
                 clearSsoCookie();
-                window.location.href = '/';
+                window.location.href = returnPath;
                 return;
             }
 
             const code = searchParams.get('code');
             const state = searchParams.get('state');
             if (!code || !state) {
-                window.location.href = '/';
+                window.location.href = returnPath;
                 return;
             }
 
@@ -78,7 +83,6 @@ export function AuthPage() {
             const fromLoading = getLocalStorageFromLoading() ?? '';
             const savedUserId = getLocalStorageUserId() ?? '';
             const savedData = getLocalStorageDataCache() ?? '';
-            const returnPath = getSafeReturnPath();
 
             if (newUser) {
                 setLocalStorageOnFirstSignin('true');
@@ -87,7 +91,7 @@ export function AuthPage() {
             }
 
             if (!providerId) {
-                window.location.href = '/';
+                window.location.href = returnPath;
                 return;
             }
 
@@ -151,7 +155,7 @@ export function AuthPage() {
         } catch (error) {
             console.error('Error during authentication', error);
             clearSsoCookie();
-            window.location.href = '/';
+            window.location.href = returnPath;
         }
     }, [searchParams]);
 

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -2,10 +2,12 @@ import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreAct
 import { LoadingScreen } from '$components/LoadingScreen';
 import trpc from '$lib/api/trpc';
 import {
+    getLocalStorageAuthReturnPath,
     getLocalStorageDataCache,
     getLocalStorageFromLoading,
     setLocalStorageImportedUser,
     getLocalStorageUserId,
+    removeLocalStorageAuthReturnPath,
     removeLocalStorageUserId,
     removeLocalStorageImportedUser,
     removeLocalStorageDataCache,
@@ -16,6 +18,30 @@ import { clearSsoCookie, setSsoCookie } from '$lib/ssoCookie';
 import AppStore from '$stores/AppStore';
 import { useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
+
+function getSafeReturnPath() {
+    const candidate = getLocalStorageAuthReturnPath();
+    removeLocalStorageAuthReturnPath();
+
+    if (!candidate) {
+        return '/';
+    }
+
+    if (candidate.startsWith('/') && !candidate.startsWith('//')) {
+        return candidate;
+    }
+
+    try {
+        const url = new URL(candidate, window.location.origin);
+        if (url.origin === window.location.origin) {
+            return `${url.pathname}${url.search}${url.hash}`;
+        }
+    } catch {
+        // Ignore malformed candidate and fallback to root.
+    }
+
+    return '/';
+}
 
 export function AuthPage() {
     const [searchParams] = useSearchParams();
@@ -52,6 +78,7 @@ export function AuthPage() {
             const fromLoading = getLocalStorageFromLoading() ?? '';
             const savedUserId = getLocalStorageUserId() ?? '';
             const savedData = getLocalStorageDataCache() ?? '';
+            const returnPath = getSafeReturnPath();
 
             if (newUser) {
                 setLocalStorageOnFirstSignin('true');
@@ -71,7 +98,7 @@ export function AuthPage() {
                 removeLocalStorageFromLoading();
                 removeLocalStorageDataCache();
                 removeLocalStorageImportedUser();
-                window.location.href = '/';
+                window.location.href = returnPath;
                 return;
             }
 
@@ -79,7 +106,7 @@ export function AuthPage() {
             if (savedUserId === '' && savedData === '') {
                 removeLocalStorageDataCache();
                 removeLocalStorageImportedUser();
-                window.location.href = '/';
+                window.location.href = returnPath;
                 return;
             }
 
@@ -120,7 +147,7 @@ export function AuthPage() {
                     },
                 });
             }
-            window.location.href = '/';
+            window.location.href = returnPath;
         } catch (error) {
             console.error('Error during authentication', error);
             clearSsoCookie();

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -2,12 +2,10 @@ import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreAct
 import { LoadingScreen } from '$components/LoadingScreen';
 import trpc from '$lib/api/trpc';
 import {
-    getLocalStorageAuthReturnPath,
     getLocalStorageDataCache,
     getLocalStorageFromLoading,
     setLocalStorageImportedUser,
     getLocalStorageUserId,
-    removeLocalStorageAuthReturnPath,
     removeLocalStorageUserId,
     removeLocalStorageImportedUser,
     removeLocalStorageDataCache,
@@ -19,30 +17,6 @@ import AppStore from '$stores/AppStore';
 import { useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-function getSafeReturnPath() {
-    const candidate = getLocalStorageAuthReturnPath();
-    removeLocalStorageAuthReturnPath();
-
-    if (!candidate) {
-        return '/';
-    }
-
-    if (candidate.startsWith('/') && !candidate.startsWith('//')) {
-        return candidate;
-    }
-
-    try {
-        const url = new URL(candidate, window.location.origin);
-        if (url.origin === window.location.origin) {
-            return `${url.pathname}${url.search}${url.hash}`;
-        }
-    } catch {
-        // Ignore malformed candidate and fallback to root.
-    }
-
-    return '/';
-}
-
 export function AuthPage() {
     const [searchParams] = useSearchParams();
     const isAuthenticatingRef = useRef(false);
@@ -53,29 +27,24 @@ export function AuthPage() {
             return;
         }
 
-        // Compute (and immediately clear) the return path at the top so that
-        // every exit — success, error, or early-return — uses the same value
-        // and never leaves a stale authReturnPath in localStorage.
-        const returnPath = getSafeReturnPath();
-
         try {
             // Silent SSO returned an error — the auth server has no session.
             if (searchParams.get('error') === 'login_required') {
                 clearSsoCookie();
-                window.location.href = returnPath;
+                window.location.href = '/';
                 return;
             }
 
             const code = searchParams.get('code');
             const state = searchParams.get('state');
             if (!code || !state) {
-                window.location.href = returnPath;
+                window.location.href = '/';
                 return;
             }
 
             isAuthenticatingRef.current = true;
 
-            const { userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
+            const { userId, providerId, newUser, redirectUrl } = await trpc.userData.handleGoogleCallback.mutate({
                 code: code,
                 state: state,
             });
@@ -91,7 +60,7 @@ export function AuthPage() {
             }
 
             if (!providerId) {
-                window.location.href = returnPath;
+                window.location.href = redirectUrl || '/';
                 return;
             }
 
@@ -102,7 +71,7 @@ export function AuthPage() {
                 removeLocalStorageFromLoading();
                 removeLocalStorageDataCache();
                 removeLocalStorageImportedUser();
-                window.location.href = returnPath;
+                window.location.href = redirectUrl || '/';
                 return;
             }
 
@@ -110,7 +79,7 @@ export function AuthPage() {
             if (savedUserId === '' && savedData === '') {
                 removeLocalStorageDataCache();
                 removeLocalStorageImportedUser();
-                window.location.href = returnPath;
+                window.location.href = redirectUrl || '/';
                 return;
             }
 
@@ -151,11 +120,11 @@ export function AuthPage() {
                     },
                 });
             }
-            window.location.href = returnPath;
+            window.location.href = redirectUrl || '/';
         } catch (error) {
             console.error('Error during authentication', error);
             clearSsoCookie();
-            window.location.href = returnPath;
+            window.location.href = '/';
         }
     }, [searchParams]);
 


### PR DESCRIPTION
## Summary
Preserve the exact path after auth
Implemented to avoid breaking the import from planner flow, but this _should_ also be beneficial in other cases as well.
## Test Plan
Verify auth is not broken. Verify the path is preserved.

To test specifically for the purposes of import from planner:
1. Sign out of scheduler
2. Open a planner import URL (e.x. `/?importRoadmap=1864&term=2026+Summer10wk`)
3. Get prompted to sign in and do so
4. Expected behavior: You see the course results from the import

## Issues
N/A

<!-- [Optional]
## Future Followup
-->
