### PR TITLE
fix(antalmanac): PrereqTree lint, keys, and MUI theme colors

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable prefer-const */
-import { Button, Popover } from '@mui/material';
+import { CourseInfo } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoBar';
+import { Button, Popover, useTheme } from '@mui/material';
 import { Prerequisite, PrerequisiteTree } from '@packages/antalmanac-types';
 import { FC, useState } from 'react';
-
-import { CourseInfo } from '$components/RightPane/SectionTable/CourseInfo/CourseInfoBar';
-import { useThemeStore } from '$stores/SettingsStore';
 
 import './PrereqTree.css';
 
@@ -19,18 +16,17 @@ const phraseMapping = {
 interface NodeProps {
     node: string;
     label: string;
-    index?: number;
 }
 
 const Node: FC<NodeProps> = (props) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const theme = useTheme();
     return (
-        <div style={{ padding: '1px 0' }} className={`${props.node}`} key={props.index}>
+        <div style={{ padding: '1px 0' }} className={`${props.node}`}>
             <div
                 className={'course'}
                 style={{
-                    backgroundColor: isDark ? '#303030' : '#e0e0e0',
-                    color: isDark ? '#bfbfbf' : 'black',
+                    backgroundColor: theme.palette.background.paper,
+                    color: theme.palette.text.primary,
                 }}
             >
                 {props.label}
@@ -47,7 +43,6 @@ interface TreeProps {
 }
 
 const PrereqTreeNode: FC<TreeProps> = (props) => {
-    // eslint-disable-next-line prefer-const
     const prerequisite = props.prerequisite;
     const isValueNode = Object.prototype.hasOwnProperty.call(prerequisite, 'prereqType');
 
@@ -102,8 +97,8 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
 type PrereqProps = CourseInfo;
 
 const PrereqTree: FC<PrereqProps> = (props) => {
-    let hasPrereqs = JSON.stringify(props.prerequisite_tree) !== '{}';
-    let hasDependencies = Object.keys(props.prerequisite_for).length !== 0;
+    const hasPrereqs = Object.keys(props.prerequisite_tree).length > 0;
+    const hasDependencies = Object.keys(props.prerequisite_for).length !== 0;
 
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `PrereqTree.tsx` to align with React list-key usage, drop redundant ESLint suppressions, replace hardcoded hex colors with MUI theme palette tokens, and detect an empty prerequisite tree via `Object.keys` instead of `JSON.stringify`.

## Changes

- Use `const` for `hasPrereqs` / `hasDependencies` and remove `prefer-const` disables.
- Remove the ineffective `key` on `Node`'s root element and the unused `index` prop from `NodeProps`.
- Style course nodes with `useTheme()` (`background.paper`, `text.primary`) instead of `useThemeStore` + hex colors.
- Treat a non-empty `prerequisite_tree` as `Object.keys(...).length > 0`.

## Verification

- `pnpm lint -- apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx` passes with `--deny-warnings`.
- Full-package `tsc` still reports pre-existing errors elsewhere; none reference `PrereqTree.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64ec3d7c-3c65-4254-a035-5b9bfb02faa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64ec3d7c-3c65-4254-a035-5b9bfb02faa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

