### PR TITLE
fix: use schedule name as downloaded file name

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -360,7 +360,7 @@ export function exportCalendar() {
         });
 
         // Download the .ics file
-        const scheduleName = AppStore.getScheduleNames()[AppStore.getCurrentScheduleIndex()];
+        const scheduleName = AppStore.getScheduleNames()[AppStore.getCurrentScheduleIndex()] ?? 'schedule';
         saveAs(data, `${scheduleName}.ics`);
         openSnackbar('success', 'Schedule downloaded!', { durationSeconds: 5 });
     });

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -1,14 +1,13 @@
-import type { HourMinute } from '@packages/antalmanac-types';
-import { saveAs } from 'file-saver';
-import { createEvents, type EventAttributes } from 'ics';
-
-import { notNull } from './utils';
-
 import type { CustomEvent, FinalExam } from '$components/Calendar/CourseCalendarEvent';
 import buildingCatalogue from '$lib/locations/buildingCatalogue';
 import { getDefaultTerm, termData } from '$lib/termData';
 import AppStore from '$stores/AppStore';
 import { openSnackbar } from '$stores/SnackbarStore';
+import type { HourMinute } from '@packages/antalmanac-types';
+import { saveAs } from 'file-saver';
+import { createEvents, type EventAttributes } from 'ics';
+
+import { notNull } from './utils';
 
 export const quarterStartDates = Object.fromEntries(termData.map((term) => [term.shortName, term.startDate]));
 
@@ -361,7 +360,8 @@ export function exportCalendar() {
         });
 
         // Download the .ics file
-        saveAs(data, 'schedule.ics');
+        const scheduleName = AppStore.getScheduleNames()[AppStore.getCurrentScheduleIndex()];
+        saveAs(data, `${scheduleName}.ics`);
         openSnackbar('success', 'Schedule downloaded!', { durationSeconds: 5 });
     });
 }


### PR DESCRIPTION
## Summary
Previously, the .ics download file is always schedule.ics. This has now been changed to use the name of the calendar that is being downloaded.

## Test Plan
Downloaded .ics file now has name of calendar.

## Issues

Closes https://github.com/icssc/AntAlmanac/issues/1708
<!-- [Optional]
## Future Followup
-->
