### PR TITLE
feat: union catalogue search index with websoc

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -37,6 +37,7 @@
         "@mui/system": "^7.3.7",
         "@mui/x-date-pickers": "^8.3.1",
         "@packages/antalmanac-types": "workspace:^",
+        "@packages/anteater-api-types": "workspace:^",
         "@paralleldrive/cuid2": "^2.2.2",
         "@reactour/tour": "^3.6.1",
         "@tanstack/react-query": "^4.24.4",

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -98,6 +98,11 @@ async function main() {
     await mkdir(join(__dirname, '../src/generated/'), { recursive: true });
     await mkdir(join(__dirname, '../src/generated/terms/'), { recursive: true });
 
+    /*
+     * WebSOC may receive updates sooner than the course catalogue updates, notably for a
+     * new academic year (i.e. Fall term). Querying Websoc to build course data ensures all
+     * available courses are represented.
+     */
     const latestTerm = termData[0];
     const [latestYear, latestQuarter] = latestTerm.shortName.split(' ');
     console.log(`Fetching WebSoc REST for ${latestTerm.shortName} (union with catalogue)...`);

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -8,6 +8,12 @@ import type {
     DepartmentSearchResult,
     CoursesFilteredAPIResult,
 } from '@packages/antalmanac-types';
+import type {
+    WebsocAPIResponse,
+    WebsocAPIResult,
+    WebsocCourse,
+    WebsocDepartment,
+} from '@packages/anteater-api-types';
 
 import { fetchAnteaterAPI, queryGraphQL } from '../src/backend/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
@@ -26,8 +32,32 @@ const ALIASES: Record<string, string | undefined> = {
     IN4MATX: 'INF',
 };
 
+function catalogCourseKey(department: string, courseNumber: string) {
+    return `${department.trim()}\0${courseNumber.trim()}`;
+}
+
+function indexWebsocCoursesByCatalogKey(data: WebsocAPIResponse) {
+    const out = new Map<
+        string,
+        Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
+    >();
+    for (const school of data.schools) {
+        for (const dept of school.departments) {
+            for (const course of dept.courses) {
+                const key = catalogCourseKey(dept.deptCode, course.courseNumber);
+                out.set(key, {
+                    deptCode: dept.deptCode,
+                    deptName: dept.deptName,
+                    courseNumber: course.courseNumber,
+                    courseTitle: course.courseTitle,
+                });
+            }
+        }
+    }
+    return out;
+}
+
 async function main() {
-    // Staging/preview: merge or deploy from a feature branch to exercise the full pipeline.
     console.log('Generating cache for fuzzy search.');
     console.log('Fetching courses from Anteater API...');
     const courses: Course[] = [];
@@ -41,6 +71,7 @@ async function main() {
     console.log(`Fetched ${courses.length} courses.`);
     const courseMap = new Map<string, CourseSearchResult & { id: string }>();
     const deptMap = new Map<string, DepartmentSearchResult & { id: string }>();
+    const catalogueKeys = new Set<string>();
     for (const course of courses) {
         courseMap.set(course.id, {
             id: course.id,
@@ -52,6 +83,7 @@ async function main() {
                 number: course.courseNumber,
             },
         });
+        catalogueKeys.add(catalogCourseKey(course.department, course.courseNumber));
         deptMap.set(course.department, {
             id: course.department,
             type: 'DEPARTMENT',
@@ -65,16 +97,58 @@ async function main() {
 
     await mkdir(join(__dirname, '../src/generated/'), { recursive: true });
     await mkdir(join(__dirname, '../src/generated/terms/'), { recursive: true });
+
+    const latestTerm = termData[0];
+    const [latestYear, latestQuarter] = latestTerm.shortName.split(' ');
+    console.log(`Fetching WebSoc REST for ${latestTerm.shortName} (union with catalogue)...`);
+    const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
+        `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
+            year: latestYear,
+            quarter: latestQuarter,
+        }).toString()}`,
+        { isApiKeyRequired: true }
+    );
+    const fromWebsoc = indexWebsocCoursesByCatalogKey(websocRest.data);
+
+    let addedFromWebsoc = 0;
+    for (const [key, row] of fromWebsoc) {
+        if (catalogueKeys.has(key)) {
+            continue;
+        }
+        addedFromWebsoc += 1;
+        const id = `ws:${row.deptCode}:${row.courseNumber}`;
+        const name = (row.courseTitle ?? '').trim() || `${row.deptCode} ${row.courseNumber}`;
+        courseMap.set(id, {
+            id,
+            type: 'COURSE',
+            name,
+            alias: ALIASES[row.deptCode],
+            metadata: {
+                department: row.deptCode,
+                number: row.courseNumber,
+            },
+        });
+        if (!deptMap.has(row.deptCode)) {
+            deptMap.set(row.deptCode, {
+                id: row.deptCode,
+                type: 'DEPARTMENT',
+                name: (row.deptName ?? '').trim() || row.deptCode,
+                alias: ALIASES[row.deptCode],
+            });
+        }
+    }
+    console.log(`WebSoc union: ${fromWebsoc.size} courses in schedule, ${addedFromWebsoc} not in catalogue.`);
+
     await writeFile(
         join(__dirname, '../src/generated/searchData.ts'),
         `
     import type { CourseSearchResult, DepartmentSearchResult } from "@packages/antalmanac-types";
     export const departments: Array<DepartmentSearchResult & { id: string }> = ${JSON.stringify(
-        Array.from(deptMap.values())
-    )};
+            Array.from(deptMap.values())
+        )};
     export const courses: Array<CourseSearchResult & { id: string }> = ${JSON.stringify(
-        Array.from(courseMap.values())
-    )};
+            Array.from(courseMap.values())
+        )};
     `
     );
 

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -36,20 +36,20 @@ function catalogCourseKey(department: string, courseNumber: string) {
     return `${department.trim()}::${courseNumber.trim()}`;
 }
 
-function indexWebsocCoursesByCatalogKey(data: WebsocAPIResponse) {
+function getWebsocCoursesFromResponse(data: WebsocAPIResponse) {
     const out = new Map<
         string,
         Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
     >();
     for (const school of data.schools) {
         for (const dept of school.departments) {
-            for (const course of dept.courses) {
-                const key = catalogCourseKey(dept.deptCode, course.courseNumber);
+            for (const wsCourse of dept.courses) {
+                const key = catalogCourseKey(dept.deptCode, wsCourse.courseNumber);
                 out.set(key, {
                     deptCode: dept.deptCode,
                     deptName: dept.deptName,
-                    courseNumber: course.courseNumber,
-                    courseTitle: course.courseTitle,
+                    courseNumber: wsCourse.courseNumber,
+                    courseTitle: wsCourse.courseTitle,
                 });
             }
         }
@@ -113,32 +113,32 @@ async function main() {
         }).toString()}`,
         { isApiKeyRequired: true }
     );
-    const fromWebsoc = indexWebsocCoursesByCatalogKey(websocRest.data);
+    const fromWebsoc = getWebsocCoursesFromResponse(websocRest.data);
 
     let addedFromWebsoc = 0;
-    for (const [key, row] of fromWebsoc) {
+    for (const [key, course] of fromWebsoc) {
         if (catalogueKeys.has(key)) {
             continue;
         }
         addedFromWebsoc += 1;
-        const id = `ws:${row.deptCode}:${row.courseNumber}`;
-        const name = (row.courseTitle ?? '').trim() || `${row.deptCode} ${row.courseNumber}`;
+        const id = `ws:${course.deptCode}:${course.courseNumber}`;
+        const name = (course.courseTitle ?? '').trim() || `${course.deptCode} ${course.courseNumber}`;
         courseMap.set(id, {
             id,
             type: 'COURSE',
             name,
-            alias: ALIASES[row.deptCode],
+            alias: ALIASES[course.deptCode],
             metadata: {
-                department: row.deptCode,
-                number: row.courseNumber,
+                department: course.deptCode,
+                number: course.courseNumber,
             },
         });
-        if (!deptMap.has(row.deptCode)) {
-            deptMap.set(row.deptCode, {
-                id: row.deptCode,
+        if (!deptMap.has(course.deptCode)) {
+            deptMap.set(course.deptCode, {
+                id: course.deptCode,
                 type: 'DEPARTMENT',
-                name: (row.deptName ?? '').trim() || row.deptCode,
-                alias: ALIASES[row.deptCode],
+                name: (course.deptName ?? '').trim() || course.deptCode,
+                alias: ALIASES[course.deptCode],
             });
         }
     }

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -33,7 +33,7 @@ const ALIASES: Record<string, string | undefined> = {
 };
 
 function catalogCourseKey(department: string, courseNumber: string) {
-    return `${department.trim()}\0${courseNumber.trim()}`;
+    return `${department.trim()}::${courseNumber.trim()}`;
 }
 
 function indexWebsocCoursesByCatalogKey(data: WebsocAPIResponse) {

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -27,6 +27,7 @@ const ALIASES: Record<string, string | undefined> = {
 };
 
 async function main() {
+    // Staging/preview: merge or deploy from a feature branch to exercise the full pipeline.
     console.log('Generating cache for fuzzy search.');
     console.log('Fetching courses from Anteater API...');
     const courses: Course[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@packages/antalmanac-types':
         specifier: workspace:^
         version: link:../../packages/types
+      '@packages/anteater-api-types':
+        specifier: workspace:^
+        version: link:../../packages/anteater-api-types
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`get-search-data.ts` unions the **course catalogue** (`GET /v2/rest/courses`) with **one WebSoc schedule**: `GET /v2/rest/websoc` for **`termData[0]`** (latest SOC-available quarter). Courses on WebSoc that are not already in the catalogue get a synthetic autocomplete row with id `ws:{deptCode}:{courseNumber}` so search can reflect the schedule before the catalogue lists the class.

**Dedup (build-time only):** While merging, catalogue coverage is tracked in a `Set` using keys `trim(dept)::trim(courseNumber)`. That string is **not** written to `searchData.ts` or term JSON; persisted course ids remain the catalogue API `id` or the synthetic `ws:…` id above.

Types for the WebSoc payload: **`@packages/anteater-api-types`** (direct dependency on `apps/antalmanac`). **`pnpm-lock.yaml`** includes that workspace link.

## CI / `cache-generated-data`

The action restores **`apps/antalmanac/src/generated`** so old **`terms/*.json`** can be reused. **`tsx scripts/get-search-data.ts` always runs from the checked-out branch**, so script changes always apply. Union logs (`Fetching WebSoc REST for …`, `WebSoc union: …`) confirm that path ran.

## Limits

- Union uses **only** `termData[0]`, not every cached term.
- WebSoc does not expose the catalogue **`course.id`**; overlap is inferred from **dept + course number** (after trim), not from shared ids.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5adda475-868a-44dd-ad15-90946af71425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5adda475-868a-44dd-ad15-90946af71425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

