### PR TITLE
Align Past Syllabi popover with enrollment history selection

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -7,6 +7,7 @@ import { PastSyllabiPopover } from '$components/RightPane/SectionTable/SectionTa
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { AnalyticsCategory } from '$lib/analytics/analytics';
 import { SECTION_TABLE_COLUMNS, type SectionTableColumn, useColumnStore } from '$stores/ColumnStore';
+import { useEnrollmentAnchorStore } from '$stores/EnrollmentAnchorStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
 import { useTabStore } from '$stores/TabStore';
 import { HistoryEdu, Route } from '@mui/icons-material';
@@ -58,6 +59,24 @@ function SectionTable(props: SectionTableProps) {
     const courseId = useMemo(() => {
         return courseDetails.deptCode.replaceAll(' ', '') + courseDetails.courseNumber;
     }, [courseDetails.deptCode, courseDetails.courseNumber]);
+
+    const enrollmentAnchor = useEnrollmentAnchorStore((s) => s.anchor);
+
+    const { anchorYearQuarter, anchorPrimaryInstructor } = useMemo(() => {
+        const firstSectionInstructor = courseDetails.sections[0]?.instructors?.[0];
+
+        if (enrollmentAnchor?.courseId === courseId) {
+            return {
+                anchorYearQuarter: `${enrollmentAnchor.year} ${enrollmentAnchor.quarter}`,
+                anchorPrimaryInstructor: enrollmentAnchor.primaryInstructor ?? firstSectionInstructor,
+            };
+        }
+
+        return {
+            anchorYearQuarter: term,
+            anchorPrimaryInstructor: firstSectionInstructor,
+        };
+    }, [courseDetails.sections, courseId, enrollmentAnchor, term]);
 
     const formattedTime = useMemo(() => {
         if (!courseDetails.updatedAt) {
@@ -126,6 +145,8 @@ function SectionTable(props: SectionTableProps) {
                             courseId={courseId}
                             deptCode={courseDetails.deptCode}
                             courseNumber={courseDetails.courseNumber}
+                            anchorYearQuarter={anchorYearQuarter}
+                            anchorPrimaryInstructor={anchorPrimaryInstructor}
                         />
                     }
                 />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
@@ -7,6 +7,10 @@ import { Box, ButtonBase, Popover, Tooltip, Typography } from '@mui/material';
 import type { WebsocSectionEnrollment, WebsocSectionType } from '@packages/antalmanac-types';
 import { useCallback, useMemo, useState } from 'react';
 
+function courseIdFromDeptAndNumber(deptCode: string, courseNumber: string) {
+    return deptCode.replaceAll(' ', '') + courseNumber;
+}
+
 interface EnrollmentCellProps {
     sectionType: WebsocSectionType;
     deptCode: string;
@@ -49,6 +53,8 @@ export const EnrollmentCell = ({
     const [loadingEnrollmentHistory, setLoadingEnrollmentHistory] = useState(false);
 
     const deptEnrollmentHistory = useMemo(() => new DepartmentEnrollmentHistory(deptCode), [deptCode]);
+
+    const courseId = useMemo(() => courseIdFromDeptAndNumber(deptCode, courseNumber), [deptCode, courseNumber]);
 
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
@@ -127,6 +133,7 @@ export const EnrollmentCell = ({
                     sectionType={sectionType}
                     department={deptCode}
                     courseNumber={courseNumber}
+                    courseId={courseId}
                     enrollmentHistory={enrollmentHistory}
                     loading={loadingEnrollmentHistory}
                 />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
@@ -4,7 +4,8 @@ import { ArrowBack, ArrowForward } from '@mui/icons-material';
 import { Box, Card, CardContent, CardHeader, IconButton, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import type { WebsocSectionType } from '@packages/antalmanac-types';
-import { useCallback, useMemo, useState } from 'react';
+import { useEnrollmentAnchorStore } from '$stores/EnrollmentAnchorStore';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     CartesianGrid,
     Legend,
@@ -20,6 +21,8 @@ interface EnrollmentHistoryPopoverProps {
     sectionType: WebsocSectionType;
     department: string;
     courseNumber: string;
+    /** Dept + course number without spaces; used to align Past Syllabi with this enrollment graph. */
+    courseId: string;
     enrollmentHistory: EnrollmentHistory[] | undefined;
     loading?: boolean;
 }
@@ -32,10 +35,12 @@ export function EnrollmentHistoryPopover({
     sectionType,
     department,
     courseNumber,
+    courseId,
     enrollmentHistory,
     loading = false,
 }: EnrollmentHistoryPopoverProps) {
     const [selectedGraphKey, setSelectedGraphKey] = useState<string>();
+    const setEnrollmentAnchor = useEnrollmentAnchorStore((s) => s.setAnchor);
 
     const theme = useTheme();
     const isMobile = useIsMobile();
@@ -59,6 +64,20 @@ export function EnrollmentHistoryPopover({
         }
         return enrollmentHistory.length - 1;
     }, [enrollmentHistory, selectedGraphKey]);
+
+    useEffect(() => {
+        const curr = enrollmentHistory?.at(activeGraphIndex);
+        if (curr == null) {
+            return;
+        }
+
+        setEnrollmentAnchor({
+            courseId,
+            year: curr.year,
+            quarter: curr.quarter,
+            primaryInstructor: curr.instructors.at(0),
+        });
+    }, [activeGraphIndex, courseId, enrollmentHistory, setEnrollmentAnchor]);
 
     const title = `${department} ${courseNumber}`;
     const currEnrollmentHistory = enrollmentHistory?.at(activeGraphIndex);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
@@ -14,20 +14,32 @@ import {
 } from '@mui/material';
 import type { WebsocSyllabiResponse } from '@packages/antalmanac-types';
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+function normalizeInstructorName(name: string) {
+    return name.trim().toLowerCase().replace(/\s+/g, ' ');
+}
 
 export interface PastSyllabiPopoverProps {
     deptCode: string;
     courseNumber: string;
     courseId: string;
+    /**
+     * When set (e.g. from the enrollment history graph), scroll to this term + instructor row first.
+     * Format matches list grouping: "YYYY Quarter" (e.g. "2024 Fall").
+     */
+    anchorYearQuarter?: string;
+    /** Primary instructor name to match the first entry in `instructorNames` when disambiguating. */
+    anchorPrimaryInstructor?: string;
 }
 
 export function PastSyllabiPopover(props: PastSyllabiPopoverProps) {
     const isMobile = useIsMobile();
-    const { deptCode, courseNumber, courseId } = props;
+    const { deptCode, courseNumber, courseId, anchorYearQuarter, anchorPrimaryInstructor } = props;
 
     const [loading, setLoading] = useState(true);
     const [syllabi, setSyllabi] = useState<WebsocSyllabiResponse>([]);
+    const anchorItemRef = useRef<HTMLDivElement>(null);
 
     const width = isMobile ? 250 : 400;
     const height = isMobile ? 150 : 200;
@@ -45,6 +57,58 @@ export function PastSyllabiPopover(props: PastSyllabiPopoverProps) {
             {} as Record<string, WebsocSyllabiResponse[number][]>
         );
     }, [syllabi]);
+
+    const defaultAnchorEntry = useMemo(() => {
+        if (syllabi.length === 0) {
+            return undefined;
+        }
+
+        const termFilter = anchorYearQuarter?.trim();
+        const profNorm = anchorPrimaryInstructor?.trim()
+            ? normalizeInstructorName(anchorPrimaryInstructor)
+            : undefined;
+
+        if (termFilter && profNorm) {
+            const match = syllabi.find((entry) => {
+                const term = `${entry.year} ${entry.quarter}`;
+                if (term !== termFilter) {
+                    return false;
+                }
+                const primary = entry.instructorNames.at(0) ?? '';
+                return normalizeInstructorName(primary) === profNorm;
+            });
+            if (match) {
+                return match;
+            }
+        }
+
+        if (termFilter) {
+            const inTerm = syllabi.filter((entry) => `${entry.year} ${entry.quarter}` === termFilter);
+            if (inTerm.length === 1) {
+                return inTerm[0];
+            }
+            if (inTerm.length > 1 && profNorm) {
+                const profMatch = inTerm.find((entry) => {
+                    const primary = entry.instructorNames.at(0) ?? '';
+                    return normalizeInstructorName(primary) === profNorm;
+                });
+                if (profMatch) {
+                    return profMatch;
+                }
+            }
+            return inTerm[0];
+        }
+
+        return undefined;
+    }, [syllabi, anchorYearQuarter, anchorPrimaryInstructor]);
+
+    useEffect(() => {
+        if (loading || defaultAnchorEntry == null) {
+            return;
+        }
+
+        anchorItemRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, [defaultAnchorEntry, loading, syllabi]);
 
     const title = `${deptCode} ${courseNumber}`;
     const subheader = loading ? (
@@ -93,18 +157,31 @@ export function PastSyllabiPopover(props: PastSyllabiPopoverProps) {
                                 <Typography variant="body1" color="text.primary">
                                     {term}
                                 </Typography>
-                                {entries.map((entry) => (
-                                    <ListItemButton
-                                        LinkComponent={Link}
-                                        href={entry.url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        key={entry.url}
-                                    >
-                                        <ListItemText primary={entry.instructorNames.at(0) ?? 'N/A'} />
-                                        <OpenInNew />
-                                    </ListItemButton>
-                                ))}
+                                {entries.map((entry) => {
+                                    const isHighlighted =
+                                        defaultAnchorEntry != null && entry.url === defaultAnchorEntry.url;
+                                    return (
+                                        <ListItemButton
+                                            LinkComponent={Link}
+                                            href={entry.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            key={entry.url}
+                                            ref={isHighlighted ? anchorItemRef : undefined}
+                                            selected={isHighlighted}
+                                            sx={
+                                                isHighlighted
+                                                    ? {
+                                                          bgcolor: 'action.selected',
+                                                      }
+                                                    : undefined
+                                            }
+                                        >
+                                            <ListItemText primary={entry.instructorNames.at(0) ?? 'N/A'} />
+                                            <OpenInNew />
+                                        </ListItemButton>
+                                    );
+                                })}
                             </ListSubheader>
                         ))}
                     </List>

--- a/apps/antalmanac/src/stores/EnrollmentAnchorStore.ts
+++ b/apps/antalmanac/src/stores/EnrollmentAnchorStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export interface EnrollmentAnchor {
+    courseId: string;
+    year: string;
+    quarter: string;
+    primaryInstructor: string | undefined;
+}
+
+export interface EnrollmentAnchorStore {
+    anchor: EnrollmentAnchor | undefined;
+    setAnchor: (anchor: EnrollmentAnchor | undefined) => void;
+}
+
+export const useEnrollmentAnchorStore = create<EnrollmentAnchorStore>((set) => ({
+    anchor: undefined,
+    setAnchor: (anchor) => set({ anchor }),
+}));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When users step through **enrollment history** (year/quarter/instructor), **Past Syllabi** now opens scrolled to and visually highlighting the syllabus row that matches that graph (same course, year, quarter, and primary instructor when the API data allows).

## How it works

- `EnrollmentHistoryPopover` writes the active graph’s `year`, `quarter`, and primary instructor to a small Zustand store (`EnrollmentAnchorStore`), keyed by `courseId`.
- `SectionTable` passes `anchorYearQuarter` and `anchorPrimaryInstructor` into `PastSyllabiPopover` when the store matches the current course; otherwise it falls back to the search `term` and the first section’s instructor.
- `PastSyllabiPopover` finds the best-matching entry in the fetched list, sets `selected` on that row, and scrolls it into view.

## Notes

- Matching normalizes instructor names (trim, lowercase, collapse spaces) to tolerate minor formatting differences between enrollment and syllabus data.
- If the user has not opened enrollment history for this course, behavior matches the previous implicit default: highlight within the current term when possible.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-985b99cd-0194-4395-9e50-b1adf4873f38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-985b99cd-0194-4395-9e50-b1adf4873f38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

