### PR TITLE
Configure Cursor Cloud AntAlmanac setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+    "install": "bash scripts/cursor-cloud-install.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@
 - `pnpm --filter antalmanac fetch-term-data` generates `apps/antalmanac/src/generated/termData.ts`.
 - `pnpm --filter antalmanac get-data` generates `termData.ts`, `searchData.ts`, and `terms/*.json`. It requires `ANTEATER_API_KEY` for the course search cache.
 - If `ANTEATER_API_KEY` is unavailable, the Cursor install script still generates `termData.ts` and writes a minimal `searchData.ts` so `pnpm --filter antalmanac build` can resolve build-time imports. Run `ANTEATER_API_KEY=<key> pnpm --filter antalmanac get-data` when testing search behavior or producing deploy-ready caches.
+- The install script writes `apps/antalmanac/.env` from `.env.example` when missing so Next can collect route data during `pnpm --filter antalmanac build` in cloud agents. Replace those placeholder values with real secrets before testing API-backed behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Repository instructions
+
+## Cursor Cloud specific instructions
+
+- Cursor Cloud Agents run `scripts/cursor-cloud-install.sh` from `.cursor/environment.json` before tasks start.
+- The install script runs `pnpm install --frozen-lockfile` so workspace dependencies are ready before agent work begins.
+- AntAlmanac builds need generated files under `apps/antalmanac/src/generated`, which are ignored except for `deployed_terms.json`.
+- `pnpm --filter antalmanac fetch-term-data` generates `apps/antalmanac/src/generated/termData.ts`.
+- `pnpm --filter antalmanac get-data` generates `termData.ts`, `searchData.ts`, and `terms/*.json`. It requires `ANTEATER_API_KEY` for the course search cache.
+- If `ANTEATER_API_KEY` is unavailable, the Cursor install script still generates `termData.ts` and writes a minimal `searchData.ts` so `pnpm --filter antalmanac build` can resolve build-time imports. Run `ANTEATER_API_KEY=<key> pnpm --filter antalmanac get-data` when testing search behavior or producing deploy-ready caches.

--- a/README.md
+++ b/README.md
@@ -151,8 +151,13 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 6. Fetch the static data (course information, term data, etc.).
 
     ```bash
-    cd apps/antalmanac && pnpm get-data
+    pnpm --filter antalmanac get-data
     ```
+
+    `pnpm --filter antalmanac build` requires generated files in `apps/antalmanac/src/generated`.
+    Run the full command above with `ANTEATER_API_KEY` set to generate `termData.ts`, `searchData.ts`,
+    and `terms/*.json`. Without an API key, `pnpm --filter antalmanac fetch-term-data` plus a minimal
+    `searchData.ts` stub is enough to satisfy build-time imports, but local course search data will be empty.
 
 7. Start the development server.
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
     pnpm --filter antalmanac get-data
     ```
 
-    `pnpm --filter antalmanac build` requires generated files in `apps/antalmanac/src/generated`.
-    Run the full command above with `ANTEATER_API_KEY` set to generate `termData.ts`, `searchData.ts`,
-    and `terms/*.json`. Without an API key, `pnpm --filter antalmanac fetch-term-data` plus a minimal
-    `searchData.ts` stub is enough to satisfy build-time imports, but local course search data will be empty.
+    `pnpm --filter antalmanac build` requires generated files in `apps/antalmanac/src/generated`
+    and local environment variables from `apps/antalmanac/.env`. Run the full command above
+    with `ANTEATER_API_KEY` set to generate `termData.ts`, `searchData.ts`, and `terms/*.json`.
+    Without an API key, `pnpm --filter antalmanac fetch-term-data` plus a minimal `searchData.ts`
+    stub is enough to satisfy build-time imports, but local course search data will be empty.
 
 7. Start the development server.
 

--- a/apps/antalmanac/.env.example
+++ b/apps/antalmanac/.env.example
@@ -5,3 +5,4 @@ DB_URL="postgres://postgres:postgres@localhost:5432/antalmanac"
 OIDC_CLIENT_ID=antalmanac-dev
 OIDC_ISSUER_URL=https://auth.icssc.club
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth
+PLANNER_CLIENT_API_KEY=

--- a/scripts/cursor-cloud-install.sh
+++ b/scripts/cursor-cloud-install.sh
@@ -3,6 +3,32 @@ set -euo pipefail
 
 pnpm install --frozen-lockfile
 
+env_file="apps/antalmanac/.env"
+
+if [[ ! -f "$env_file" ]]; then
+    cp apps/antalmanac/.env.example "$env_file"
+fi
+
+ensure_env_var() {
+    local key="$1"
+    local value="$2"
+
+    while IFS= read -r line; do
+        [[ "$line" == "$key="* ]] && return
+    done < "$env_file"
+
+    printf '%s=%s\n' "$key" "$value" >> "$env_file"
+}
+
+ensure_env_var "STAGE" "local"
+ensure_env_var "MAPBOX_ACCESS_TOKEN" ""
+ensure_env_var "ANTEATER_API_KEY" ""
+ensure_env_var "DB_URL" "\"postgres://postgres:postgres@localhost:5432/antalmanac\""
+ensure_env_var "OIDC_CLIENT_ID" "antalmanac-dev"
+ensure_env_var "OIDC_ISSUER_URL" "https://auth.icssc.club"
+ensure_env_var "GOOGLE_REDIRECT_URI" "http://localhost:3000/auth"
+ensure_env_var "PLANNER_CLIENT_API_KEY" ""
+
 pnpm --filter antalmanac fetch-term-data
 
 if [[ -n "${ANTEATER_API_KEY:-}" ]]; then

--- a/scripts/cursor-cloud-install.sh
+++ b/scripts/cursor-cloud-install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm install --frozen-lockfile
+
+pnpm --filter antalmanac fetch-term-data
+
+if [[ -n "${ANTEATER_API_KEY:-}" ]]; then
+    pnpm --filter antalmanac get-data
+else
+    cat > apps/antalmanac/src/generated/searchData.ts <<'EOF'
+import type { CourseSearchResult, DepartmentSearchResult } from "@packages/antalmanac-types";
+
+export const departments: Array<DepartmentSearchResult & { id: string }> = [];
+export const courses: Array<CourseSearchResult & { id: string }> = [];
+EOF
+
+    echo "ANTEATER_API_KEY is not set; wrote a minimal searchData.ts for build-time imports."
+    echo "Run 'pnpm --filter antalmanac get-data' with ANTEATER_API_KEY to generate full search caches."
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Cursor Cloud environment config that runs an idempotent install script before tasks start.
- Install pnpm workspace dependencies, seed ignored AntAlmanac local env placeholders, and generate AntAlmanac build inputs under `apps/antalmanac/src/generated`.
- Document the generated files required for `pnpm --filter antalmanac build` and when full API-backed caches are needed.

## Test Plan
- `bash scripts/cursor-cloud-install.sh`
- `pnpm --filter antalmanac build`

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f132d678-a2fa-4e21-9abb-2fcf60045d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f132d678-a2fa-4e21-9abb-2fcf60045d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

