### PR TITLE
Hide patch notes after 30 days from release date

### DIFF
--- a/apps/antalmanac/src/components/buttons/PatchNotesButton.tsx
+++ b/apps/antalmanac/src/components/buttons/PatchNotesButton.tsx
@@ -1,4 +1,4 @@
-import { arePatchNotesStale, usePatchNotesStore } from '$stores/PatchNotesStore';
+import { usePatchNotesStore } from '$stores/PatchNotesStore';
 import { Campaign } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { useCallback } from 'react';
@@ -10,10 +10,6 @@ export const PatchNotesButton = () => {
     const handleClick = useCallback(() => {
         setShowPatchNotes(true);
     }, [setShowPatchNotes]);
-
-    if (arePatchNotesStale()) {
-        return null;
-    }
 
     return (
         <Button onClick={handleClick} color="inherit" startIcon={<Campaign />} size="large" variant="text">

--- a/apps/antalmanac/src/components/buttons/PatchNotesButton.tsx
+++ b/apps/antalmanac/src/components/buttons/PatchNotesButton.tsx
@@ -1,4 +1,4 @@
-import { usePatchNotesStore } from '$stores/PatchNotesStore';
+import { arePatchNotesStale, usePatchNotesStore } from '$stores/PatchNotesStore';
 import { Campaign } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { useCallback } from 'react';
@@ -10,6 +10,10 @@ export const PatchNotesButton = () => {
     const handleClick = useCallback(() => {
         setShowPatchNotes(true);
     }, [setShowPatchNotes]);
+
+    if (arePatchNotesStale()) {
+        return null;
+    }
 
     return (
         <Button onClick={handleClick} color="inherit" startIcon={<Campaign />} size="large" variant="text">

--- a/apps/antalmanac/src/stores/PatchNotesStore.ts
+++ b/apps/antalmanac/src/stores/PatchNotesStore.ts
@@ -1,5 +1,6 @@
 import { getLocalStoragePatchNotesKey } from '$lib/localStorage';
 import { tourShouldRun } from '$lib/TutorialHelpers';
+import { differenceInCalendarDays, parse, startOfDay } from 'date-fns';
 import { create } from 'zustand';
 
 /**
@@ -10,13 +11,28 @@ import { create } from 'zustand';
  */
 export const LATEST_PATCH_NOTES_UPDATE = '20260130';
 
+const PATCH_NOTES_ADDED_ON = parse(LATEST_PATCH_NOTES_UPDATE, 'yyyyMMdd', new Date());
+
+/** Hide auto patch notes and the Patch Notes entry point after this many calendar days since release. */
+const PATCH_NOTES_MAX_AGE_CALENDAR_DAYS = 30;
+
+export function arePatchNotesStale(now: Date = new Date()) {
+    return (
+        differenceInCalendarDays(startOfDay(now), startOfDay(PATCH_NOTES_ADDED_ON)) > PATCH_NOTES_MAX_AGE_CALENDAR_DAYS
+    );
+}
+
 export interface PatchNotesStoreProps {
     showPatchNotes: boolean;
     setShowPatchNotes: (value: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 export function shouldShowPatchNotes() {
-    return getLocalStoragePatchNotesKey() !== LATEST_PATCH_NOTES_UPDATE && !tourShouldRun();
+    return (
+        !arePatchNotesStale() &&
+        getLocalStoragePatchNotesKey() !== LATEST_PATCH_NOTES_UPDATE &&
+        !tourShouldRun()
+    );
 }
 
 export const usePatchNotesStore = create<PatchNotesStoreProps>((set) => {

--- a/apps/antalmanac/src/stores/PatchNotesStore.ts
+++ b/apps/antalmanac/src/stores/PatchNotesStore.ts
@@ -13,10 +13,10 @@ export const LATEST_PATCH_NOTES_UPDATE = '20260130';
 
 const PATCH_NOTES_ADDED_ON = parse(LATEST_PATCH_NOTES_UPDATE, 'yyyyMMdd', new Date());
 
-/** Hide auto patch notes and the Patch Notes entry point after this many calendar days since release. */
+/** Stop auto-opening the patch notes modal after this many calendar days since release. */
 const PATCH_NOTES_MAX_AGE_CALENDAR_DAYS = 30;
 
-export function arePatchNotesStale(now: Date = new Date()) {
+function arePatchNotesStale(now: Date = new Date()) {
     return (
         differenceInCalendarDays(startOfDay(now), startOfDay(PATCH_NOTES_ADDED_ON)) > PATCH_NOTES_MAX_AGE_CALENDAR_DAYS
     );

--- a/apps/antalmanac/tests/patch-notes.test.tsx
+++ b/apps/antalmanac/tests/patch-notes.test.tsx
@@ -1,6 +1,11 @@
 import PatchNotes, { closeButtonTestId, dialogTestId, backdropTestId } from '$components/PatchNotes';
+import {
+    getLocalStoragePatchNotesKey,
+    setLocalStoragePatchNotesKey,
+    setLocalStorageTourHasRun,
+} from '$lib/localStorage';
 import { LATEST_PATCH_NOTES_UPDATE, shouldShowPatchNotes, usePatchNotesStore } from '$stores/PatchNotesStore';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 describe('patch notes', () => {
@@ -67,7 +72,7 @@ describe('patch notes', () => {
     });
 
     describe('close patch notes with button', () => {
-        test('clicking the button closes the dialog', () => {
+        test('clicking the button closes the dialog', async () => {
             usePatchNotesStore.setState({ showPatchNotes: true });
 
             render(<PatchNotes />);
@@ -76,7 +81,9 @@ describe('patch notes', () => {
                 screen.getByTestId(closeButtonTestId).click();
             });
 
-            expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
+            await waitFor(() => {
+                expect(screen.queryByTestId(dialogTestId)).toBeNull();
+            });
         });
 
         test('the latest patch notes is saved to local storage', () => {
@@ -94,7 +101,7 @@ describe('patch notes', () => {
     });
 
     describe('closing the dialog by clicking the backdrop ', () => {
-        test('clicking the backdrop closes the dialog', () => {
+        test('clicking the backdrop closes the dialog', async () => {
             usePatchNotesStore.setState({ showPatchNotes: true });
 
             render(<PatchNotes />);
@@ -103,7 +110,9 @@ describe('patch notes', () => {
                 screen.getByTestId(backdropTestId).click();
             });
 
-            expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
+            await waitFor(() => {
+                expect(screen.queryByTestId(dialogTestId)).toBeNull();
+            });
         });
 
         test('the latest patch notes is saved to local storage', () => {

--- a/apps/antalmanac/tests/patch-notes.test.tsx
+++ b/apps/antalmanac/tests/patch-notes.test.tsx
@@ -1,4 +1,5 @@
 import PatchNotes, { closeButtonTestId, dialogTestId, backdropTestId } from '$components/PatchNotes';
+import { PatchNotesButton } from '$components/buttons/PatchNotesButton';
 import {
     getLocalStoragePatchNotesKey,
     setLocalStoragePatchNotesKey,
@@ -6,13 +7,17 @@ import {
 } from '$lib/localStorage';
 import { LATEST_PATCH_NOTES_UPDATE, shouldShowPatchNotes, usePatchNotesStore } from '$stores/PatchNotesStore';
 import { render, screen, act } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 describe('patch notes', () => {
     /**
      * A date that's guaranteed to be outdated.
      */
     const outdatedPatchNotes = '00000000';
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
 
     describe('patch notes displays appropriately', () => {
         test('displays when latest patch notes is outdated ', () => {
@@ -33,6 +38,43 @@ describe('patch notes', () => {
 
             expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
         });
+
+        test('no auto display when patch notes are older than 30 calendar days', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-03-02T12:00:00.000Z'));
+
+            setLocalStoragePatchNotesKey(outdatedPatchNotes);
+            setLocalStorageTourHasRun('true');
+            usePatchNotesStore.setState({ showPatchNotes: shouldShowPatchNotes() });
+
+            render(<PatchNotes />);
+
+            expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
+        });
+
+        test('auto display still allowed on the 30th calendar day after release', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
+
+            setLocalStoragePatchNotesKey(outdatedPatchNotes);
+            setLocalStorageTourHasRun('true');
+            usePatchNotesStore.setState({ showPatchNotes: shouldShowPatchNotes() });
+
+            render(<PatchNotes />);
+
+            expect(screen.queryByTestId(dialogTestId)).toBeTruthy();
+        });
+    });
+
+    describe('patch notes button visibility', () => {
+        test('hides Patch Notes button when release is past 30 calendar days', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-03-02T12:00:00.000Z'));
+
+            render(<PatchNotesButton />);
+
+            expect(screen.queryByRole('button', { name: /patch notes/i })).toBeFalsy();
+        });
     });
 
     describe('close patch notes with button', () => {
@@ -45,7 +87,7 @@ describe('patch notes', () => {
                 screen.getByTestId(closeButtonTestId).click();
             });
 
-            expect(screen.queryByTitle(dialogTestId)).toBeFalsy();
+            expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
         });
 
         test('the latest patch notes is saved to local storage', () => {
@@ -72,9 +114,7 @@ describe('patch notes', () => {
                 screen.getByTestId(backdropTestId).click();
             });
 
-            const dialog = screen.queryByTitle(dialogTestId);
-
-            expect(dialog).toBeFalsy();
+            expect(screen.queryByTestId(dialogTestId)).toBeFalsy();
         });
 
         test('the latest patch notes is saved to local storage', () => {

--- a/apps/antalmanac/tests/patch-notes.test.tsx
+++ b/apps/antalmanac/tests/patch-notes.test.tsx
@@ -1,10 +1,4 @@
 import PatchNotes, { closeButtonTestId, dialogTestId, backdropTestId } from '$components/PatchNotes';
-import { PatchNotesButton } from '$components/buttons/PatchNotesButton';
-import {
-    getLocalStoragePatchNotesKey,
-    setLocalStoragePatchNotesKey,
-    setLocalStorageTourHasRun,
-} from '$lib/localStorage';
 import { LATEST_PATCH_NOTES_UPDATE, shouldShowPatchNotes, usePatchNotesStore } from '$stores/PatchNotesStore';
 import { render, screen, act } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -69,26 +63,6 @@ describe('patch notes', () => {
             render(<PatchNotes />);
 
             expect(screen.queryByTestId(dialogTestId)).toBeTruthy();
-        });
-    });
-
-    describe('patch notes button visibility', () => {
-        test('shows Patch Notes button when release is within 30 calendar days', () => {
-            vi.useFakeTimers();
-            vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
-
-            render(<PatchNotesButton />);
-
-            expect(screen.getByRole('button', { name: /patch notes/i })).toBeTruthy();
-        });
-
-        test('hides Patch Notes button when release is past 30 calendar days', () => {
-            vi.useFakeTimers();
-            vi.setSystemTime(new Date('2026-03-02T12:00:00.000Z'));
-
-            render(<PatchNotesButton />);
-
-            expect(screen.queryByRole('button', { name: /patch notes/i })).toBeFalsy();
         });
     });
 

--- a/apps/antalmanac/tests/patch-notes.test.tsx
+++ b/apps/antalmanac/tests/patch-notes.test.tsx
@@ -21,6 +21,9 @@ describe('patch notes', () => {
 
     describe('patch notes displays appropriately', () => {
         test('displays when latest patch notes is outdated ', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
+
             setLocalStoragePatchNotesKey(outdatedPatchNotes);
             setLocalStorageTourHasRun('true');
             usePatchNotesStore.setState({ showPatchNotes: shouldShowPatchNotes() });
@@ -31,6 +34,9 @@ describe('patch notes', () => {
         });
 
         test('no display when latest patch notes is up to date', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
+
             setLocalStoragePatchNotesKey(LATEST_PATCH_NOTES_UPDATE);
             usePatchNotesStore.setState({ showPatchNotes: shouldShowPatchNotes() });
 
@@ -67,6 +73,15 @@ describe('patch notes', () => {
     });
 
     describe('patch notes button visibility', () => {
+        test('shows Patch Notes button when release is within 30 calendar days', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
+
+            render(<PatchNotesButton />);
+
+            expect(screen.getByRole('button', { name: /patch notes/i })).toBeTruthy();
+        });
+
         test('hides Patch Notes button when release is past 30 calendar days', () => {
             vi.useFakeTimers();
             vi.setSystemTime(new Date('2026-03-02T12:00:00.000Z'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Patch notes are tied to `LATEST_PATCH_NOTES_UPDATE` (YYYYMMDD). After more than **30 calendar days** since that date, **`shouldShowPatchNotes()`** no longer opens the modal on load. The **Patch Notes** menu button always remains so users can open the dialog manually.

## Tests
- Vitest fake timers pin `"now"` where `shouldShowPatchNotes()` is asserted.
- Restored `localStorage` helper imports (fixes `setLocalStoragePatchNotesKey is not defined` in CI).
- Close/backdrop tests use `waitFor` until the dialog unmounts (MUI keeps the root during exit transition).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd5df1ef-fee2-4a07-a243-60a947eecbf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd5df1ef-fee2-4a07-a243-60a947eecbf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

