### PR TITLE
fix(antalmanac): temp-save clamp, loadSchedule flag, auto-save cleanup

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import * as AppStoreActions from '$actions/AppStoreActions';
+import { autoSaveSchedule } from '$actions/AppStoreActions';
 import { getLocalStorageAutoSave } from '$lib/localStorage';
 import { postHog } from '$providers/PostHog';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
@@ -121,11 +121,8 @@ class ActionTypesStore extends EventEmitter {
         }
 
         this.emit('autoSaveStart');
-        try {
-            await AppStoreActions.autoSaveSchedule({ postHog });
-        } finally {
-            this.emit('autoSaveEnd');
-        }
+        await autoSaveSchedule({ postHog });
+        this.emit('autoSaveEnd');
     }
 }
 

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -1,9 +1,8 @@
 import { EventEmitter } from 'events';
 
-import { autoSaveSchedule } from '$actions/AppStoreActions';
+import { autoSaveSchedule as persistAutoSaveSchedule } from '$actions/AppStoreActions';
 import { getLocalStorageAutoSave } from '$lib/localStorage';
 import { postHog } from '$providers/PostHog';
-import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
 import type { CustomEventId, RepeatingCustomEvent, ScheduleCourse } from '@packages/antalmanac-types';
@@ -117,17 +116,15 @@ class ActionTypesStore extends EventEmitter {
             return;
         }
 
-        if (autoSave) {
-            this.emit('autoSaveStart');
+        if (!autoSave) {
+            return;
+        }
 
-            try {
-                await autoSaveSchedule({ postHog });
-                AppStore.unsavedChanges = false;
-            } catch (error) {
-                console.error('Auto-save failed:', error);
-            } finally {
-                this.emit('autoSaveEnd');
-            }
+        this.emit('autoSaveStart');
+        try {
+            await persistAutoSaveSchedule({ postHog });
+        } finally {
+            this.emit('autoSaveEnd');
         }
     }
 }

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { autoSaveSchedule as persistAutoSaveSchedule } from '$actions/AppStoreActions';
+import * as AppStoreActions from '$actions/AppStoreActions';
 import { getLocalStorageAutoSave } from '$lib/localStorage';
 import { postHog } from '$providers/PostHog';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
@@ -122,7 +122,7 @@ class ActionTypesStore extends EventEmitter {
 
         this.emit('autoSaveStart');
         try {
-            await persistAutoSaveSchedule({ postHog });
+            await AppStoreActions.autoSaveSchedule({ postHog });
         } finally {
             this.emit('autoSaveEnd');
         }

--- a/apps/antalmanac/src/components/Header/Settings/ExperimentalMenu.tsx
+++ b/apps/antalmanac/src/components/Header/Settings/ExperimentalMenu.tsx
@@ -1,6 +1,5 @@
-import actionTypesStore from '$actions/ActionTypesStore';
 import { autoSaveSchedule } from '$actions/AppStoreActions';
-import appStore from '$stores/AppStore';
+import actionTypesStore from '$actions/ActionTypesStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { usePreviewStore, useAutoSaveStore, useDevModeStore } from '$stores/SettingsStore';
@@ -14,7 +13,6 @@ export function ExperimentalMenu() {
     const { sessionIsValid } = useSessionStore();
     const { setOpenAutoSaveWarning } = scheduleComponentsToggleStore();
     const [devMode, setDevMode] = useDevModeStore((store) => [store.devMode, store.setDevMode]);
-
     const postHog = usePostHog();
 
     const handlePreviewChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +33,6 @@ export function ExperimentalMenu() {
 
         actionTypesStore.emit('autoSaveStart');
         await autoSaveSchedule({ postHog });
-        appStore.unsavedChanges = false;
         actionTypesStore.emit('autoSaveEnd');
     };
 

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -25,6 +25,7 @@ import type {
     AddScheduleAction,
 } from '$actions/ActionTypesStore';
 import type { CalendarEvent, CourseEvent } from '$components/Calendar/CourseCalendarEvent';
+import { removeLocalStorageUnsavedActions } from '$lib/localStorage';
 import { Schedules } from '$stores/Schedules';
 import { useTabStore } from '$stores/TabStore';
 import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
@@ -305,7 +306,7 @@ class AppStore extends EventEmitter {
 
     saveSchedule() {
         this.unsavedChanges = false;
-        window.localStorage.removeItem('unsavedActions');
+        removeLocalStorageUnsavedActions();
     }
 
     copySchedule(scheduleIndex: number, newScheduleName: string) {
@@ -348,7 +349,8 @@ class AppStore extends EventEmitter {
     }
 
     async loadSchedule(savedSchedule: ScheduleSaveState) {
-        const hasDataChanged = JSON.stringify(this.schedule.getScheduleAsSaveState()) === JSON.stringify(savedSchedule);
+        const loadedStateMatchesCurrent =
+            JSON.stringify(this.schedule.getScheduleAsSaveState()) === JSON.stringify(savedSchedule);
         const loadSuccess = await this.loadScheduleFromSaveState(savedSchedule);
         if (!loadSuccess) {
             return false;
@@ -357,7 +359,7 @@ class AppStore extends EventEmitter {
 
         this.schedule.clearPreviousStates();
 
-        if (hasDataChanged) {
+        if (loadedStateMatchesCurrent) {
             deleteTempSaveData();
         } else {
             loadTempSaveData(savedSchedule.schedules.length);

--- a/apps/antalmanac/src/stores/localTempSaveDataHelpers.ts
+++ b/apps/antalmanac/src/stores/localTempSaveDataHelpers.ts
@@ -39,7 +39,7 @@ export function loadTempSaveData(scheduleCount: number) {
 
         if (parsedData.currentScheduleIndex !== undefined) {
             if (parsedData.currentScheduleIndex >= scheduleCount) {
-                parsedData.currentScheduleIndex = scheduleCount = 1;
+                parsedData.currentScheduleIndex = scheduleCount > 0 ? scheduleCount - 1 : 0;
             }
             changeCurrentSchedule(parsedData.currentScheduleIndex);
         }
@@ -53,7 +53,7 @@ export function loadTempSaveData(scheduleCount: number) {
  *
  * ```typescript
  *
- *   setTempSaveData({ currentSCheduleIndex: 0 });
+ *   setTempSaveData({ currentScheduleIndex: 0 });
  *
  * ```
  *


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up for review feedback on [#1716](https://github.com/icssc/AntAlmanac/pull/1716):

- Restored the named import `import { autoSaveSchedule } from '$actions/AppStoreActions'` (no need for `import * as AppStoreActions`).
- Removed the `try`/`finally` around `autoSaveSchedule`: `autoSaveSchedule` in `AppStoreActions` catches failures internally and does not rethrow, so `autoSaveEnd` can follow a plain `await` after `autoSaveStart`.

Prior changes (temp-save clamp, `loadSchedule` flag, unsaved-actions cleanup, ExperimentalMenu, etc.) are unchanged from the earlier revision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39783602-249f-453c-b710-5b0e70213db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39783602-249f-453c-b710-5b0e70213db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

