### PR TITLE
refactor: consolidate fuzzy search libraries

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -29,7 +29,6 @@
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@leeoniya/ufuzzy": "1.0.14",
         "@mui/icons-material": "^7.3.7",
         "@mui/lab": "7.0.1-beta.21",
         "@mui/material": "^7.3.7",

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -92,20 +92,23 @@ const searchRouter = router({
                 }
             }
 
-            const matchedGEs = fuzzysort.go(query, geCategoryEntries, { keys: ['key', 'name'] }).map((r) => r.obj.key);
-            if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
+            const matchedGEs = fuzzysort
+                .go(query, geCategoryEntries, { keys: ['key', 'name'], limit: 3 })
+                .map((r) => r.obj.key);
+
+            const usedSlots = matchedSections.length + matchedGEs.length;
 
             const matchedDepts =
-                matchedSections.length === MAX_AUTOCOMPLETE_RESULTS
+                usedSlots >= MAX_AUTOCOMPLETE_RESULTS
                     ? []
                     : fuzzysort.go(query, searchData.departments, {
                           keys: ['id', 'name', 'alias'],
-                          limit: MAX_AUTOCOMPLETE_RESULTS - matchedSections.length,
+                          limit: MAX_AUTOCOMPLETE_RESULTS - usedSlots,
                           threshold: 0.7,
                       });
 
             const matchedCourses =
-                matchedSections.length + matchedDepts.length === MAX_AUTOCOMPLETE_RESULTS
+                usedSlots + matchedDepts.length >= MAX_AUTOCOMPLETE_RESULTS
                     ? []
                     : fuzzysort
                           .go(query, searchData.courses, {
@@ -129,10 +132,11 @@ const searchRouter = router({
                               if (a.obj.isOffered === b.obj.isOffered) return 0;
                               return a.obj.isOffered ? -1 : 1;
                           })
-                          .slice(0, MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - matchedSections.length);
+                          .slice(0, MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - usedSlots);
 
             return Object.fromEntries([
                 ...matchedSections.map((x) => [x.sectionCode, x]),
+                ...matchedGEs.map(toGESearchResult),
                 ...matchedDepts.map((x) => [x.obj.id, x.obj]),
                 ...matchedCourses.map((x) => [x.obj.id, x.obj]),
             ]);

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 
 // eslint-disable-next-line import/no-unresolved
 import * as searchData from '$generated/searchData';
-import uFuzzy from '@leeoniya/ufuzzy';
 import type { GESearchResult, SearchResult, SectionSearchResult } from '@packages/antalmanac-types';
 import * as fuzzysort from 'fuzzysort';
 import { z } from 'zod';
@@ -42,8 +41,6 @@ const toGESearchResult = (key: GECategoryKey): [string, SearchResult] => [
     key.toUpperCase().replace('GE', 'GE-'),
     geCategories[key],
 ];
-
-const toMutable = <T>(arr: readonly T[]): T[] => arr as T[];
 
 async function getTermSectionCodes(year: string, quarter: string): Promise<Record<string, SectionSearchResult>> {
     const parsedTerm = `${quarter}_${year}`;
@@ -93,8 +90,7 @@ const searchRouter = router({
                 }
             }
 
-            const u = new uFuzzy();
-            const matchedGEs = u.search(toMutable(geCategoryKeys), query)[0]?.map((i) => geCategoryKeys[i]) ?? [];
+            const matchedGEs = fuzzysort.go(query, [...geCategoryKeys]).map((r) => r.target as GECategoryKey);
             if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
 
             const matchedDepts =

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -37,8 +37,6 @@ const geCategories: Record<GECategoryKey, GESearchResult> = {
     ge8: { type: 'GE_CATEGORY', name: 'International/Global Issues' },
 };
 
-const geCategoryEntries = geCategoryKeys.map((key) => ({ key, name: geCategories[key].name }));
-
 const toGESearchResult = (key: GECategoryKey): [string, SearchResult] => [
     key.toUpperCase().replace('GE', 'GE-'),
     geCategories[key],
@@ -93,22 +91,22 @@ const searchRouter = router({
             }
 
             const matchedGEs = fuzzysort
-                .go(query, geCategoryEntries, { keys: ['key', 'name'], limit: 3 })
-                .map((r) => r.obj.key);
-
-            const usedSlots = matchedSections.length + matchedGEs.length;
+                .go(query, [...geCategoryKeys])
+                .map((r) => r.target)
+                .filter((t): t is GECategoryKey => t in geCategories);
+            if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
 
             const matchedDepts =
-                usedSlots >= MAX_AUTOCOMPLETE_RESULTS
+                matchedSections.length === MAX_AUTOCOMPLETE_RESULTS
                     ? []
                     : fuzzysort.go(query, searchData.departments, {
                           keys: ['id', 'name', 'alias'],
-                          limit: MAX_AUTOCOMPLETE_RESULTS - usedSlots,
+                          limit: MAX_AUTOCOMPLETE_RESULTS - matchedSections.length,
                           threshold: 0.7,
                       });
 
             const matchedCourses =
-                usedSlots + matchedDepts.length >= MAX_AUTOCOMPLETE_RESULTS
+                matchedSections.length + matchedDepts.length === MAX_AUTOCOMPLETE_RESULTS
                     ? []
                     : fuzzysort
                           .go(query, searchData.courses, {
@@ -132,11 +130,10 @@ const searchRouter = router({
                               if (a.obj.isOffered === b.obj.isOffered) return 0;
                               return a.obj.isOffered ? -1 : 1;
                           })
-                          .slice(0, MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - usedSlots);
+                          .slice(0, MAX_AUTOCOMPLETE_RESULTS - matchedDepts.length - matchedSections.length);
 
             return Object.fromEntries([
                 ...matchedSections.map((x) => [x.sectionCode, x]),
-                ...matchedGEs.map(toGESearchResult),
                 ...matchedDepts.map((x) => [x.obj.id, x.obj]),
                 ...matchedCourses.map((x) => [x.obj.id, x.obj]),
             ]);

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -90,7 +90,10 @@ const searchRouter = router({
                 }
             }
 
-            const matchedGEs = fuzzysort.go(query, [...geCategoryKeys]).map((r) => r.target as GECategoryKey);
+            const matchedGEs = fuzzysort
+                .go(query, [...geCategoryKeys])
+                .map((r) => r.target)
+                .filter((t): t is GECategoryKey => t in geCategories);
             if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
 
             const matchedDepts =

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -37,6 +37,8 @@ const geCategories: Record<GECategoryKey, GESearchResult> = {
     ge8: { type: 'GE_CATEGORY', name: 'International/Global Issues' },
 };
 
+const geCategoryEntries = geCategoryKeys.map((key) => ({ key, name: geCategories[key].name }));
+
 const toGESearchResult = (key: GECategoryKey): [string, SearchResult] => [
     key.toUpperCase().replace('GE', 'GE-'),
     geCategories[key],
@@ -90,10 +92,7 @@ const searchRouter = router({
                 }
             }
 
-            const matchedGEs = fuzzysort
-                .go(query, [...geCategoryKeys])
-                .map((r) => r.target)
-                .filter((t): t is GECategoryKey => t in geCategories);
+            const matchedGEs = fuzzysort.go(query, geCategoryEntries, { keys: ['key', 'name'] }).map((r) => r.obj.key);
             if (matchedGEs.length) return Object.fromEntries(matchedGEs.map(toGESearchResult));
 
             const matchedDepts =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.10.5
         version: 11.13.0(@emotion/react@11.13.3(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1)
-      '@leeoniya/ufuzzy':
-        specifier: 1.0.14
-        version: 1.0.14
       '@mui/icons-material':
         specifier: ^7.3.7
         version: 7.3.7(@mui/material@7.3.7(@emotion/react@11.13.3(@types/react@19.2.7)(react@19.2.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react@19.2.7)(react@19.2.1)
@@ -2013,9 +2010,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@leeoniya/ufuzzy@1.0.14':
-    resolution: {integrity: sha512-/xF4baYuCQMo+L/fMSUrZnibcu0BquEGnbxfVPiZhs/NbJeKj4c/UmFpQzW9Us0w45ui/yYW3vyaqawhNYsTzA==}
 
   '@mapbox/corslite@0.0.7':
     resolution: {integrity: sha512-w/uS474VFjmqQ7fFWIMZINQM1BAQxDLuoJaZZIPES1BmeYpCtlh9MtbFxKGGDAsfvut8/HircIsVvEYRjQ+iMg==}
@@ -8583,8 +8577,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@leeoniya/ufuzzy@1.0.14': {}
 
   '@mapbox/corslite@0.0.7': {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `@leeoniya/ufuzzy` dependency and consolidates all fuzzy search to use `fuzzysort` exclusively.

`uFuzzy` was used in exactly one place: fuzzy-matching a fixed 10-element array of GE category keys (`ge1a`, `ge1b`, ...). `fuzzysort` already handles all other search (departments, courses) and natively supports plain string array search via `fuzzysort.go(query, stringArray)`.

**Changes:**
- Replace `new uFuzzy().search(...)` with `fuzzysort.go(query, [...geCategoryKeys]).map(r => r.target).filter((t): t is GECategoryKey => t in geCategories)` — type predicate filter against the actual lookup table, no assertion needed
- Remove the `toMutable` helper that existed solely to cast the readonly tuple for uFuzzy
- Remove `@leeoniya/ufuzzy` from `package.json` and `pnpm-lock.yaml`
- GE key-only matching and exclusive early-return behavior are preserved unchanged

## Test Plan

- ✅ `oxlint src/backend/routers/search.ts` — 0 warnings, 0 errors
- ✅ TypeScript errors in `search.ts` are identical to pre-change (all pre-existing from missing generated `$generated/searchData` module)
- ✅ No remaining references to `ufuzzy` / `uFuzzy` in source files or manifests

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2de404f1-2c7c-4c2c-a247-746af4be855f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2de404f1-2c7c-4c2c-a247-746af4be855f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

