### PR TITLE
Fix search empty/loading pane fitting without hardcoded spacer heights

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneButtonRow.tsx
@@ -1,3 +1,6 @@
+import { NotificationsDialog } from '$components/RightPane/AddedCourses/Notifications/NotificationsDialog';
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
 import { ArrowBack, Visibility, Refresh } from '@mui/icons-material';
 import {
     Box,
@@ -15,16 +18,11 @@ import {
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useMemo, useState } from 'react';
 
-import { NotificationsDialog } from '$components/RightPane/AddedCourses/Notifications/NotificationsDialog';
-import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { useColumnStore, SECTION_TABLE_COLUMNS, type SectionTableColumn } from '$stores/ColumnStore';
-
 /**
  * All the interactive buttons have the same styles.
  */
 const buttonSx: SxProps = {
     backgroundColor: 'rgba(236, 236, 236, 1)',
-    marginRight: 1,
     padding: 1.5,
     boxShadow: '2',
     color: 'black',
@@ -160,10 +158,12 @@ export function CoursePaneButtonRow(props: CoursePaneButtonRowProps) {
     return (
         <Box
             sx={{
-                display: props.showSearch ? 'block' : 'none',
-                width: 'fit-content',
+                display: props.showSearch ? 'flex' : 'none',
+                flexShrink: 0,
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                gap: 1,
                 zIndex: 3,
-                position: 'absolute',
             }}
         >
             <Tooltip title="Back">

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -1,7 +1,3 @@
-import { Box } from '@mui/material';
-import { usePostHog } from 'posthog-js/react';
-import { useCallback, useEffect } from 'react';
-
 import { CoursePaneButtonRow } from '$components/RightPane/CoursePane/CoursePaneButtonRow';
 import CourseRenderPane from '$components/RightPane/CoursePane/CourseRenderPane';
 import { SearchForm } from '$components/RightPane/CoursePane/SearchForm/SearchForm';
@@ -12,6 +8,9 @@ import { Grades } from '$lib/grades';
 import { WebSOC } from '$lib/websoc';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { openSnackbar } from '$stores/SnackbarStore';
+import { Box } from '@mui/material';
+import { usePostHog } from 'posthog-js/react';
+import { useCallback, useEffect } from 'react';
 
 export function CoursePaneRoot() {
     const { key, forceUpdate, searchFormIsDisplayed, displaySearch, displaySections, advancedSearchEnabled } =
@@ -62,16 +61,28 @@ export function CoursePaneRoot() {
     }, [handleKeydown]);
 
     return (
-        <Box sx={{ height: 0, flexGrow: 1 }}>
+        <Box
+            sx={{
+                height: 0,
+                flexGrow: 1,
+                minHeight: 0,
+                display: 'flex',
+                flexDirection: 'column',
+            }}
+        >
             <CoursePaneButtonRow
                 showSearch={!searchFormIsDisplayed}
                 onDismissSearchResults={displaySearch}
                 onRefreshSearch={refreshSearch}
             />
             {searchFormIsDisplayed ? (
-                <SearchForm toggleSearch={handleSearch} />
+                <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+                    <SearchForm toggleSearch={handleSearch} />
+                </Box>
             ) : (
-                <CourseRenderPane key={key} id={key} />
+                <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+                    <CourseRenderPane key={key} id={key} />
+                </Box>
             )}
         </Box>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -32,6 +32,7 @@ import {
     GE,
 } from '@packages/antalmanac-types';
 import Image from 'next/image';
+import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 
@@ -199,12 +200,23 @@ const SectionTableWrapped = (
     return <div>{component}</div>;
 };
 
+const centeredPaneImageStyle: CSSProperties = {
+    objectFit: 'contain',
+    maxWidth: '80%',
+    maxHeight: '100%',
+    width: 'auto',
+    height: 'auto',
+};
+
 const LoadingMessage = () => {
     const isDark = useThemeStore((store) => store.isDark);
     return (
-        <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-            <Image src={isDark ? darkModeLoadingGif : loadingGif} alt="Loading courses" unoptimized />
-        </Box>
+        <Image
+            src={isDark ? darkModeLoadingGif : loadingGif}
+            alt="Loading courses"
+            unoptimized
+            style={centeredPaneImageStyle}
+        />
     );
 };
 
@@ -220,17 +232,18 @@ const ErrorMessage = () => {
     return (
         <Box
             sx={{
-                height: '100%',
+                flex: 1,
+                minHeight: 0,
                 display: 'flex',
-                alignItems: 'center',
                 flexDirection: 'column',
+                overflow: 'hidden',
             }}
         >
             {courseId && multiSearchData.length === 0 ? (
                 <Link
                     href={`https://antalmanac.com/planner/course/${encodeURIComponent(courseId)}`}
                     target="_blank"
-                    sx={{ width: '100%' }}
+                    sx={{ width: '100%', flexShrink: 0 }}
                 >
                     <Alert
                         variant="filled"
@@ -254,11 +267,21 @@ const ErrorMessage = () => {
                 </Link>
             ) : null}
 
-            <Image
-                src={isDark ? darkNoNothing : noNothing}
-                alt="No Results Found"
-                style={{ objectFit: 'contain', width: '80%', height: '80%', pointerEvents: 'none' }}
-            />
+            <Box
+                sx={{
+                    flex: 1,
+                    minHeight: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                <Image
+                    src={isDark ? darkNoNothing : noNothing}
+                    alt="No Results Found"
+                    style={{ ...centeredPaneImageStyle, pointerEvents: 'none' }}
+                />
+            </Box>
         </Box>
     );
 };
@@ -405,10 +428,18 @@ export default function CourseRenderPane(props: { id?: number }) {
         };
     }, [setHoveredEvent]);
 
-    return (
-        <>
-            <Box sx={{ height: '56px' }} />
+    const showCourseRows = !loading && !error && courseData.length > 0;
 
+    return (
+        <Box
+            sx={{
+                flex: 1,
+                minHeight: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                ...(!showCourseRows ? { overflow: 'hidden' } : {}),
+            }}
+        >
             {Object.entries(RightPaneStore.getWarningMessages()).map(([warningType, messages]) => {
                 return messages.map((message) => (
                     <WarningAlert
@@ -430,13 +461,24 @@ export default function CourseRenderPane(props: { id?: number }) {
                 );
             })}
             {loading ? (
-                <LoadingMessage />
+                <Box
+                    sx={{
+                        flex: 1,
+                        minHeight: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        overflow: 'hidden',
+                    }}
+                >
+                    <LoadingMessage />
+                </Box>
             ) : error || courseData.length === 0 ? (
                 <ErrorMessage />
             ) : (
                 <>
                     <RecruitmentBanner />
-                    <Box>
+                    <Box sx={{ flexShrink: 0 }}>
                         {courseData.map((_: WebsocSchool | WebsocDepartment | AACourse, index: number) => {
                             let heightEstimate = 200;
                             if ((courseData[index] as AACourse).sections !== undefined)
@@ -453,6 +495,6 @@ export default function CourseRenderPane(props: { id?: number }) {
                     </Box>
                 </>
             )}
-        </>
+        </Box>
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Empty and loading search results could introduce a tiny extra scroll because `ErrorMessage` used `height: 100%` while sitting below other siblings (including a fixed `56px` spacer for the floating toolbar), so total content height exceeded the pane.

## Changes

- **Course pane layout**: `CoursePaneRoot` is now a column flex container with `minHeight: 0` so children can receive a bounded height. Search form and results each sit in a `flex: 1` / `minHeight: 0` region as appropriate.
- **Toolbar**: `CoursePaneButtonRow` uses normal flex flow instead of `position: absolute`, so reserved space matches the real control row—no spacer `Box` needed.
- **CourseRenderPane**: Loading and error branches use `flex: 1` with `minHeight: 0` and `overflow: hidden` so content fills remaining space; illustrations use `maxWidth` / `maxHeight` percentages inside a centered flex region instead of `width`/`height` percentages that fought the layout.

Long result lists still grow the pane and scroll in the existing tab `Stack` as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d20e30bc-ccdd-4802-9a3b-f9ae5aabb5f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d20e30bc-ccdd-4802-9a3b-f9ae5aabb5f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

