### PR TITLE
fix: align getCurrentFallbackSchedule return type with indexing

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -16,7 +16,7 @@ import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleS
 import { useTabStore } from '$stores/TabStore';
 import { MenuBook } from '@mui/icons-material';
 import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, useTheme } from '@mui/material';
-import { AACourse, type ShortCourseSchedule } from '@packages/antalmanac-types';
+import { AACourse } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -40,13 +40,6 @@ export interface CourseWithTerm extends AACourse {
 }
 
 const NOTE_MAX_LEN = 5000;
-
-const EMPTY_FALLBACK_SCHEDULE: ShortCourseSchedule = {
-    scheduleName: '',
-    courses: [],
-    customEvents: [],
-    scheduleNote: '',
-};
 
 function getCourses() {
     const currentCourses = AppStore.schedule.getCurrentCourses();
@@ -103,7 +96,7 @@ function CustomEventsBox() {
 
     const [customEvents, setCustomEvents] = useState(
         fallbackMode
-            ? (getCurrentFallbackSchedule(currentScheduleIndex)?.customEvents ?? [])
+            ? getCurrentFallbackSchedule(currentScheduleIndex).customEvents
             : AppStore.schedule.getCurrentCustomEvents()
     );
 
@@ -149,7 +142,7 @@ function ScheduleNoteBox() {
     const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore();
     const [scheduleNote, setScheduleNote] = useState(
         fallbackMode
-            ? (getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex())?.scheduleNote ?? '')
+            ? getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex()).scheduleNote
             : AppStore.getCurrentScheduleNote()
     );
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
@@ -236,8 +229,7 @@ function FallbackSchedule() {
         };
     }, []);
 
-    const fallbackSchedule =
-        getCurrentFallbackSchedule(currentScheduleIndex) ?? EMPTY_FALLBACK_SCHEDULE;
+    const fallbackSchedule = getCurrentFallbackSchedule(currentScheduleIndex);
 
     const sectionsByTerm: [string, string[]][] = useMemo(() => {
         const result = fallbackSchedule.courses.reduce(

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -16,7 +16,7 @@ import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleS
 import { useTabStore } from '$stores/TabStore';
 import { MenuBook } from '@mui/icons-material';
 import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, useTheme } from '@mui/material';
-import { AACourse } from '@packages/antalmanac-types';
+import { AACourse, type ShortCourseSchedule } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -40,6 +40,13 @@ export interface CourseWithTerm extends AACourse {
 }
 
 const NOTE_MAX_LEN = 5000;
+
+const EMPTY_FALLBACK_SCHEDULE: ShortCourseSchedule = {
+    scheduleName: '',
+    courses: [],
+    customEvents: [],
+    scheduleNote: '',
+};
 
 function getCourses() {
     const currentCourses = AppStore.schedule.getCurrentCourses();
@@ -96,7 +103,7 @@ function CustomEventsBox() {
 
     const [customEvents, setCustomEvents] = useState(
         fallbackMode
-            ? getCurrentFallbackSchedule(currentScheduleIndex).customEvents
+            ? (getCurrentFallbackSchedule(currentScheduleIndex)?.customEvents ?? [])
             : AppStore.schedule.getCurrentCustomEvents()
     );
 
@@ -142,7 +149,7 @@ function ScheduleNoteBox() {
     const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore();
     const [scheduleNote, setScheduleNote] = useState(
         fallbackMode
-            ? getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex()).scheduleNote
+            ? (getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex())?.scheduleNote ?? '')
             : AppStore.getCurrentScheduleNote()
     );
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
@@ -229,7 +236,8 @@ function FallbackSchedule() {
         };
     }, []);
 
-    const fallbackSchedule = getCurrentFallbackSchedule(currentScheduleIndex);
+    const fallbackSchedule =
+        getCurrentFallbackSchedule(currentScheduleIndex) ?? EMPTY_FALLBACK_SCHEDULE;
 
     const sectionsByTerm: [string, string[]][] = useMemo(() => {
         const result = fallbackSchedule.courses.reduce(

--- a/apps/antalmanac/src/stores/FallbackStore.ts
+++ b/apps/antalmanac/src/stores/FallbackStore.ts
@@ -6,7 +6,7 @@ interface FallbackStore {
     fallbackSchedules: ShortCourseSchedule[];
 
     loadFallbackSchedules: (schedules: ShortCourseSchedule[]) => void;
-    getCurrentFallbackSchedule: (currentScheduleIndex: number) => ShortCourseSchedule;
+    getCurrentFallbackSchedule: (currentScheduleIndex: number) => ShortCourseSchedule | undefined;
     getFallbackScheduleNames: () => string[];
 }
 

--- a/apps/antalmanac/src/stores/FallbackStore.ts
+++ b/apps/antalmanac/src/stores/FallbackStore.ts
@@ -1,12 +1,19 @@
 import type { ShortCourseSchedule } from '@packages/antalmanac-types';
 import { create } from 'zustand';
 
+const EMPTY_FALLBACK_SCHEDULE: ShortCourseSchedule = {
+    scheduleName: '',
+    courses: [],
+    customEvents: [],
+    scheduleNote: '',
+};
+
 interface FallbackStore {
     fallbackMode: boolean;
     fallbackSchedules: ShortCourseSchedule[];
 
     loadFallbackSchedules: (schedules: ShortCourseSchedule[]) => void;
-    getCurrentFallbackSchedule: (currentScheduleIndex: number) => ShortCourseSchedule | undefined;
+    getCurrentFallbackSchedule: (currentScheduleIndex: number) => ShortCourseSchedule;
     getFallbackScheduleNames: () => string[];
 }
 
@@ -19,7 +26,7 @@ export const useFallbackStore = create<FallbackStore>((set, get) => ({
     },
 
     getCurrentFallbackSchedule: (currentScheduleIndex: number) => {
-        return get().fallbackSchedules[currentScheduleIndex];
+        return get().fallbackSchedules.at(currentScheduleIndex) ?? EMPTY_FALLBACK_SCHEDULE;
     },
 
     getFallbackScheduleNames: () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the open review on https://github.com/icssc/AntAlmanac/pull/1709: `getCurrentFallbackSchedule` must not pretend array indexing always yields a schedule. The handler now uses `fallbackSchedules.at(index) ?? EMPTY_FALLBACK_SCHEDULE`, so the public type stays `ShortCourseSchedule` and callers stay simple. The empty default lives next to the getter in `FallbackStore`.

(Finding identified by cubic on #1709.)

## Test Plan

- Not run locally (Node/pnpm unavailable in this environment). CI lint should cover the change.

## Issues

Related to #1208 (parent PR stack).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-021d481d-8dd1-4b33-8704-e7e57d50d5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-021d481d-8dd1-4b33-8704-e7e57d50d5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

