### PR TITLE
Prevent theme flash on initial page load

### DIFF
--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -5,7 +5,6 @@ import { useThemeStore } from '$stores/SettingsStore';
 import { CssBaseline, type PaletteOptions } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Roboto } from 'next/font/google';
-import { usePostHog } from 'posthog-js/react';
 import { useEffect, useMemo } from 'react';
 
 const roboto = Roboto({
@@ -120,13 +119,10 @@ declare module '@mui/material/styles' {
  */
 export default function AppThemeProvider(props: Props) {
     const appTheme = useThemeStore((store) => store.appTheme);
-    const setAppTheme = useThemeStore((store) => store.setAppTheme);
-    const postHog = usePostHog();
+    const refreshSystemTheme = useThemeStore((store) => store.refreshSystemTheme);
 
     useEffect(() => {
-        const onChange = (e: MediaQueryListEvent) => {
-            setAppTheme(e.matches ? 'dark' : 'light', postHog);
-        };
+        const onChange = () => refreshSystemTheme();
 
         const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
 
@@ -135,7 +131,11 @@ export default function AppThemeProvider(props: Props) {
         return () => {
             mediaQueryList.removeEventListener('change', onChange);
         };
-    }, [setAppTheme, postHog]);
+    }, [refreshSystemTheme]);
+
+    useEffect(() => {
+        document.documentElement.dataset.appTheme = appTheme;
+    }, [appTheme]);
 
     const theme = useMemo(
         () =>

--- a/apps/antalmanac/src/app/globals.css
+++ b/apps/antalmanac/src/app/globals.css
@@ -1,9 +1,16 @@
 html {
     font-size: 12px;
+    background-color: #f5f6fc;
 }
 
 body {
+    background-color: #f5f6fc;
     overflow: hidden;
+}
+
+html[data-app-theme='dark'],
+html[data-app-theme='dark'] body {
+    background-color: #1e1e1e;
 }
 
 .sr-only {

--- a/apps/antalmanac/src/app/layout.tsx
+++ b/apps/antalmanac/src/app/layout.tsx
@@ -5,6 +5,20 @@ import './globals.css';
 
 const ANTALMANAC_DESCRIPTION = 'A schedule planning and course exploration tool for UCI students.';
 
+const THEME_INITIALIZER_SCRIPT = `
+(function () {
+    try {
+        var storedTheme = window.localStorage.getItem('theme') || 'system';
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var appTheme = storedTheme === 'dark' || (storedTheme === 'system' && prefersDark) ? 'dark' : 'light';
+
+        document.documentElement.dataset.appTheme = appTheme;
+    } catch (_) {
+        document.documentElement.dataset.appTheme = 'light';
+    }
+})();
+`;
+
 export const metadata: Metadata = {
     title: 'AntAlmanac - UCI Schedule Planner',
     description: ANTALMANAC_DESCRIPTION,
@@ -61,7 +75,10 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="en">
+        <html lang="en" suppressHydrationWarning>
+            <Script id="theme-initializer" strategy="beforeInteractive">
+                {THEME_INITIALIZER_SCRIPT}
+            </Script>
             <body>
                 <Script>
                     {`console.log(

--- a/apps/antalmanac/src/app/layout.tsx
+++ b/apps/antalmanac/src/app/layout.tsx
@@ -7,15 +7,17 @@ const ANTALMANAC_DESCRIPTION = 'A schedule planning and course exploration tool 
 
 const THEME_INITIALIZER_SCRIPT = `
 (function () {
-    try {
-        var storedTheme = window.localStorage.getItem('theme') || 'system';
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        var appTheme = storedTheme === 'dark' || (storedTheme === 'system' && prefersDark) ? 'dark' : 'light';
+    var storedTheme = 'system';
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-        document.documentElement.dataset.appTheme = appTheme;
+    try {
+        storedTheme = window.localStorage.getItem('theme') || 'system';
     } catch (_) {
-        document.documentElement.dataset.appTheme = 'light';
+        storedTheme = 'system';
     }
+
+    document.documentElement.dataset.appTheme =
+        storedTheme === 'dark' || (storedTheme === 'system' && prefersDark) ? 'dark' : 'light';
 })();
 `;
 

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -28,6 +28,7 @@ export interface ThemeStore {
     isDark: boolean;
 
     setAppTheme: (themeSetting: ThemeSetting, postHog?: PostHog) => void;
+    refreshSystemTheme: () => void;
 }
 
 function themeShouldBeDark(themeSetting: ThemeSetting) {
@@ -35,9 +36,17 @@ function themeShouldBeDark(themeSetting: ThemeSetting) {
     return themeSetting == 'dark';
 }
 
+function setDocumentTheme(appTheme: 'light' | 'dark') {
+    document.documentElement.dataset.appTheme = appTheme;
+}
+
 export const useThemeStore = create<ThemeStore>((set) => {
     const storedThemeSetting: ThemeSetting = (getLocalStorageTheme() ?? 'system') as ThemeSetting;
     const isDark = themeShouldBeDark(storedThemeSetting);
+
+    if (typeof document !== 'undefined') {
+        setDocumentTheme(isDark ? 'dark' : 'light');
+    }
 
     return {
         themeSetting: storedThemeSetting,
@@ -50,6 +59,7 @@ export const useThemeStore = create<ThemeStore>((set) => {
             const isDark = themeShouldBeDark(themeSetting);
             const appTheme = isDark ? 'dark' : 'light';
 
+            setDocumentTheme(appTheme);
             set({ appTheme, themeSetting, isDark });
 
             logAnalytics(postHog, {
@@ -57,6 +67,17 @@ export const useThemeStore = create<ThemeStore>((set) => {
                 action: analyticsEnum.nav.actions.CHANGE_THEME,
                 label: themeSetting,
             });
+        },
+        refreshSystemTheme: () => {
+            const state = useThemeStore.getState();
+
+            if (state.themeSetting !== 'system') return;
+
+            const isDark = themeShouldBeDark('system');
+            const appTheme = isDark ? 'dark' : 'light';
+
+            setDocumentTheme(appTheme);
+            set({ appTheme, isDark });
         },
     };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a before-interactive theme initializer that derives the initial app theme from the saved `theme` setting and `prefers-color-scheme`
- Add global light/dark fallback backgrounds so the first paint matches the eventual MUI theme
- Keep the document `data-app-theme` in sync with the Zustand theme store, including system theme changes without overwriting the selected setting

## Test Plan
- `pnpm lint`
- `git diff --check`
- `pnpm --filter antalmanac build` *(fails: missing generated `$generated/searchData` and `$generated/termData` in this environment)*

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3c55648-9ba5-41a8-968d-477851d31dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3c55648-9ba5-41a8-968d-477851d31dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

