### PR TITLE
ci: offset check_new_quarter schedule to minute 4

### DIFF
--- a/.github/workflows/check_new_quarter.yml
+++ b/.github/workflows/check_new_quarter.yml
@@ -2,7 +2,8 @@ name: Check and deploy new quarter
 
 on:
     schedule:
-        - cron: '0 * * * *'
+        # Avoid minute 0 — many schedulers fire on the hour; a small offset spreads load.
+        - cron: '4 * * * *'
     workflow_dispatch:
 
 env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the hourly `check_new_quarter` workflow from `0 * * * *` to `4 * * * *` (UTC) so it does not align with the top of the hour when many other cron jobs tend to run.

## Test Plan

- [ ] Confirm workflow YAML is valid (GitHub will parse on merge).
- [ ] Optional: run the workflow via `workflow_dispatch` after merge to verify it still succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3964aae3-77bf-4839-a5a0-512074d0111c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3964aae3-77bf-4839-a5a0-512074d0111c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

