### PR TITLE
feat: add optional text review field to review prompt

### DIFF
--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -29,7 +29,7 @@ const submitReviewInput = z.object({
     difficulty: z.number().int().min(1).max(5),
     tags: z.array(reviewTagsEnum).default([]),
     anonymous: z.boolean().default(true),
-    content: z.string().optional(),
+    content: z.string().max(500).optional(),
 });
 
 const reviewRouter = router({

--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -29,6 +29,7 @@ const submitReviewInput = z.object({
     difficulty: z.number().int().min(1).max(5),
     tags: z.array(reviewTagsEnum).default([]),
     anonymous: z.boolean().default(true),
+    content: z.string().optional(),
 });
 
 const reviewRouter = router({
@@ -67,6 +68,7 @@ const reviewRouter = router({
                 difficulty: input.difficulty,
                 tags: input.tags,
                 anonymous: input.anonymous,
+                content: input.content,
             })
             .returning({ id: instructorReviews.id });
 

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -13,6 +13,7 @@ import {
     IconButton,
     Rating,
     Stack,
+    TextField,
     Typography,
 } from '@mui/material';
 
@@ -59,6 +60,8 @@ export function ReviewStep() {
     const selectedTags = useReviewPromptStore((s) => s.selectedTags);
     const setRating = useReviewPromptStore((s) => s.setRating);
     const setDifficulty = useReviewPromptStore((s) => s.setDifficulty);
+    const textReview = useReviewPromptStore((s) => s.textReview);
+    const setTextReview = useReviewPromptStore((s) => s.setTextReview);
     const toggleTag = useReviewPromptStore((s) => s.toggleTag);
     const submitReview = useReviewPromptStore((s) => s.submitReview);
     const dismiss = useReviewPromptStore((s) => s.dismiss);
@@ -106,6 +109,17 @@ export function ReviewStep() {
                             </Box>
                         </Box>
                     </Box>
+
+                    <TextField
+                        label="Write a review (optional)"
+                        multiline
+                        minRows={1}
+                        maxRows={5}
+                        fullWidth
+                        value={textReview}
+                        onChange={(e) => setTextReview(e.target.value)}
+                        slotProps={{ htmlInput: { maxLength: 1000 } }}
+                    />
 
                     <Box display="flex" flexDirection="column" gap={0.5}>
                         <Typography color="text.secondary">Tags</Typography>

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { LIGHT_BLUE } from '$src/globals';
 import { REVIEW_TAGS } from '$stores/ReviewPromptStore';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { Close } from '@mui/icons-material';
@@ -15,6 +16,7 @@ import {
     Stack,
     TextField,
     Typography,
+    useTheme,
 } from '@mui/material';
 
 function ratingLabel(rating: number): string {
@@ -53,6 +55,7 @@ function difficultyLabel(difficulty: number): string {
 }
 
 export function ReviewStep() {
+    const theme = useTheme();
     const courseId = useReviewPromptStore((s) => s.candidate?.courseId ?? '');
     const professorId = useReviewPromptStore((s) => s.candidate?.professorId ?? '');
     const rating = useReviewPromptStore((s) => s.rating);
@@ -122,6 +125,14 @@ export function ReviewStep() {
                             htmlInput: { maxLength: 500 },
                             formHelperText: { sx: { textAlign: 'right', mx: 0 } },
                         }}
+                        sx={
+                            theme.palette.mode === 'dark'
+                                ? {
+                                      '& .MuiInputLabel-root': { color: LIGHT_BLUE },
+                                      '& .MuiInputLabel-root.Mui-focused': { color: LIGHT_BLUE },
+                                  }
+                                : {}
+                        }
                         helperText={`${textReview.length}/500`}
                     />
 

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -118,7 +118,7 @@ export function ReviewStep() {
                         fullWidth
                         value={textReview}
                         onChange={(e) => setTextReview(e.target.value)}
-                        slotProps={{ htmlInput: { maxLength: 1000 } }}
+                        slotProps={{ htmlInput: { maxLength: 500 } }}
                     />
 
                     <Box display="flex" flexDirection="column" gap={0.5}>

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -118,7 +118,11 @@ export function ReviewStep() {
                         fullWidth
                         value={textReview}
                         onChange={(e) => setTextReview(e.target.value)}
-                        slotProps={{ htmlInput: { maxLength: 500 } }}
+                        slotProps={{
+                            htmlInput: { maxLength: 500 },
+                            formHelperText: { sx: { textAlign: 'right', mx: 0 } },
+                        }}
+                        helperText={`${textReview.length}/500`}
                     />
 
                     <Box display="flex" flexDirection="column" gap={0.5}>

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -130,6 +130,8 @@ export function ReviewStep() {
                                 ? {
                                       '& .MuiInputLabel-root': { color: LIGHT_BLUE },
                                       '& .MuiInputLabel-root.Mui-focused': { color: LIGHT_BLUE },
+                                      '& .MuiInput-underline:before': { borderBottomColor: LIGHT_BLUE },
+                                      '& .MuiInput-underline:after': { borderBottomColor: LIGHT_BLUE },
                                   }
                                 : {}
                         }

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -42,6 +42,7 @@ const initialState = {
     rating: 0,
     difficulty: 0,
     selectedTags: [] as ReviewTag[],
+    textReview: '',
 };
 
 export const useReviewPromptStore = create(
@@ -141,7 +142,7 @@ export const useReviewPromptStore = create(
             }
 
             const candidate = eligible[Math.floor(Math.random() * eligible.length)];
-            set({ step: 'enrollment-confirm', candidate, rating: 0, difficulty: 0, selectedTags: [] });
+            set({ step: 'enrollment-confirm', candidate, rating: 0, difficulty: 0, selectedTags: [], textReview: '' });
             logAnalytics(postHog, {
                 category: analyticsEnum.review,
                 action: analyticsEnum.review.actions.PROMPT_SHOWN,
@@ -176,7 +177,7 @@ export const useReviewPromptStore = create(
          */
         dismiss: () => {
             const { candidate, step } = get();
-            set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [] });
+            set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [], textReview: '' });
             if (candidate) {
                 logAnalytics(postHog, {
                     category: analyticsEnum.review,
@@ -200,6 +201,8 @@ export const useReviewPromptStore = create(
 
         setDifficulty: (difficulty: number) => set({ difficulty }),
 
+        setTextReview: (textReview: string) => set({ textReview }),
+
         toggleTag: (tag: ReviewTag) => {
             const { selectedTags } = get();
             set({
@@ -210,7 +213,7 @@ export const useReviewPromptStore = create(
         },
 
         submitReview: async () => {
-            const { candidate, rating, difficulty, selectedTags } = get();
+            const { candidate, rating, difficulty, selectedTags, textReview } = get();
             if (!candidate || rating === 0 || difficulty === 0) return;
 
             try {
@@ -221,8 +224,9 @@ export const useReviewPromptStore = create(
                     rating,
                     difficulty,
                     tags: selectedTags,
+                    content: textReview || undefined,
                 });
-                set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [] });
+                set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [], textReview: '' });
                 logAnalytics(postHog, {
                     category: analyticsEnum.review,
                     action: analyticsEnum.review.actions.SUBMITTED,

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -216,6 +216,8 @@ export const useReviewPromptStore = create(
             const { candidate, rating, difficulty, selectedTags, textReview } = get();
             if (!candidate || rating === 0 || difficulty === 0) return;
 
+            const trimmedReview = textReview.trim();
+
             try {
                 await trpc.review.submitReview.mutate({
                     professorId: candidate.professorId,
@@ -224,7 +226,7 @@ export const useReviewPromptStore = create(
                     rating,
                     difficulty,
                     tags: selectedTags,
-                    content: textReview || undefined,
+                    content: trimmedReview || undefined,
                 });
                 set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [], textReview: '' });
                 logAnalytics(postHog, {

--- a/packages/db/src/schema/review/review.ts
+++ b/packages/db/src/schema/review/review.ts
@@ -47,7 +47,7 @@ export const instructorReviews = pgTable(
         /** Whether the review is displayed anonymously. Defaults to true. */
         anonymous: boolean('anonymous').notNull().default(true),
 
-        /** Optional free-text review body. Not collected in the quick-review UI. */
+        /** Optional free-text review body. */
         content: text('content'),
 
         /** Overall quality rating 1–5. */


### PR DESCRIPTION
## Summary
Adds a text field where users can write a review. Made it optional.


Untouched
<img width="638" height="311" alt="image" src="https://github.com/user-attachments/assets/b02dd187-ee42-4dd8-8f3c-b16f35d1c6ec" />

Filled out for submission

<img width="651" height="332" alt="image" src="https://github.com/user-attachments/assets/3d412a7b-f6a7-4027-a3fe-e3ee3e7866a9" />

Closes #1675

<!-- [Optional]
## Future Followup
-->
