### PR TITLE
feat: use KeyboardEvent.key for undo/redo and legacy sign-in Enter

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -436,13 +436,13 @@ export const addCustomEvent = (customEvent: RepeatingCustomEvent, scheduleIndice
 };
 
 export const undoDelete = (event: KeyboardEvent | null) => {
-    if (event == null || (event.keyCode === 90 && (event.ctrlKey || event.metaKey) && !event.shiftKey)) {
+    if (event == null || (event.key === 'z' && (event.ctrlKey || event.metaKey) && !event.shiftKey)) {
         AppStore.undoAction();
     }
 };
 
 export const redoDelete = (event: KeyboardEvent | null) => {
-    if (event == null || (event.keyCode === 90 && (event.ctrlKey || event.metaKey) && event.shiftKey)) {
+    if (event == null || (event.key === 'z' && (event.ctrlKey || event.metaKey) && event.shiftKey)) {
         AppStore.redoAction();
     }
 };

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -442,7 +442,7 @@ export const undoDelete = (event: KeyboardEvent | null) => {
 };
 
 export const redoDelete = (event: KeyboardEvent | null) => {
-    if (event == null || (event.key === 'z' && (event.ctrlKey || event.metaKey) && event.shiftKey)) {
+    if (event == null || (event.key.toLowerCase() === 'z' && (event.ctrlKey || event.metaKey) && event.shiftKey)) {
         AppStore.redoAction();
     }
 };

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -134,9 +134,7 @@ export const Signin = () => {
         (event: KeyboardEvent) => {
             if (!showLegacyLogin) return;
 
-            const charCode = event.which ? event.which : event.keyCode;
-
-            if (charCode === 13 || charCode === 10) {
+            if (event.key === 'Enter') {
                 event.preventDefault();
                 setIsOpen(false);
                 document.removeEventListener('keydown', enterEvent, false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces deprecated keyboard APIs: undo/redo shortcuts now use `event.key === 'z'` with ctrl/meta, and the legacy guest sign-in dialog treats Enter via `event.key === 'Enter'` instead of `keyCode`/`which`.

## Test Plan

- [ ] Undo (Ctrl/Cmd+Z) and redo (Ctrl/Cmd+Shift+Z) still work from the document key listeners.
- [ ] Legacy username dialog: pressing Enter still submits and loads the schedule.

## Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

