### PR TITLE
Document assumption: all course sectionTypes are required for missing-section alert

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/getMissingSections.ts
@@ -2,6 +2,14 @@ import { WebsocSectionType } from '@packages/antalmanac-types';
 
 import { CourseWithTerm } from '$components/RightPane/AddedCourses/AddedCoursePane';
 
+/**
+ * Returns human-readable labels for section types the user has not added yet.
+ *
+ * Product assumption: every modality listed in `course.sectionTypes` (the union of
+ * types WebSOC lists for that offering) is treated as required—the schedule should
+ * include at least one section per type. When `sectionTypes` is empty we cannot
+ * infer requirements and return no missing labels.
+ */
 export const getMissingSections = (userCourses: CourseWithTerm): string[] => {
     const requiredTypes = new Set<WebsocSectionType>(userCourses.sectionTypes ?? []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the product rule that `getMissingSections` already implements: every modality in `sectionTypes` counts as required until the user has added at least one section of that type.

## Test Plan

- No runtime changes; comment-only.

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23c70325-5961-4bff-8826-e2bc637cd319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23c70325-5961-4bff-8826-e2bc637cd319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

