### PR TITLE
refactor: split userData tRPC router into auth and schedule

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -95,7 +95,7 @@ export const saveSchedule = async ({ postHog }: { postHog?: PostHog }) => {
     }
 
     try {
-        const result = await trpc.userData.saveUserData.mutate({
+        const result = await trpc.schedule.save.mutate({
             userData: scheduleSaveState,
         });
 
@@ -135,7 +135,7 @@ export async function autoSaveSchedule(options: AutoSaveScheduleOptions) {
 
     const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
     try {
-        const result = await trpc.userData.saveUserData.mutate({
+        const result = await trpc.schedule.save.mutate({
             userData: scheduleSaveState,
         });
 
@@ -194,7 +194,7 @@ const handleScheduleImport = async (username: string, skipImportedCheck = false,
         throw new Error("Invalid session: User isn't logged in.");
     }
 
-    const incoming = await trpc.userData.getGuestScheduleByUsername.query({ username }).catch(() => {
+    const incoming = await trpc.schedule.getGuest.query({ username }).catch(() => {
         throw new Error(`Oops! Schedule "${username}" doesn't seem to exist.`);
     });
 
@@ -231,7 +231,7 @@ const handleScheduleImport = async (username: string, skipImportedCheck = false,
 
             await saveSchedule({ postHog });
 
-            await trpc.userData.flagImportedSchedule.mutate({
+            await trpc.schedule.flagImported.mutate({
                 username,
             });
         }
@@ -269,7 +269,7 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
             }
 
             try {
-                const result = await trpc.userData.getGuestScheduleByUsername.query({ username });
+                const result = await trpc.schedule.getGuest.query({ username });
                 const scheduleSaveState = result.userData;
 
                 let error = false;
@@ -323,13 +323,13 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
 };
 
 interface LoadScheduleOptions {
-    prefetched: Awaited<ReturnType<typeof trpc.userData.getUserData.query>> | null;
+    prefetched: Awaited<ReturnType<typeof trpc.schedule.get.query>> | null;
     postHog?: PostHog;
 }
 
 export const loadSchedule = async ({ prefetched, postHog }: LoadScheduleOptions) => {
     try {
-        const userDataResponse = prefetched ?? (await trpc.userData.getUserData.query());
+        const userDataResponse = prefetched ?? (await trpc.schedule.get.query());
         const scheduleSaveState = userDataResponse?.userData;
         const userId = userDataResponse?.id;
         let analyticsErrorMessage = '';
@@ -392,7 +392,7 @@ export const loginUser = async (postHog?: PostHog) => {
     try {
         const redirectUri = isNativeIosApp() ? NATIVE_IOS_REDIRECT_URI : undefined;
         const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-        const authUrl = await trpc.userData.getGoogleAuthUrl.query({
+        const authUrl = await trpc.auth.getGoogleAuthUrl.query({
             ...(redirectUri ? { redirectUri } : {}),
             returnTo,
         });

--- a/apps/antalmanac/src/backend/routers/auth.ts
+++ b/apps/antalmanac/src/backend/routers/auth.ts
@@ -4,7 +4,6 @@ import { ALLOWED_REDIRECT_URIS, isAllowedRedirectUri, oauthClientForRedirectUri 
 import { getCookiesFromHeader, getSafeAuthRedirectPath } from '$src/backend/lib/helpers';
 import { RDS } from '$src/backend/lib/rds';
 import { procedure, protectedProcedure, router } from '$src/backend/trpc';
-import { type ScheduleSaveState, ScheduleSaveStateSchema } from '@packages/antalmanac-types';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { CodeChallengeMethod, decodeIdToken, generateCodeVerifier, generateState, type OAuth2Tokens } from 'arctic';
@@ -13,24 +12,9 @@ import { z } from 'zod';
 const { OIDC_ISSUER_URL, GOOGLE_REDIRECT_URI } = oidcOAuthEnvSchema.parse(process.env);
 const NODE_ENV = process.env.NODE_ENV;
 
-const userDataRouter = router({
+const authRouter = router({
     getUserAndAccount: protectedProcedure.query(async ({ ctx }) => {
         return await RDS.getUserAndAccountBySessionToken(db, ctx.sessionToken);
-    }),
-
-    getGuestScheduleByUsername: procedure.input(z.object({ username: z.string() })).query(async ({ input }) => {
-        const result = await RDS.getGuestScheduleByUsername(db, input.username);
-        if (!result) {
-            throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: `Couldn't find schedules for username "${input.username}".`,
-            });
-        }
-        return result;
-    }),
-
-    getUserData: protectedProcedure.query(async ({ ctx }) => {
-        return await RDS.fetchUserDataWithSession(db, ctx.sessionToken);
     }),
 
     /**
@@ -223,38 +207,10 @@ const userDataRouter = router({
             }
         }),
 
-    saveUserData: protectedProcedure
-        .input(z.object({ userData: z.custom<ScheduleSaveState>() }))
-        .mutation(async ({ input, ctx }) => {
-            const result = ScheduleSaveStateSchema.safeParse(input.userData);
-            if (!result.success) {
-                throw new TRPCError({
-                    code: 'BAD_REQUEST',
-                    message: `Invalid schedule data: ${result.error.message}`,
-                });
-            }
-
-            const userData = result.data;
-
-            try {
-                return await RDS.upsertUserData(db, ctx.userId, userData);
-            } catch (error) {
-                console.error('RDS Failed to upsert user data:', error);
-                throw new TRPCError({
-                    code: 'INTERNAL_SERVER_ERROR',
-                    message: 'Failed to save user data',
-                });
-            }
-        }),
-
     getAuthReturnUrl: procedure.query(async ({ ctx }) => {
         const cookies = getCookiesFromHeader(ctx.req.headers);
         const redirectUrl = getSafeAuthRedirectPath(cookies['auth_redirect_url'], ctx.req.url, GOOGLE_REDIRECT_URI);
         return redirectUrl || '/';
-    }),
-
-    flagImportedSchedule: protectedProcedure.input(z.object({ username: z.string() })).mutation(async ({ input }) => {
-        return await RDS.flagImportedUser(db, input.username);
     }),
 
     /**
@@ -289,4 +245,4 @@ const userDataRouter = router({
     }),
 });
 
-export default userDataRouter;
+export default authRouter;

--- a/apps/antalmanac/src/backend/routers/index.ts
+++ b/apps/antalmanac/src/backend/routers/index.ts
@@ -1,26 +1,28 @@
 import { router } from '../trpc';
+import authRouter from './auth';
 import courseRouter from './course';
 import enrollHistRouter from './enrollHist';
 import gradesRouter from './grades';
 import notificationsRouter from './notifications';
 import reviewRouter from './review';
 import roadmapRouter from './roadmap';
+import scheduleRouter from './schedule';
 import searchRouter from './search';
-import userDataRouter from './userData';
 import websocRouter from './websoc';
 import zotcourseRouter from './zotcourse';
 
 const appRouter = router({
+    auth: authRouter,
     course: courseRouter,
     enrollHist: enrollHistRouter,
     grades: gradesRouter,
     notifications: notificationsRouter,
     review: reviewRouter,
+    roadmap: roadmapRouter,
+    schedule: scheduleRouter,
     search: searchRouter,
-    userData: userDataRouter,
     websoc: websocRouter,
     zotcourse: zotcourseRouter,
-    roadmap: roadmapRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/antalmanac/src/backend/routers/schedule.ts
+++ b/apps/antalmanac/src/backend/routers/schedule.ts
@@ -1,0 +1,53 @@
+import { RDS } from '$src/backend/lib/rds';
+import { procedure, protectedProcedure, router } from '$src/backend/trpc';
+import { type ScheduleSaveState, ScheduleSaveStateSchema } from '@packages/antalmanac-types';
+import { db } from '@packages/db';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+const scheduleRouter = router({
+    getGuest: procedure.input(z.object({ username: z.string() })).query(async ({ input }) => {
+        const result = await RDS.getGuestScheduleByUsername(db, input.username);
+        if (!result) {
+            throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: `Couldn't find schedules for username "${input.username}".`,
+            });
+        }
+        return result;
+    }),
+
+    get: protectedProcedure.query(async ({ ctx }) => {
+        return await RDS.fetchUserDataWithSession(db, ctx.sessionToken);
+    }),
+
+    save: protectedProcedure
+        .input(z.object({ userData: z.custom<ScheduleSaveState>() }))
+        .mutation(async ({ input, ctx }) => {
+            const result = ScheduleSaveStateSchema.safeParse(input.userData);
+            if (!result.success) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: `Invalid schedule data: ${result.error.message}`,
+                });
+            }
+
+            const userData = result.data;
+
+            try {
+                return await RDS.upsertUserData(db, ctx.userId, userData);
+            } catch (error) {
+                console.error('RDS Failed to upsert user data:', error);
+                throw new TRPCError({
+                    code: 'INTERNAL_SERVER_ERROR',
+                    message: 'Failed to save user data',
+                });
+            }
+        }),
+
+    flagImported: protectedProcedure.input(z.object({ username: z.string() })).mutation(async ({ input }) => {
+        return await RDS.flagImportedUser(db, input.username);
+    }),
+});
+
+export default scheduleRouter;

--- a/apps/antalmanac/src/backend/routers/schedule.ts
+++ b/apps/antalmanac/src/backend/routers/schedule.ts
@@ -6,17 +6,6 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 const scheduleRouter = router({
-    getGuest: procedure.input(z.object({ username: z.string() })).query(async ({ input }) => {
-        const result = await RDS.getGuestScheduleByUsername(db, input.username);
-        if (!result) {
-            throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: `Couldn't find schedules for username "${input.username}".`,
-            });
-        }
-        return result;
-    }),
-
     get: protectedProcedure.query(async ({ ctx }) => {
         return await RDS.fetchUserDataWithSession(db, ctx.sessionToken);
     }),
@@ -44,6 +33,17 @@ const scheduleRouter = router({
                 });
             }
         }),
+
+    getGuest: procedure.input(z.object({ username: z.string() })).query(async ({ input }) => {
+        const result = await RDS.getGuestScheduleByUsername(db, input.username);
+        if (!result) {
+            throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: `Couldn't find schedules for username "${input.username}".`,
+            });
+        }
+        return result;
+    }),
 
     flagImported: protectedProcedure.input(z.object({ username: z.string() })).mutation(async ({ input }) => {
         return await RDS.flagImportedUser(db, input.username);

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -44,7 +44,7 @@ export function AutoSignIn() {
 
             try {
                 const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-                const authUrl = await trpc.userData.getGoogleAuthUrl.query({ prompt: 'none', returnTo });
+                const authUrl = await trpc.auth.getGoogleAuthUrl.query({ prompt: 'none', returnTo });
                 window.location.href = authUrl.toString();
             } catch {
                 // Silent SSO failed (e.g. backend unavailable). Don't retry.

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -77,7 +77,7 @@ export const Signin = () => {
 
     const validateImportedUser = useCallback(async (userID: string) => {
         try {
-            const res = await trpc.userData.getGuestScheduleByUsername.query({ username: userID });
+            const res = await trpc.schedule.getGuest.query({ username: userID });
             if (res.user.imported) {
                 setAlertMessage(ALERT_MESSAGES.SCHEDULE_IMPORTED);
                 setOpenalert(true);
@@ -105,7 +105,7 @@ export const Signin = () => {
 
             const [validSession, prefetchedUserData] = await Promise.all([
                 loadSession(),
-                trpc.userData.getUserData.query().catch(() => null),
+                trpc.schedule.get.query().catch(() => null),
             ]);
 
             if (validSession) {

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -31,7 +31,7 @@ export function AuthPage() {
         }
 
         try {
-            const returnUrl = await trpc.userData.getAuthReturnUrl.query();
+            const returnUrl = await trpc.auth.getAuthReturnUrl.query();
 
             // Silent SSO returned an error — the auth server has no session.
             if (searchParams.get('error') === 'login_required') {
@@ -49,7 +49,7 @@ export function AuthPage() {
 
             isAuthenticatingRef.current = true;
 
-            const { userId, providerId, newUser } = await trpc.userData.handleGoogleCallback.mutate({
+            const { userId, providerId, newUser } = await trpc.auth.handleGoogleCallback.mutate({
                 code: code,
                 state: state,
             });
@@ -92,11 +92,11 @@ export function AuthPage() {
 
             // handle unsaved changes
             if (savedData !== '') {
-                const userData = await trpc.userData.getUserData.query();
+                const userData = await trpc.schedule.get.query();
                 const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
 
                 if (savedUserId !== '') {
-                    await trpc.userData.flagImportedSchedule.mutate({ username: savedUserId });
+                    await trpc.schedule.flagImported.mutate({ username: savedUserId });
                     setLocalStorageImportedUser(savedUserId);
                 }
 
@@ -113,7 +113,7 @@ export function AuthPage() {
                     }
                 }
 
-                await trpc.userData.saveUserData.mutate({
+                await trpc.schedule.save.mutate({
                     userData: scheduleSaveState,
                 });
             }

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -51,7 +51,7 @@ export const useSessionStore = create<SessionState>((set) => {
 
         loadSession: async () => {
             try {
-                const { users, accounts } = await trpc.userData.getUserAndAccount.query();
+                const { users, accounts } = await trpc.auth.getUserAndAccount.query();
 
                 let googleId = accounts?.providerAccountId ?? null;
                 if (googleId?.startsWith('google_')) {
@@ -95,7 +95,7 @@ export const useSessionStore = create<SessionState>((set) => {
         clearSession: async () => {
             let logoutUrl: string | null = null;
             try {
-                const result = await trpc.userData.logout.mutate({
+                const result = await trpc.auth.logout.mutate({
                     redirectUrl: window.location.origin,
                 });
                 logoutUrl = result.logoutUrl;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Split the monolithic `userData` tRPC router into two routers: `auth` (OAuth, session, `getUserAndAccount`) and `schedule` (fetch/save/guest/import flag). Procedure bodies are unchanged except for renames on the schedule router (`get`, `save`, `getGuest`, `flagImported`). All client call sites were updated to `trpc.auth.*` and `trpc.schedule.*`.

## Test Plan

- `rg 'trpc\.userData' apps/antalmanac` — no matches.
- `pnpm --filter antalmanac exec tsc --noEmit` — the workspace reports existing errors (missing `$generated/*`, scripts, gif/png modules); filtered output contained no diagnostics for touched files (`auth.ts`, `schedule.ts`, updated actions/stores/routes/components).

## Issues




Grep
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6123cc8b-9b2d-423e-81a8-d71eb7d5a466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6123cc8b-9b2d-423e-81a8-d71eb7d5a466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

