### PR TITLE
fix: open tutorial on page load, not menu open

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -1,7 +1,6 @@
 import './App.css';
 import { undoDelete, redoDelete } from '$actions/AppStoreActions';
 import { AutoSignIn } from '$components/AutoSignIn';
-import { TutorialInitializer } from '$components/TutorialInitializer';
 import PosthogPageviewTracker from '$lib/analytics/PostHogPageviewTracker';
 import AppPostHogProvider from '$providers/PostHog';
 import AppQueryProvider from '$providers/Query';
@@ -145,7 +144,6 @@ export default function App() {
                                 }),
                             }}
                         >
-                            <TutorialInitializer />
                             <RouterProvider router={ROUTER} />
                         </TourProvider>
                     </AppQueryProvider>

--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 import { undoDelete, redoDelete } from '$actions/AppStoreActions';
 import { AutoSignIn } from '$components/AutoSignIn';
+import { TutorialInitializer } from '$components/TutorialInitializer';
 import PosthogPageviewTracker from '$lib/analytics/PostHogPageviewTracker';
 import AppPostHogProvider from '$providers/PostHog';
 import AppQueryProvider from '$providers/Query';
@@ -144,6 +145,7 @@ export default function App() {
                                 }),
                             }}
                         >
+                            <TutorialInitializer />
                             <RouterProvider router={ROUTER} />
                         </TourProvider>
                     </AppQueryProvider>

--- a/apps/antalmanac/src/components/TutorialInitializer.tsx
+++ b/apps/antalmanac/src/components/TutorialInitializer.tsx
@@ -1,0 +1,21 @@
+import { stepsFactory, tourShouldRun } from '$lib/TutorialHelpers';
+import { useTour } from '@reactour/tour';
+import { useEffect } from 'react';
+
+export function TutorialInitializer() {
+    const { setSteps, setCurrentStep, setIsOpen } = useTour();
+
+    useEffect(() => {
+        if (setSteps == null || setCurrentStep == null) {
+            return;
+        }
+
+        setSteps(stepsFactory(setCurrentStep));
+
+        if (tourShouldRun()) {
+            setIsOpen(true);
+        }
+    }, [setCurrentStep, setSteps, setIsOpen]);
+
+    return null;
+}

--- a/apps/antalmanac/src/components/buttons/TutorialButton.tsx
+++ b/apps/antalmanac/src/components/buttons/TutorialButton.tsx
@@ -1,19 +1,17 @@
+import { removeSampleClasses } from '$lib/tourExampleGeneration';
+import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { PlayLesson } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { useTour } from '@reactour/tour';
 import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-import { stepsFactory, tourShouldRun } from '$lib/TutorialHelpers';
-import { removeSampleClasses } from '$lib/tourExampleGeneration';
-import { useCoursePaneStore } from '$stores/CoursePaneStore';
-
 interface TutorialButtonProps {
     onMenuClose?: () => void;
 }
 
 export const TutorialButton = ({ onMenuClose }: TutorialButtonProps) => {
-    const { setCurrentStep, setIsOpen, setSteps, isOpen } = useTour();
+    const { setCurrentStep, setIsOpen, isOpen } = useTour();
     const [displaySearch, disableManualSearch] = useCoursePaneStore(
         useShallow((state) => [state.displaySearch, state.disableManualSearch])
     );
@@ -25,21 +23,11 @@ export const TutorialButton = ({ onMenuClose }: TutorialButtonProps) => {
         setIsOpen(true);
     }, [displaySearch, disableManualSearch, setCurrentStep, setIsOpen]);
 
-    useEffect(() => setIsOpen(tourShouldRun), [setIsOpen]);
-
     useEffect(() => {
         return () => {
             removeSampleClasses();
         };
     }, [isOpen]);
-
-    useEffect(() => {
-        if (setSteps == null || setCurrentStep == null) {
-            return;
-        }
-
-        setSteps(stepsFactory(setCurrentStep));
-    }, [setCurrentStep, setSteps]);
 
     const handleClick = useCallback(() => {
         onMenuClose?.();

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -6,6 +6,7 @@ import { NotificationSnackbar } from '$components/NotificationSnackbar';
 import PatchNotes from '$components/PatchNotes';
 import { ReviewPrompt } from '$components/ReviewPrompt/ReviewPrompt';
 import { ScheduleManagement } from '$components/ScheduleManagement/ScheduleManagement';
+import { TutorialInitializer } from '$components/TutorialInitializer';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useKeyboardShortcutsModal } from '$hooks/useKeyboardShortcutsModal';
 import { BLUE } from '$src/globals';
@@ -81,6 +82,7 @@ export default function Home() {
 
     return (
         <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <TutorialInitializer />
             <PatchNotes />
             <InstallPWABanner />
 


### PR DESCRIPTION
## Summary
Move the `useEffect` and `setIsOpen` to the root component so that the tutorial launches on page load rather than only when you can see the tutorial button in the menu.


## Test Plan
- Open an incognito window, visit AntAlmanac
- Tutorial opens on page load, doesn't automatically open when viewing menu

## Issues

Closes https://github.com/icssc/AntAlmanac/issues/1689
