### PR TITLE
Stable React keys for map routes and search result rows

### DIFF
--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -316,6 +316,12 @@ export default function CourseMap() {
         );
     }, [markersToDisplay, customEventMarkersToDisplay]);
 
+    const routeSegmentKey = (pair: (typeof markersToDisplay)[number][], segmentIndex: number) => {
+        const latLngTuples = pair.map((marker) => [marker.lat, marker.lng] as LatLngTuple);
+        const coords = latLngTuples.map(([lat, lng]) => `${lat},${lng}`).join('|');
+        return `route-${today}-${segmentIndex}-${coords}`;
+    };
+
     return (
         <Box
             sx={{ width: '100%', display: 'flex', flexDirection: 'column', flexGrow: 1, height: '100%' }}
@@ -359,14 +365,16 @@ export default function CourseMap() {
 
                 {/* Draw out routes if the user is viewing a specific day. */}
                 {today !== 'All' &&
-                    startDestPairs.map((startDestPair) => {
+                    startDestPairs.map((startDestPair, segmentIndex) => {
                         const latLngTuples = startDestPair.map((marker) => [marker.lat, marker.lng] as LatLngTuple);
                         const color = startDestPair[0]?.color;
-                        /**
-                         * Previous renders of the routes will be left behind if the keys aren't unique.
-                         */
-                        const key = Math.random().toString(36).substring(7);
-                        return <Routes key={key} latLngTuples={latLngTuples} color={color} />;
+                        return (
+                            <Routes
+                                key={routeSegmentKey(startDestPair, segmentIndex)}
+                                latLngTuples={latLngTuples}
+                                color={color}
+                            />
+                        );
                     })}
 
                 {/* Draw a marker for each class that occurs today. */}
@@ -383,8 +391,10 @@ export default function CourseMap() {
                         .filter((location) => location.building == marker.locations[0].building)
                         .reduce((roomList, location) => [...roomList, location.room], [] as string[]);
 
+                    const markerListKey = `course-${marker.term}-${marker.sectionCode}-${marker.start.getTime()}-${marker.locations[0]?.building ?? ''}-${index}`;
+
                     return (
-                        <Fragment key={Object.values(marker).join('')}>
+                        <Fragment key={markerListKey}>
                             <LocationMarker
                                 {...marker}
                                 key={marker.key}
@@ -413,7 +423,7 @@ export default function CourseMap() {
                     const customEventSameBuildingPrior = customEventMarkersToDisplay.slice(0, index);
 
                     return (
-                        <Fragment key={Object.values(customEventMarkers).join('')}>
+                        <Fragment key={`custom-${customEventMarkers.customEventID}-${index}`}>
                             <LocationMarker
                                 {...customEventMarkers}
                                 label={'E'}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -32,7 +32,7 @@ import {
     GE,
 } from '@packages/antalmanac-types';
 import Image from 'next/image';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
 function getColors() {
@@ -95,6 +95,24 @@ function getFilteredCourses(
         });
     }
     return allCourses;
+}
+
+function searchResultsRowKey(
+    item: WebsocSchool | WebsocDepartment | AACourse,
+    formData: CourseSearchParams,
+    index: number
+): string {
+    if ('departments' in item && item.departments !== undefined) {
+        return `school-${item.schoolName}-${index}`;
+    }
+    if ('courses' in item && item.courses !== undefined) {
+        return `dept-${item.deptCode}-${item.deptName}-${index}`;
+    }
+    const course = item as AACourse;
+    if (formData.ge !== 'ANY') {
+        return `ge-course-${course.deptCode}-${course.courseNumber}-${index}`;
+    }
+    return `course-${course.deptCode}-${course.courseNumber}-${index}`;
 }
 
 const RecruitmentBanner = () => {
@@ -274,6 +292,8 @@ export default function CourseRenderPane(props: { id?: number }) {
 
     const setHoveredEvent = useHoveredStore((store) => store.setHoveredEvent);
 
+    const searchFormForRowKeys = useMemo(() => RightPaneStore.getFormData(), [courseData]);
+
     const getQueryParams = useCallback((searchData: CourseSearchParams) => {
         const websocQueryParams = {
             department: searchData.deptValue,
@@ -437,12 +457,13 @@ export default function CourseRenderPane(props: { id?: number }) {
                 <>
                     <RecruitmentBanner />
                     <Box>
-                        {courseData.map((_: WebsocSchool | WebsocDepartment | AACourse, index: number) => {
+                        {courseData.map((item, index) => {
                             let heightEstimate = 200;
                             if ((courseData[index] as AACourse).sections !== undefined)
                                 heightEstimate = (courseData[index] as AACourse).sections.length * 60 + 20 + 40;
+                            const rowKey = searchResultsRowKey(item, searchFormForRowKeys, index);
                             return (
-                                <LazyLoad once key={index} overflow height={heightEstimate} offset={1000}>
+                                <LazyLoad once key={rowKey} overflow height={heightEstimate} offset={1000}>
                                     {SectionTableWrapped(index, {
                                         courseData: courseData,
                                         scheduleNames: scheduleNames,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces unstable React list keys on the campus map and in WebSOC search results:

- **Map routes:** `Routes` no longer uses `Math.random()`; each segment gets a stable key from the selected day, segment index, and endpoint coordinates.
- **Map markers:** `Fragment` keys no longer use `Object.values(marker).join('')`. Course markers use term, section code, start time, primary building, and list index; custom events use `customEventID` plus index.
- **Search results:** `LazyLoad` rows use a small `searchResultsRowKey()` helper (school name, dept code/name, or course dept/number, with GE vs normal course disambiguation) plus index, with form data memoized from the current `courseData` so keys stay in sync after a new search.

## Test Plan

- [ ] Map tab: switch day tabs with routes visible; markers still update without obvious flicker or duplicate routes.
- [ ] Search tab: run a search, scroll results; re-search with different results and confirm rows behave sensibly.

## Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7009f31a-d7ad-446d-b68a-3623e1f2a791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

