### PR TITLE
refactor: derive ShortCourse/ShortCourseSchedule wire types from DB schema

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -74,7 +74,7 @@ export function isEmptySchedule(schedules: ShortCourseSchedule[]) {
             return false;
         }
 
-        if (schedule.scheduleNote !== '') {
+        if (schedule.notes !== '') {
             return false;
         }
     }
@@ -174,15 +174,15 @@ export const mergeShortCourseSchedules = (
     incomingSchedule: ShortCourseSchedule[],
     importMessage = ''
 ) => {
-    const existingScheduleNames = new Set(currentSchedules.map((s: ShortCourseSchedule) => s.scheduleName));
+    const existingNames = new Set(currentSchedules.map((s: ShortCourseSchedule) => s.name));
     const cacheSchedule = incomingSchedule.map((schedule: ShortCourseSchedule) => {
-        let scheduleName = schedule.scheduleName;
-        if (existingScheduleNames.has(schedule.scheduleName)) {
-            scheduleName = `${scheduleName}(1)`;
+        let name = schedule.name;
+        if (existingNames.has(schedule.name)) {
+            name = `${name}(1)`;
         }
         return {
             ...schedule,
-            scheduleName: `${importMessage}${scheduleName}`,
+            name: `${importMessage}${name}`,
         };
     });
     currentSchedules.push(...cacheSchedule);

--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -228,8 +228,8 @@ export class RDS {
                     prepared.map(({ schedule, index, dbId }) => ({
                         id: dbId,
                         userId,
-                        name: schedule.scheduleName,
-                        notes: schedule.scheduleNote,
+                        name: schedule.name,
+                        notes: schedule.notes,
                         index,
                     }))
                 )
@@ -243,10 +243,10 @@ export class RDS {
         await Promise.all(
             prepared.flatMap(({ schedule, dbId }) => [
                 this.upsertCourses(tx, dbId, schedule.courses).catch((error) => {
-                    throw new Error(`Failed to upsert courses for ${schedule.scheduleName}: ${error}`);
+                    throw new Error(`Failed to upsert courses for ${schedule.name}: ${error}`);
                 }),
                 this.upsertCustomEvents(tx, dbId, schedule.customEvents).catch((error) => {
-                    throw new Error(`Failed to upsert custom events for ${schedule.scheduleName}: ${error}`);
+                    throw new Error(`Failed to upsert custom events for ${schedule.name}: ${error}`);
                 }),
             ])
         );
@@ -264,10 +264,9 @@ export class RDS {
     private static async upsertCourses(tx: Transaction, scheduleId: string, courses: ShortCourse[]) {
         const uniqueByKey = new Map<string, { sectionCode: number; term: string; color: string }>();
         for (const course of courses) {
-            const sectionCode = parseInt(course.sectionCode);
-            const key = `${sectionCode}-${course.term}`;
+            const key = `${course.sectionCode}-${course.term}`;
             if (!uniqueByKey.has(key)) {
-                uniqueByKey.set(key, { sectionCode, term: course.term, color: course.color });
+                uniqueByKey.set(key, { sectionCode: course.sectionCode, term: course.term, color: course.color });
             }
         }
         const incoming = [...uniqueByKey.values()];
@@ -426,8 +425,8 @@ export class RDS {
 
             const scheduleAggregate = schedulesMapping[scheduleId] || {
                 id: scheduleId,
-                scheduleName: schedule.name,
-                scheduleNote: schedule.notes,
+                name: schedule.name,
+                notes: schedule.notes,
                 courses: [],
                 customEvents: [],
                 index: schedule.index,
@@ -435,7 +434,7 @@ export class RDS {
 
             if (course) {
                 scheduleAggregate.courses.push({
-                    sectionCode: course.sectionCode.toString(),
+                    sectionCode: course.sectionCode,
                     term: course.term,
                     color: course.color,
                 });
@@ -448,8 +447,8 @@ export class RDS {
         customEventResults.forEach(({ schedules: schedule, customEvents: customEvent }) => {
             const scheduleId = schedule.id;
             const scheduleAggregate = schedulesMapping[scheduleId] || {
-                scheduleName: schedule.name,
-                scheduleNote: schedule.notes,
+                name: schedule.name,
+                notes: schedule.notes,
                 courses: [],
                 customEvents: [],
             };

--- a/apps/antalmanac/src/components/Header/Export.tsx
+++ b/apps/antalmanac/src/components/Header/Export.tsx
@@ -186,7 +186,7 @@ export function Export() {
                                                 label={
                                                     <Box>
                                                         <Typography variant="body2" fontWeight="medium">
-                                                            {schedule.scheduleName}
+                                                            {schedule.name}
                                                         </Typography>
                                                         <Typography variant="caption" color="text.secondary">
                                                             {schedule.courses.length} course(s),{' '}

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -396,10 +396,10 @@ export function Import() {
 
     const validateSchedule = useCallback(
         (schedule: Record<string, unknown>, scheduleIndex: number): { valid: boolean; error?: string } => {
-            if (!schedule.scheduleName || typeof schedule.scheduleName !== 'string') {
+            if (!schedule.name || typeof schedule.name !== 'string') {
                 return {
                     valid: false,
-                    error: `Schedule ${scheduleIndex + 1} is missing required field: scheduleName`,
+                    error: `Schedule ${scheduleIndex + 1} is missing required field: name`,
                 };
             }
             if (!schedule.courses || !Array.isArray(schedule.courses)) {
@@ -785,7 +785,7 @@ export function Import() {
                                                         label={
                                                             <Box>
                                                                 <Typography variant="body2" fontWeight="medium">
-                                                                    {schedule.scheduleName}
+                                                                    {schedule.name}
                                                                 </Typography>
                                                                 <Typography variant="caption" color="text.secondary">
                                                                     {schedule.courses.length} course(s),{' '}
@@ -1089,7 +1089,7 @@ export function Import() {
                                                                 label={
                                                                     <Box>
                                                                         <Typography variant="body2" fontWeight="medium">
-                                                                            {schedule.scheduleName}
+                                                                            {schedule.name}
                                                                         </Typography>
                                                                         <Typography
                                                                             variant="caption"

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -147,7 +147,7 @@ function ScheduleNoteBox() {
     const theme = useTheme();
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
     const [scheduleNote, setScheduleNote] = useState(
-        skeletonMode ? AppStore.getCurrentSkeletonSchedule().scheduleNote : AppStore.getCurrentScheduleNote()
+        skeletonMode ? AppStore.getCurrentSkeletonSchedule().notes : AppStore.getCurrentScheduleNote()
     );
     const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
 
@@ -250,7 +250,7 @@ function SkeletonSchedule() {
         const result = skeletonSchedule.courses.reduce(
             (accumulated, course) => {
                 accumulated[course.term] ??= [];
-                accumulated[course.term].push(course.sectionCode);
+                accumulated[course.term].push(String(course.sectionCode));
                 return accumulated;
             },
             {} as Record<string, string[]>
@@ -261,7 +261,7 @@ function SkeletonSchedule() {
 
     return (
         <Box display="flex" flexDirection="column" gap={1}>
-            <Typography variant="h6">{skeletonSchedule.scheduleName}</Typography>
+            <Typography variant="h6">{skeletonSchedule.name}</Typography>
             {
                 // Sections organized under terms, in case the schedule contains multiple terms
                 sectionsByTerm.map(([term, sections]) => (

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -556,16 +556,16 @@ export class Schedules {
         const shortSchedules: ShortCourseSchedule[] = this.schedules.map((schedule) => {
             return {
                 id: schedule.scheduleId,
-                scheduleName: schedule.scheduleName,
+                name: schedule.scheduleName,
                 customEvents: schedule.customEvents,
                 courses: schedule.courses.map((course) => {
                     return {
                         color: course.section.color,
                         term: course.term,
-                        sectionCode: course.section.sectionCode,
+                        sectionCode: parseInt(course.section.sectionCode),
                     };
                 }),
-                scheduleNote: this.scheduleNoteMap[schedule.scheduleNoteId],
+                notes: this.scheduleNoteMap[schedule.scheduleNoteId],
             };
         });
         return { schedules: shortSchedules, scheduleIndex: this.currentScheduleIndex };
@@ -597,7 +597,7 @@ export class Schedules {
 
         try {
             // Get a dictionary of all unique courses
-            const courseDict: { [key: string]: Set<string> } = {};
+            const courseDict: { [key: string]: Set<number> } = {};
             for (const schedule of saveState.schedules) {
                 for (const course of schedule.courses) {
                     if (course.term in courseDict) {
@@ -628,7 +628,7 @@ export class Schedules {
                 for (const shortCourse of shortCourseSchedule.courses) {
                     const courseInfoMap = courseInfoDict.get(shortCourse.term);
                     if (courseInfoMap !== undefined) {
-                        const courseInfo = courseInfoMap[shortCourse.sectionCode.padStart(5, '0')];
+                        const courseInfo = courseInfoMap[String(shortCourse.sectionCode).padStart(5, '0')];
                         if (courseInfo === undefined) {
                             // Class doesn't exist/was cancelled
                             continue;
@@ -648,16 +648,10 @@ export class Schedules {
                 const groupedCourses = groupCourseSections(courses);
 
                 const scheduleNoteId = Math.random();
-                if ('scheduleNote' in shortCourseSchedule) {
-                    this.scheduleNoteMap[scheduleNoteId] = shortCourseSchedule.scheduleNote;
-                } else {
-                    // If this is a schedule that was saved before schedule notes were implemented,
-                    // just give each schedule an empty schedule note
-                    this.scheduleNoteMap[scheduleNoteId] = '';
-                }
+                this.scheduleNoteMap[scheduleNoteId] = shortCourseSchedule.notes ?? '';
 
                 this.schedules.push({
-                    scheduleName: shortCourseSchedule.scheduleName,
+                    scheduleName: shortCourseSchedule.name,
                     courses: groupedCourses,
                     customEvents: shortCourseSchedule.customEvents,
                     scheduleNoteId: scheduleNoteId,
@@ -691,7 +685,7 @@ export class Schedules {
     }
 
     getSkeletonScheduleNames(): string[] {
-        return this.skeletonSchedules.map((schedule) => schedule.scheduleName);
+        return this.skeletonSchedules.map((schedule) => schedule.name);
     }
 
     setSkeletonSchedules(skeletonSchedules: ShortCourseSchedule[]) {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,6 +8,7 @@
     "scripts": {},
     "dependencies": {
         "@packages/anteater-api-types": "workspace:*",
+        "@packages/db": "workspace:*",
         "zod": "3.23.8"
     },
     "devDependencies": {

--- a/packages/types/src/courseData.ts
+++ b/packages/types/src/courseData.ts
@@ -1,13 +1,15 @@
-import { WebsocSection, WebsocSectionType } from '@packages/anteater-api-types';
+import { WebsocCourse, WebsocDepartment, WebsocSection, WebsocSectionType } from '@packages/anteater-api-types';
 
-export interface CourseDetails {
-    deptCode: string;
-    courseNumber: string;
-    courseTitle: string;
-    courseComment: string;
-    prerequisiteLink: string;
-    sectionTypes: WebsocSectionType[];
-}
+/**
+ * Course metadata as returned by WebSOC, derived directly from the API types.
+ * `deptCode` comes from the parent `WebsocDepartment`; the remaining fields
+ * come from `WebsocCourse`. `sectionTypes` is aggregated from the course's
+ * sections rather than being a top-level field on either API type.
+ */
+export type CourseDetails = Pick<WebsocDepartment, 'deptCode'> &
+    Pick<WebsocCourse, 'courseNumber' | 'courseTitle' | 'courseComment' | 'prerequisiteLink'> & {
+        sectionTypes: WebsocSectionType[];
+    };
 
 export interface CourseInfo {
     courseDetails: CourseDetails;

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -29,19 +29,29 @@ export type Schedule = {
 export const ShortCourseSchema = z.object({
     color: z.string(),
     term: z.string(),
-    sectionCode: z.string(),
+    /**
+     * Matches the integer `sectionCode` column in `coursesInSchedule`.
+     * The WebSOC API returns section codes as strings; convert with parseInt/String at the boundary.
+     */
+    sectionCode: z.number().int(),
 });
 export type ShortCourse = z.infer<typeof ShortCourseSchema>;
 
 export const ShortCourseScheduleSchema = z
     .object({
-        scheduleName: z.string(),
+        /**
+         * Matches the `name` column in the `schedules` table.
+         */
+        name: z.string(),
         courses: z.array(ShortCourseSchema),
         customEvents: z.array(RepeatingCustomEventSchema),
-        scheduleNote: z.string().max(SCHEDULE_NOTE_MAX_LENGTH).optional(),
+        /**
+         * Matches the `notes` column in the `schedules` table.
+         */
+        notes: z.string().max(SCHEDULE_NOTE_MAX_LENGTH).optional(),
         id: z.string().optional(),
     })
-    .transform((schedule) => ({ scheduleNote: '', ...schedule }));
+    .transform((schedule) => ({ notes: '', ...schedule }));
 export type ShortCourseSchedule = z.infer<typeof ShortCourseScheduleSchema>;
 
 export const ScheduleSaveStateSchema = z.object({

--- a/packages/types/src/schedule.ts
+++ b/packages/types/src/schedule.ts
@@ -1,57 +1,67 @@
-import { WebsocSectionType } from '@packages/anteater-api-types';
+import type { CourseInSchedule } from '@packages/db/src/schema/schedule/course';
+import type { Schedule as ScheduleRow } from '@packages/db/src/schema/schedule/schedule';
 import { z } from 'zod';
 
+import { CourseDetails } from './courseData';
 import { RepeatingCustomEvent, RepeatingCustomEventSchema } from './customEvent';
 import { AASection } from './websoc';
 
 /** Max length for schedule notes (UI and server validation). */
 export const SCHEDULE_NOTE_MAX_LENGTH = 5000;
 
-export type ScheduleCourse = {
-    courseComment: string;
-    courseNumber: string;
-    courseTitle: string;
-    deptCode: string;
-    prerequisiteLink: string;
+/**
+ * Hydrated in-memory representation of a course. Derived from {@link CourseDetails}
+ * (which itself derives from `WebsocCourse`) plus the section, term, and
+ * the `color` added by {@link AASection}.
+ */
+export type ScheduleCourse = CourseDetails & {
     section: AASection;
     term: string;
-    sectionTypes: WebsocSectionType[];
 };
 
+/**
+ * Full in-memory schedule held by the client. Not a DB type —
+ * it aggregates normalized DB data with WebSOC-fetched course details.
+ */
 export type Schedule = {
     scheduleName: string;
     courses: ScheduleCourse[];
     customEvents: RepeatingCustomEvent[];
+    /** Key into the scheduleNoteMap; never persisted directly. */
     scheduleNoteId: number;
     scheduleId: string;
 };
 
+/**
+ * Wire-format course. Picks the three columns persisted in `coursesInSchedule`.
+ * The `satisfies` constraint is a compile-time guard: if those DB column names
+ * or types change, this object literal will fail to type-check.
+ */
 export const ShortCourseSchema = z.object({
-    color: z.string(),
-    term: z.string(),
-    /**
-     * Matches the integer `sectionCode` column in `coursesInSchedule`.
-     * The WebSOC API returns section codes as strings; convert with parseInt/String at the boundary.
-     */
     sectionCode: z.number().int(),
-});
+    term: z.string(),
+    color: z.string(),
+} satisfies { [K in keyof Pick<CourseInSchedule, 'sectionCode' | 'term' | 'color'>]: z.ZodType<CourseInSchedule[K]> });
 export type ShortCourse = z.infer<typeof ShortCourseSchema>;
 
-export const ShortCourseScheduleSchema = z
-    .object({
-        /**
-         * Matches the `name` column in the `schedules` table.
-         */
-        name: z.string(),
-        courses: z.array(ShortCourseSchema),
-        customEvents: z.array(RepeatingCustomEventSchema),
-        /**
-         * Matches the `notes` column in the `schedules` table.
-         */
-        notes: z.string().max(SCHEDULE_NOTE_MAX_LENGTH).optional(),
-        id: z.string().optional(),
-    })
-    .transform((schedule) => ({ notes: '', ...schedule }));
+/**
+ * Wire-format schedule. The `id`, `name`, and `notes` keys directly mirror
+ * the `schedules` table columns; the `satisfies` constraint enforces this.
+ * `courses` and `customEvents` hold the related rows in flattened form.
+ */
+export const ShortCourseScheduleSchema = z.object({
+    id: z.string().optional(),
+    name: z.string(),
+    notes: z.string().max(SCHEDULE_NOTE_MAX_LENGTH).optional().default(''),
+    courses: z.array(ShortCourseSchema),
+    customEvents: z.array(RepeatingCustomEventSchema),
+} satisfies {
+    id: z.ZodOptional<z.ZodString>;
+    name: z.ZodType<NonNullable<ScheduleRow['name']>>;
+    notes: z.ZodDefault<z.ZodOptional<z.ZodString>>;
+    courses: z.ZodArray<typeof ShortCourseSchema>;
+    customEvents: z.ZodArray<typeof RepeatingCustomEventSchema>;
+});
 export type ShortCourseSchedule = z.infer<typeof ShortCourseScheduleSchema>;
 
 export const ScheduleSaveStateSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       '@packages/anteater-api-types':
         specifier: workspace:*
         version: link:../anteater-api-types
+      '@packages/db':
+        specifier: workspace:*
+        version: link:../db
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -6457,10 +6460,12 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8flags@2.1.1:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1566

## Summary

Aligns the wire-format types (`ShortCourse`, `ShortCourseSchedule`) with the Drizzle DB schema column names, eliminating manual field-rename mappings at the DB boundary.

### Changes

**`packages/types/src/schedule.ts`**
- `ShortCourseSchedule.scheduleName` → `name` (matches `schedules.name`)
- `ShortCourseSchedule.scheduleNote` → `notes` (matches `schedules.notes`)
- `ShortCourse.sectionCode`: `string` → `number` (matches `coursesInSchedule.sectionCode` integer column)

**`apps/antalmanac/src/backend/lib/rds.ts`** (the main beneficiary)
- `aggregateUserData`: removed `scheduleName: schedule.name` / `scheduleNote: schedule.notes` / `course.sectionCode.toString()` mappings — DB values flow directly into the wire type
- `upsertSchedulesAndContents`: removed `name: schedule.scheduleName` / `notes: schedule.scheduleNote` — wire values map directly to DB columns
- `upsertCourses`: removed `parseInt(course.sectionCode)` — `sectionCode` is already `number`

**`apps/antalmanac/src/stores/Schedules.ts`**
- `getScheduleAsSaveState`: `scheduleName:` → `name:`, `scheduleNote:` → `notes:`, added `parseInt()` at the WebSOC string boundary
- `fromScheduleSaveState`: `String(sectionCode).padStart(...)`, simplified `scheduleNote` → `notes` assignment (always present after transform), `scheduleName:` → `name:`
- `getSkeletonScheduleNames`: `schedule.scheduleName` → `schedule.name`

**`apps/antalmanac/src/actions/AppStoreActions.ts`**
- `isEmptySchedule`: `schedule.scheduleNote` → `schedule.notes`
- `mergeShortCourseSchedules`: field rename throughout

**UI components** (`Export.tsx`, `Import.tsx`, `AddedCoursePane.tsx`)
- Updated display and validation to use `schedule.name` and `schedule.notes`

### What does NOT change

The hydrated UI type (`Schedule`) retains `scheduleName` and `scheduleNoteId` — those are frontend-only concerns unrelated to the DB schema. The `parseInt`/`String` conversions now live at the correct boundary in `Schedules.ts`, where `AASection.sectionCode` (WebSOC string) meets `ShortCourse.sectionCode` (DB integer).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4996565b-ee91-49b0-8986-ee82fce27c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4996565b-ee91-49b0-8986-ee82fce27c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

