### PR TITLE
feat: connect review analytics with posthog

### DIFF
--- a/apps/antalmanac/src/lib/analytics/analytics.ts
+++ b/apps/antalmanac/src/lib/analytics/analytics.ts
@@ -15,6 +15,7 @@ export interface AnalyticsEnum {
     classSearch: AnalyticsCategory;
     addedClasses: AnalyticsCategory;
     map: AnalyticsCategory;
+    review: AnalyticsCategory;
 }
 
 const analyticsEnum: AnalyticsEnum = {
@@ -99,6 +100,15 @@ const analyticsEnum: AnalyticsEnum = {
         actions: {
             OPEN: 'Open Map',
             CLICK_PIN: 'Click on Pin',
+        },
+    },
+    review: {
+        title: 'Review Prompt',
+        actions: {
+            PROMPT_SHOWN: 'Review Prompt Shown',
+            ENROLLMENT_CONFIRMED: 'Review Enrollment Confirmed',
+            DISMISSED: 'Review Prompt Dismissed',
+            SUBMITTED: 'Review Submitted',
         },
     },
 };

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -1,5 +1,7 @@
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
 import { termData } from '$lib/termData';
+import { postHog } from '$providers/PostHog';
 import AppStore from '$stores/AppStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import { create } from 'zustand';
@@ -140,18 +142,52 @@ export const useReviewPromptStore = create(
 
             const candidate = eligible[Math.floor(Math.random() * eligible.length)];
             set({ step: 'enrollment-confirm', candidate, rating: 0, difficulty: 0, selectedTags: [] });
+            logAnalytics(postHog, {
+                category: analyticsEnum.review,
+                action: analyticsEnum.review.actions.PROMPT_SHOWN,
+                customProps: {
+                    courseId: candidate.courseId,
+                    courseTitle: candidate.courseTitle,
+                    professorId: candidate.professorId,
+                    term: candidate.term,
+                },
+            });
         },
 
-        confirm: () => set({ step: 'review' }),
+        confirm: () => {
+            const { candidate } = get();
+            set({ step: 'review' });
+            if (candidate) {
+                logAnalytics(postHog, {
+                    category: analyticsEnum.review,
+                    action: analyticsEnum.review.actions.ENROLLMENT_CONFIRMED,
+                    customProps: {
+                        courseId: candidate.courseId,
+                        professorId: candidate.professorId,
+                        term: candidate.term,
+                    },
+                });
+            }
+        },
 
         /**
          * User closed the prompt without submitting (X, Skip, "I did not", snackbar click-away, Escape).
          * Persists the course+professor combo so it is not suggested again and starts the cooldown window.
          */
         dismiss: () => {
-            const { candidate } = get();
+            const { candidate, step } = get();
             set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [] });
             if (candidate) {
+                logAnalytics(postHog, {
+                    category: analyticsEnum.review,
+                    action: analyticsEnum.review.actions.DISMISSED,
+                    customProps: {
+                        courseId: candidate.courseId,
+                        professorId: candidate.professorId,
+                        term: candidate.term,
+                        dismissedAtStep: step,
+                    },
+                });
                 trpc.review.dismissReview
                     .mutate({ professorId: candidate.professorId, courseId: candidate.courseId })
                     .catch(() => {
@@ -187,6 +223,18 @@ export const useReviewPromptStore = create(
                     tags: selectedTags,
                 });
                 set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [] });
+                logAnalytics(postHog, {
+                    category: analyticsEnum.review,
+                    action: analyticsEnum.review.actions.SUBMITTED,
+                    customProps: {
+                        courseId: candidate.courseId,
+                        professorId: candidate.professorId,
+                        term: candidate.term,
+                        rating,
+                        difficulty,
+                        tags: selectedTags,
+                    },
+                });
                 openSnackbar('success', 'Review submitted — thanks for helping other Anteaters!');
             } catch {
                 openSnackbar('error', 'Failed to submit review. Please try again.');


### PR DESCRIPTION
## Summary
- Added a `review` category to `analyticsEnum` (and its `AnalyticsEnum` interface) with four actions: `PROMPT_SHOWN`, `ENROLLMENT_CONFIRMED`, `DISMISSED`, and `SUBMITTED`
- Wired `ReviewPromptStore` to PostHog by importing the `postHog` singleton from `$providers/PostHog` and calling `logAnalytics` at each key user interaction in the review prompt flow

## Test Plan 
- [ ] Trigger the review prompt (add a course from a past term, sign in, wait for `initPrompt` to run) and confirm a `Review Prompt Shown` event appears in the PostHog dashboard with the correct `courseId`, `courseTitle`, `professorId`, and `term` props
- [ ] Click "Yes, I took this course" and confirm a `Review Enrollment Confirmed` event fires
- [ ] Dismiss the prompt via X / Skip / "I did not" and confirm a `Review Prompt Dismissed` event fires with the correct `dismissedAtStep` value (`enrollment-confirm` or `review`)
- [ ] Submit a review and confirm a `Review Submitted` event fires with `rating`, `difficulty`, and `tags` props


## Issues

Closes #1676

<!-- [Optional]
## Future Followup
-->
