### PR TITLE
Fix restrictions column font size on mobile vs desktop

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
@@ -67,6 +67,7 @@ export const RestrictionsCell = ({ restrictions }: RestrictionsCellProps) => {
                         <Typography
                             component="button"
                             type="button"
+                            variant="inherit"
                             onClick={(e) => {
                                 setAnchorEl((cur) => (cur ? null : e.currentTarget));
                             }}
@@ -92,7 +93,7 @@ export const RestrictionsCell = ({ restrictions }: RestrictionsCellProps) => {
                 ) : (
                     <Tooltip title={restrictionDescriptions}>
                         <Typography
-                            sx={{ fontSize: 'unset' }}
+                            variant="inherit"
                             component="a"
                             href="https://www.reg.uci.edu/enrollment/restrict_codes.html"
                             target="_blank"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The restrictions column used `Typography` with default `body1` sizing for the mobile tap target (`component="button"`), while desktop used `fontSize: 'unset'` so the text matched the small table. That made the cell look inconsistent across breakpoints relative to other section table cells.

Both branches now use `variant="inherit"` so the restrictions text follows the parent `TableCell` typography (same as plain text cells like status and details).

## Test Plan

- [ ] Open a course section table on desktop: restrictions codes should match surrounding column text size.
- [ ] Narrow the viewport or use mobile: tap restrictions; the underlined trigger text should match other cells, and the popover content remains readable.

## Issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-527e97c7-db45-4551-ae54-d97a24f27651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-527e97c7-db45-4551-ae54-d97a24f27651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

