### PR TITLE
Parallelize schedule courses and custom-events queries in RDS

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -382,17 +382,18 @@ export class RDS {
 
         const userId = row.users.id;
 
-        const sectionResults = await db
-            .select()
-            .from(schedules)
-            .where(eq(schedules.userId, userId))
-            .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId));
-
-        const customEventResults = await db
-            .select()
-            .from(schedules)
-            .where(eq(schedules.userId, userId))
-            .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId));
+        const [sectionResults, customEventResults] = await Promise.all([
+            db
+                .select()
+                .from(schedules)
+                .where(eq(schedules.userId, userId))
+                .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId)),
+            db
+                .select()
+                .from(schedules)
+                .where(eq(schedules.userId, userId))
+                .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId)),
+        ]);
 
         const userSchedules = RDS.aggregateUserData(sectionResults, customEventResults);
 
@@ -573,17 +574,18 @@ export class RDS {
             return null;
         }
 
-        const sectionResults = await db
-            .select()
-            .from(schedules)
-            .where(eq(schedules.userId, user.id))
-            .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId));
-
-        const customEventResults = await db
-            .select()
-            .from(schedules)
-            .where(eq(schedules.userId, user.id))
-            .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId));
+        const [sectionResults, customEventResults] = await Promise.all([
+            db
+                .select()
+                .from(schedules)
+                .where(eq(schedules.userId, user.id))
+                .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId)),
+            db
+                .select()
+                .from(schedules)
+                .where(eq(schedules.userId, user.id))
+                .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId)),
+        ]);
 
         const userSchedules = RDS.aggregateUserData(sectionResults, customEventResults);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Only `apps/antalmanac/src/backend/lib/rds.ts` is changed.

In `RDS.getGuestScheduleByUsername` and `RDS.fetchUserDataWithSession`, run the courses-in-schedule and custom-events Drizzle selects concurrently with `Promise.all` instead of awaiting them sequentially.

## Test Plan

- [ ] Smoke: load schedules for a logged-in user (`getUserData` / `fetchUserDataWithSession`).
- [ ] Smoke: load a guest schedule by username (`getGuestScheduleByUsername`).

## Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

