### PR TITLE
Remove dead TRPC procedures from userData router

### DIFF
--- a/apps/antalmanac/src/backend/routers/userData.ts
+++ b/apps/antalmanac/src/backend/routers/userData.ts
@@ -18,19 +18,6 @@ const userDataRouter = router({
         return await RDS.getUserAndAccountBySessionToken(db, ctx.sessionToken);
     }),
 
-    /**
-     * Retrieves the currently authenticated user's profile.
-     *
-     * @returns The user row for the session user.
-     */
-    getCurrentUser: protectedProcedure.query(async ({ ctx }) => {
-        return await RDS.getUserById(db, ctx.userId);
-    }),
-
-    getGoogleId: protectedProcedure.query(async ({ ctx }) => {
-        return await RDS.getGoogleIdByUserId(db, ctx.userId);
-    }),
-
     getGuestScheduleByUsername: procedure.input(z.object({ username: z.string() })).query(async ({ input }) => {
         const result = await RDS.getGuestScheduleByUsername(db, input.username);
         if (!result) {
@@ -48,7 +35,6 @@ const userDataRouter = router({
 
     /**
      * Retrieves Google authentication URL for login/sign up.
-     * Retrieves Google auth url to login/sign up
      */
     getGoogleAuthUrl: procedure
         .input(
@@ -72,12 +58,7 @@ const userDataRouter = router({
                 state,
                 CodeChallengeMethod.S256,
                 codeVerifier,
-                [
-                    'openid',
-                    'profile',
-                    'email',
-                    // 'https://www.googleapis.com/auth/calendar.readonly'
-                ]
+                ['openid', 'profile', 'email']
             );
 
             if (input?.prompt) {
@@ -306,95 +287,6 @@ const userDataRouter = router({
             logoutUrl: oidcLogoutUrl.toString(),
         };
     }),
-
-    /**
-     * Exports schedule data for a user as JSON.
-     * This allows users to export their schedule data to transfer between environments (prod/staging).
-     * @param input - An object containing the user ID.
-     * @returns The schedule data in JSON format.
-     */
-    exportScheduleData: protectedProcedure.query(async ({ ctx }) => {
-        const userData = await RDS.fetchUserDataWithSession(db, ctx.sessionToken);
-        if (!userData) {
-            throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: 'User not found',
-            });
-        }
-
-        return userData.userData;
-    }),
-
-    /**
-     * Imports schedule data from JSON.
-     * Validates the imported data before saving to prevent invalid data from being stored.
-     * @param input - An object containing the user ID and the schedule data to import.
-     * @returns Success status.
-     */
-    importScheduleData: protectedProcedure
-        .input(z.object({ scheduleData: z.unknown() }))
-        .mutation(async ({ input, ctx }) => {
-            let validatedScheduleData: ScheduleSaveState;
-            try {
-                validatedScheduleData = ScheduleSaveStateSchema.parse(input.scheduleData);
-            } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : 'Unknown validation error';
-                throw new TRPCError({
-                    code: 'BAD_REQUEST',
-                    message: `Invalid schedule data format: ${errorMessage}`,
-                });
-            }
-
-            if (
-                validatedScheduleData.scheduleIndex < 0 ||
-                validatedScheduleData.scheduleIndex >= validatedScheduleData.schedules.length
-            ) {
-                validatedScheduleData.scheduleIndex =
-                    validatedScheduleData.schedules.length > 0 ? validatedScheduleData.schedules.length - 1 : 0;
-            }
-
-            for (const schedule of validatedScheduleData.schedules) {
-                for (const course of schedule.courses) {
-                    if (typeof course.sectionCode !== 'string' || isNaN(parseInt(course.sectionCode))) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid section code: ${course.sectionCode}`,
-                        });
-                    }
-                    if (typeof course.term !== 'string' || course.term.length === 0) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid term: ${course.term}`,
-                        });
-                    }
-                    if (typeof course.color !== 'string') {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: `Invalid color: ${course.color}`,
-                        });
-                    }
-                }
-
-                for (const event of schedule.customEvents) {
-                    if (event.days.length !== 7) {
-                        throw new TRPCError({
-                            code: 'BAD_REQUEST',
-                            message: 'Invalid custom event days: must be an array of 7 booleans',
-                        });
-                    }
-                }
-            }
-
-            await RDS.upsertUserData(db, ctx.userId, validatedScheduleData).catch((error) => {
-                console.error('RDS Failed to import user data:', error);
-                throw new TRPCError({
-                    code: 'INTERNAL_SERVER_ERROR',
-                    message: 'Failed to import schedule data',
-                });
-            });
-
-            return { success: true };
-        }),
 });
 
 export default userDataRouter;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes four `userData` TRPC procedures that had no callers anywhere in this repository: `getCurrentUser`, `getGoogleId`, `exportScheduleData`, and `importScheduleData`. Schedule import/export in the app uses client-side JSON handling and `saveUserData` / `getUserData` instead of the removed endpoints. Also consolidates duplicate JSDoc on `getGoogleAuthUrl` and deletes a commented-out OAuth scope line.

## Test Plan

- `pnpm install` and `pnpm lint` (passes).
- `pnpm test run`: several suites fail in this environment due to a missing generated `termData` asset; unrelated to this change.

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dba3b88d-6cdb-4b2f-ace7-2512fb6f84d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dba3b88d-6cdb-4b2f-ace7-2512fb6f84d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

