### PR TITLE
Move course action buttons below title row

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
@@ -1,5 +1,7 @@
+import { useIsMobile } from '$hooks/useIsMobile';
 import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
-import { Box, Button, Paper, Popover } from '@mui/material';
+import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
+import { Box, Button, Paper, Popover, useTheme } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useState } from 'react';
 
@@ -21,8 +23,15 @@ export const CourseInfoButton = ({
     analyticsCategory,
 }: CourseInfoButtonProps) => {
     const postHog = usePostHog();
+    const theme = useTheme();
+    const isMobile = useIsMobile();
 
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+    const scheduleManagementWidth = useScheduleManagementStore((state) => state.scheduleManagementWidth);
+    const compact =
+        isMobile || (scheduleManagementWidth !== undefined && scheduleManagementWidth < theme.breakpoints.values.xs);
+    const showLabel = !compact || isMobile;
 
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
@@ -52,15 +61,17 @@ export const CourseInfoButton = ({
             <Button variant="contained" size="small" color="primary" onClick={handleClick}>
                 <span style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
                     {icon}
-                    <span
-                        style={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                        }}
-                    >
-                        {text}
-                    </span>
+                    {showLabel ? (
+                        <span
+                            style={{
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                            }}
+                        >
+                            {text}
+                        </span>
+                    ) : null}
                 </span>
             </Button>
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
@@ -1,7 +1,5 @@
-import { useIsMobile } from '$hooks/useIsMobile';
 import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
-import { useScheduleManagementStore } from '$stores/ScheduleManagementStore';
-import { Box, Button, Paper, Popover, useTheme } from '@mui/material';
+import { Box, Button, Paper, Popover } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useState } from 'react';
 
@@ -23,13 +21,8 @@ export const CourseInfoButton = ({
     analyticsCategory,
 }: CourseInfoButtonProps) => {
     const postHog = usePostHog();
-    const theme = useTheme();
-    const isMobile = useIsMobile();
 
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-    const scheduleManagementWidth = useScheduleManagementStore((state) => state.scheduleManagementWidth);
-    const compact = isMobile || (scheduleManagementWidth && scheduleManagementWidth < theme.breakpoints.values.xs);
 
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
@@ -57,19 +50,17 @@ export const CourseInfoButton = ({
     return (
         <Box sx={{ display: 'flex' }}>
             <Button variant="contained" size="small" color="primary" onClick={handleClick}>
-                <span style={{ display: 'flex', gap: 4 }}>
+                <span style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
                     {icon}
-                    {compact ? null : (
-                        <span
-                            style={{
-                                whiteSpace: 'nowrap',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                            }}
-                        >
-                            {text}
-                        </span>
-                    )}
+                    <span
+                        style={{
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                        }}
+                    >
+                        {text}
+                    </span>
                 </span>
             </Button>
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoButton.tsx
@@ -30,7 +30,8 @@ export const CourseInfoButton = ({
 
     const scheduleManagementWidth = useScheduleManagementStore((state) => state.scheduleManagementWidth);
     const compact =
-        isMobile || (scheduleManagementWidth !== undefined && scheduleManagementWidth < theme.breakpoints.values.xs);
+        isMobile ||
+        (scheduleManagementWidth != null && scheduleManagementWidth < theme.breakpoints.values.xs);
     const showLabel = !compact || isMobile;
 
     const handleClick = useCallback(

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -88,52 +88,70 @@ function SectionTable(props: SectionTableProps) {
         return (width * numActiveColumns) / TOTAL_NUM_COLUMNS;
     }, [activeColumns]);
 
+    const courseInfoBar = (
+        <CourseInfoBar
+            deptCode={courseDetails.deptCode}
+            courseTitle={courseDetails.courseTitle}
+            courseNumber={courseDetails.courseNumber}
+            prerequisiteLink={courseDetails.prerequisiteLink}
+            analyticsCategory={analyticsCategory}
+        />
+    );
+
+    const courseActionButtons = (
+        <>
+            {activeTab !== 2 ? null : <CourseInfoSearchButton courseDetails={courseDetails} term={term} />}
+
+            <CourseInfoButton
+                analyticsCategory={analyticsCategory}
+                analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
+                text="Planner"
+                icon={<Route />}
+                redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
+            />
+
+            <CourseInfoButton
+                analyticsCategory={analyticsCategory}
+                analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_SYLLABI}
+                text="Past Syllabi"
+                icon={<HistoryEdu />}
+                popupContent={
+                    <PastSyllabiPopover
+                        courseId={courseId}
+                        deptCode={courseDetails.deptCode}
+                        courseNumber={courseDetails.courseNumber}
+                    />
+                }
+            />
+        </>
+    );
+
     return (
         <>
             <Box
                 sx={{
                     display: 'flex',
-                    flexDirection: 'column',
+                    flexDirection: isMobile ? 'column' : 'row',
                     gap: '4px',
                     marginBottom: '8px',
                     marginTop: '4px',
                 }}
             >
-                <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
-                    <CourseInfoBar
-                        deptCode={courseDetails.deptCode}
-                        courseTitle={courseDetails.courseTitle}
-                        courseNumber={courseDetails.courseNumber}
-                        prerequisiteLink={courseDetails.prerequisiteLink}
-                        analyticsCategory={analyticsCategory}
-                    />
-                </Box>
-
-                <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
-                    {activeTab !== 2 ? null : <CourseInfoSearchButton courseDetails={courseDetails} term={term} />}
-
-                    <CourseInfoButton
-                        analyticsCategory={analyticsCategory}
-                        analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
-                        text="Planner"
-                        icon={<Route />}
-                        redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
-                    />
-
-                    <CourseInfoButton
-                        analyticsCategory={analyticsCategory}
-                        analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_SYLLABI}
-                        text="Past Syllabi"
-                        icon={<HistoryEdu />}
-                        popupContent={
-                            <PastSyllabiPopover
-                                courseId={courseId}
-                                deptCode={courseDetails.deptCode}
-                                courseNumber={courseDetails.courseNumber}
-                            />
-                        }
-                    />
-                </Box>
+                {isMobile ? (
+                    <>
+                        <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
+                            {courseInfoBar}
+                        </Box>
+                        <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
+                            {courseActionButtons}
+                        </Box>
+                    </>
+                ) : (
+                    <>
+                        {courseInfoBar}
+                        {courseActionButtons}
+                    </>
+                )}
             </Box>
 
             {missingSections?.length > 0 && (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -93,42 +93,47 @@ function SectionTable(props: SectionTableProps) {
             <Box
                 sx={{
                     display: 'flex',
+                    flexDirection: 'column',
                     gap: '4px',
                     marginBottom: '8px',
                     marginTop: '4px',
                 }}
             >
-                <CourseInfoBar
-                    deptCode={courseDetails.deptCode}
-                    courseTitle={courseDetails.courseTitle}
-                    courseNumber={courseDetails.courseNumber}
-                    prerequisiteLink={courseDetails.prerequisiteLink}
-                    analyticsCategory={analyticsCategory}
-                />
+                <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
+                    <CourseInfoBar
+                        deptCode={courseDetails.deptCode}
+                        courseTitle={courseDetails.courseTitle}
+                        courseNumber={courseDetails.courseNumber}
+                        prerequisiteLink={courseDetails.prerequisiteLink}
+                        analyticsCategory={analyticsCategory}
+                    />
+                </Box>
 
-                {activeTab !== 2 ? null : <CourseInfoSearchButton courseDetails={courseDetails} term={term} />}
+                <Box sx={{ display: 'flex', gap: '4px', flexWrap: 'wrap', alignItems: 'center' }}>
+                    {activeTab !== 2 ? null : <CourseInfoSearchButton courseDetails={courseDetails} term={term} />}
 
-                <CourseInfoButton
-                    analyticsCategory={analyticsCategory}
-                    analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
-                    text="Planner"
-                    icon={<Route />}
-                    redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
-                />
+                    <CourseInfoButton
+                        analyticsCategory={analyticsCategory}
+                        analyticsAction={analyticsEnum.classSearch.actions.CLICK_REVIEWS}
+                        text="Planner"
+                        icon={<Route />}
+                        redirectLink={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
+                    />
 
-                <CourseInfoButton
-                    analyticsCategory={analyticsCategory}
-                    analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_SYLLABI}
-                    text="Past Syllabi"
-                    icon={<HistoryEdu />}
-                    popupContent={
-                        <PastSyllabiPopover
-                            courseId={courseId}
-                            deptCode={courseDetails.deptCode}
-                            courseNumber={courseDetails.courseNumber}
-                        />
-                    }
-                />
+                    <CourseInfoButton
+                        analyticsCategory={analyticsCategory}
+                        analyticsAction={analyticsEnum.classSearch.actions.CLICK_PAST_SYLLABI}
+                        text="Past Syllabi"
+                        icon={<HistoryEdu />}
+                        popupContent={
+                            <PastSyllabiPopover
+                                courseId={courseId}
+                                deptCode={courseDetails.deptCode}
+                                courseNumber={courseDetails.courseNumber}
+                            />
+                        }
+                    />
+                </Box>
             </Box>
 
             {missingSections?.length > 0 && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Mobile only:** Course title row (`CourseInfoBar`) stacks above the blue action row with the same **4px** gaps as before.
- **Desktop:** Restores the original single horizontal row (title + actions).
- **Labels:** Planner / Past Syllabi text shows on mobile (even in the previous “compact” width case). On desktop, very narrow panes still use icon-only buttons when width is below the `xs` breakpoint, matching prior behavior aside from mobile.

## Fix

- `CourseInfoButton`: use `scheduleManagementWidth != null` so TypeScript narrows `number | null` before comparing to the breakpoint.

## Files

- `SectionTable.tsx` — conditional `flexDirection` and row structure
- `CourseInfoButton.tsx` — `showLabel = !compact || isMobile`, null-safe width check
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c699dd1-2e17-462f-9494-1047233d8acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c699dd1-2e17-462f-9494-1047233d8acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

