### PR TITLE
fix(antalmanac): shared save validation and OAuth cache schema check

### DIFF
--- a/apps/antalmanac/src/backend/routers/userData.ts
+++ b/apps/antalmanac/src/backend/routers/userData.ts
@@ -13,6 +13,57 @@ import { z } from 'zod';
 const { OIDC_ISSUER_URL, GOOGLE_REDIRECT_URI } = oidcOAuthEnvSchema.parse(process.env);
 const NODE_ENV = process.env.NODE_ENV;
 
+function clampScheduleIndex(state: ScheduleSaveState): ScheduleSaveState {
+    const { schedules, scheduleIndex } = state;
+    if (scheduleIndex < 0 || scheduleIndex >= schedules.length) {
+        return {
+            ...state,
+            scheduleIndex: schedules.length > 0 ? schedules.length - 1 : 0,
+        };
+    }
+    return state;
+}
+
+function assertScheduleSaveStateInvariants(state: ScheduleSaveState): void {
+    for (const schedule of state.schedules) {
+        for (const course of schedule.courses) {
+            if (typeof course.sectionCode !== 'string' || isNaN(parseInt(course.sectionCode, 10))) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: `Invalid section code: ${course.sectionCode}`,
+                });
+            }
+            if (typeof course.term !== 'string' || course.term.length === 0) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: `Invalid term: ${course.term}`,
+                });
+            }
+            if (typeof course.color !== 'string') {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: `Invalid color: ${course.color}`,
+                });
+            }
+        }
+
+        for (const event of schedule.customEvents) {
+            if (event.days.length !== 7) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'Invalid custom event days: must be an array of 7 booleans',
+                });
+            }
+        }
+    }
+}
+
+function preparePersistableScheduleSaveState(state: ScheduleSaveState): ScheduleSaveState {
+    const clamped = clampScheduleIndex(state);
+    assertScheduleSaveStateInvariants(clamped);
+    return clamped;
+}
+
 const userDataRouter = router({
     getUserAndAccount: protectedProcedure.query(async ({ ctx }) => {
         return await RDS.getUserAndAccountBySessionToken(db, ctx.sessionToken);
@@ -253,7 +304,7 @@ const userDataRouter = router({
                 });
             }
 
-            const userData = result.data;
+            const userData = preparePersistableScheduleSaveState(result.data);
 
             try {
                 return await RDS.upsertUserData(db, ctx.userId, userData);
@@ -345,47 +396,9 @@ const userDataRouter = router({
                 });
             }
 
-            if (
-                validatedScheduleData.scheduleIndex < 0 ||
-                validatedScheduleData.scheduleIndex >= validatedScheduleData.schedules.length
-            ) {
-                validatedScheduleData.scheduleIndex =
-                    validatedScheduleData.schedules.length > 0 ? validatedScheduleData.schedules.length - 1 : 0;
-            }
+            const userData = preparePersistableScheduleSaveState(validatedScheduleData);
 
-            for (const schedule of validatedScheduleData.schedules) {
-                for (const course of schedule.courses) {
-                    if (typeof course.sectionCode !== 'string' || isNaN(parseInt(course.sectionCode))) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid section code: ${course.sectionCode}`,
-                        });
-                    }
-                    if (typeof course.term !== 'string' || course.term.length === 0) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid term: ${course.term}`,
-                        });
-                    }
-                    if (typeof course.color !== 'string') {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid color: ${course.color}`,
-                        });
-                    }
-                }
-
-                for (const event of schedule.customEvents) {
-                    if (event.days.length !== 7) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: 'Invalid custom event days: must be an array of 7 booleans',
-                        });
-                    }
-                }
-            }
-
-            await RDS.upsertUserData(db, ctx.userId, validatedScheduleData).catch((error) => {
+            await RDS.upsertUserData(db, ctx.userId, userData).catch((error) => {
                 console.error('RDS Failed to import user data:', error);
                 throw new TRPCError({
                     code: 'INTERNAL_SERVER_ERROR',

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -15,9 +15,13 @@ import {
 } from '$lib/localStorage';
 import { clearSsoCookie, setSsoCookie } from '$lib/ssoCookie';
 import AppStore from '$stores/AppStore';
+import { ShortCourseScheduleSchema } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { z } from 'zod';
+
+const dataCacheSchedulesSchema = z.array(ShortCourseScheduleSchema);
 
 export function AuthPage() {
     const [searchParams] = useSearchParams();
@@ -100,7 +104,25 @@ export function AuthPage() {
                     setLocalStorageImportedUser(savedUserId);
                 }
 
-                const data = JSON.parse(savedData);
+                let rawSchedules: unknown;
+                try {
+                    rawSchedules = JSON.parse(savedData);
+                } catch {
+                    removeLocalStorageDataCache();
+                    removeLocalStorageImportedUser();
+                    window.location.href = returnUrl;
+                    return;
+                }
+
+                const parsedCache = dataCacheSchedulesSchema.safeParse(rawSchedules);
+                if (!parsedCache.success) {
+                    removeLocalStorageDataCache();
+                    removeLocalStorageImportedUser();
+                    window.location.href = returnUrl;
+                    return;
+                }
+
+                const data = parsedCache.data;
 
                 if (userData !== null && isEmptySchedule(userData.userData.schedules)) {
                     scheduleSaveState.schedules = data;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns persisted schedule validation and hardens the OAuth post-login merge path.

**Server (`userData` router)**  
- Introduces `preparePersistableScheduleSaveState`: clamps `scheduleIndex` to a valid range and applies the same course/custom-event checks previously only run on `importScheduleData`.  
- `saveUserData` now runs this after `ScheduleSaveStateSchema.safeParse`, so normal saves get the same invariants as import.

**Client (`AuthPage`)**  
- Replaces bare `JSON.parse` of `dataCache` with `JSON.parse` in a try/catch plus `z.array(ShortCourseScheduleSchema).safeParse`. Invalid or corrupt cache entries clear the cache-related keys and continue to `returnUrl` without calling `saveUserData`.

Targets `main` only; independent of the minor save-path fixes PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39783602-249f-453c-b710-5b0e70213db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39783602-249f-453c-b710-5b0e70213db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

