### PR TITLE
GPA chart: lighter blue tooltip and bars

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -170,16 +170,12 @@ export function GradesPopup(props: GradesPopupProps) {
                                 <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} unit="%" width={35} />
                                 <RechartsTooltip
                                     contentStyle={{
-                                        backgroundColor: accentBlue,
+                                        backgroundColor: theme.palette.background.paper,
                                         border: 'none',
                                         borderRadius: 4,
                                     }}
-                                    labelStyle={{
-                                        color: theme.palette.mode === 'dark' ? '#212529' : '#fff',
-                                    }}
-                                    itemStyle={{
-                                        color: theme.palette.mode === 'dark' ? '#212529' : '#fff',
-                                    }}
+                                    labelStyle={{ color: accentBlue }}
+                                    itemStyle={{ color: accentBlue }}
                                 />
                                 <Bar dataKey="all" fill={accentBlue} />
                             </BarChart>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GradesPopup.tsx
@@ -1,3 +1,4 @@
+import { useSecondaryColor } from '$hooks/useSecondaryColor';
 import { Grades, type GradesProps } from '$lib/grades';
 import {
     Box,
@@ -69,6 +70,7 @@ export interface GradesPopupProps {
 
 export function GradesPopup(props: GradesPopupProps) {
     const theme = useTheme();
+    const accentBlue = useSecondaryColor();
 
     const { deptCode, courseNumber, instructor = '', isMobile } = props;
 
@@ -166,8 +168,20 @@ export function GradesPopup(props: GradesPopupProps) {
                                     height={20}
                                 />
                                 <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} unit="%" width={35} />
-                                <RechartsTooltip contentStyle={{ backgroundColor: theme.palette.background.paper }} />
-                                <Bar dataKey="all" fill={theme.palette.primary.main} />
+                                <RechartsTooltip
+                                    contentStyle={{
+                                        backgroundColor: accentBlue,
+                                        border: 'none',
+                                        borderRadius: 4,
+                                    }}
+                                    labelStyle={{
+                                        color: theme.palette.mode === 'dark' ? '#212529' : '#fff',
+                                    }}
+                                    itemStyle={{
+                                        color: theme.palette.mode === 'dark' ? '#212529' : '#fff',
+                                    }}
+                                />
+                                <Bar dataKey="all" fill={accentBlue} />
                             </BarChart>
                         </ResponsiveContainer>
                     </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the grade distribution popover chart: bars use the accent blue (`useSecondaryColor`). The Recharts hover tooltip uses **paper background** with **blue text** (label + value), not a blue tooltip panel.

## Testing

Not run (node_modules unavailable in agent environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2393f156-50c8-4f30-bba3-79c3507cc70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2393f156-50c8-4f30-bba3-79c3507cc70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

