### PR TITLE
fix(schedule-select): simplify handlers, widths, and list indexing

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -1,17 +1,20 @@
-import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
-import { Box, Button, Popover, Typography, useTheme, Tooltip } from '@mui/material';
-import { PostHog, usePostHog } from 'posthog-js/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-
 import { changeCurrentSchedule } from '$actions/AppStoreActions';
+import { CopyScheduleButton } from '$components/buttons/Copy';
 import { SortableList } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableList';
 import { AddScheduleButton } from '$components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton';
 import { DeleteScheduleButton } from '$components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/DeleteScheduleButton';
 import { RenameScheduleButton } from '$components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/RenameScheduleButton';
-import { CopyScheduleButton } from '$components/buttons/Copy';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
+import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
+import { Box, Button, Popover, Typography, useTheme, Tooltip } from '@mui/material';
+import { PostHog, usePostHog } from 'posthog-js/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// TODO: maybe these widths should be dynamic based on i.e. the viewport width?
+const scheduleSelectButtonMinWidth = 100;
+const scheduleSelectButtonMaxWidth = 150;
 
 type EventContext = {
     triggeredBy?: string;
@@ -36,15 +39,6 @@ function handleScheduleChange(index: number, postHog?: PostHog) {
 }
 
 /**
- * Creates an event handler callback that will change the current schedule to the one at a specified index.
- */
-function createScheduleSelector(index: number, postHog?: PostHog) {
-    return () => {
-        handleScheduleChange(index, postHog);
-    };
-}
-
-/**
  * Simulates an HTML select element using a popover.
  *
  * Can select a schedule, and also control schedule settings with buttons.
@@ -63,10 +57,6 @@ export function SelectSchedulePopover() {
     const anchorElementRef = useRef(null);
 
     const postHog = usePostHog();
-
-    // TODO: maybe these widths should be dynamic based on i.e. the viewport width?
-    const minWidth = useMemo(() => 100, []);
-    const maxWidth = useMemo(() => 150, []);
 
     const handleClick = useCallback(() => {
         setOpenScheduleSelect(true);
@@ -143,7 +133,11 @@ export function SelectSchedulePopover() {
                     color="inherit"
                     variant="outlined"
                     onClick={handleClick}
-                    sx={{ minWidth, maxWidth, justifyContent: 'space-between' }}
+                    sx={{
+                        minWidth: scheduleSelectButtonMinWidth,
+                        maxWidth: scheduleSelectButtonMaxWidth,
+                        justifyContent: 'space-between',
+                    }}
                 >
                     <Typography whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden" textTransform="none">
                         {scheduleMappingToUse[currentScheduleIndex]?.name || null}
@@ -162,8 +156,7 @@ export function SelectSchedulePopover() {
                     <SortableList
                         items={scheduleMappingToUse}
                         onChange={setScheduleMapping}
-                        renderItem={(item) => {
-                            const index = scheduleMappingToUse.indexOf(item);
+                        renderItem={(item, index) => {
                             return (
                                 <SortableList.Item id={item.id}>
                                     <Box
@@ -198,8 +191,8 @@ export function SelectSchedulePopover() {
                                                 <Button
                                                     color="inherit"
                                                     sx={{
-                                                        minWidth,
-                                                        maxWidth,
+                                                        minWidth: scheduleSelectButtonMinWidth,
+                                                        maxWidth: scheduleSelectButtonMaxWidth,
                                                         width: '100%',
                                                         display: 'flex',
                                                         justifyContent: 'flex-start',
@@ -208,7 +201,7 @@ export function SelectSchedulePopover() {
                                                                 ? theme.palette.action.selected
                                                                 : undefined,
                                                     }}
-                                                    onClick={() => createScheduleSelector(index, postHog)()}
+                                                    onClick={() => handleScheduleChange(index, postHog)}
                                                 >
                                                     <Typography
                                                         overflow="hidden"

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableList.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableList.tsx
@@ -1,3 +1,7 @@
+import { DragHandle } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/DragHandle';
+import { SortableItem } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableItem';
+import { SortableOverlay } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableOverlay';
+import AppStore from '$stores/AppStore';
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import type { Active, UniqueIdentifier } from '@dnd-kit/core';
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
@@ -6,11 +10,6 @@ import { List } from '@mui/material';
 import type { ReactNode } from 'react';
 import { Fragment, useMemo, useState } from 'react';
 
-import { DragHandle } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/DragHandle';
-import { SortableItem } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableItem';
-import { SortableOverlay } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableOverlay';
-import AppStore from '$stores/AppStore';
-
 interface BaseItem {
     id: UniqueIdentifier;
 }
@@ -18,7 +17,7 @@ interface BaseItem {
 interface Props<T extends BaseItem> {
     items: T[];
     onChange(items: T[]): void;
-    renderItem(item: T): ReactNode;
+    renderItem(item: T, index: number): ReactNode;
 }
 
 // ref: https://codesandbox.io/p/sandbox/dnd-kit-sortable-starter-template-22x1ix
@@ -54,12 +53,19 @@ export function SortableList<T extends BaseItem>({ items, onChange, renderItem }
         >
             <SortableContext items={items}>
                 <List sx={{ padding: 0 }}>
-                    {items.map((item) => (
-                        <Fragment key={item.id}>{renderItem(item)}</Fragment>
+                    {items.map((item, index) => (
+                        <Fragment key={item.id}>{renderItem(item, index)}</Fragment>
                     ))}
                 </List>
             </SortableContext>
-            <SortableOverlay>{activeItem ? renderItem(activeItem) : null}</SortableOverlay>
+            <SortableOverlay>
+                {activeItem
+                    ? renderItem(
+                          activeItem,
+                          items.findIndex(({ id }) => id === activeItem.id)
+                      )
+                    : null}
+            </SortableOverlay>
         </DndContext>
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed the `createScheduleSelector` factory and call `handleScheduleChange` directly from the schedule row button.
- Replaced `useMemo`-wrapped width literals with module-level numeric constants and dropped the unused `useMemo` import.
- Extended `SortableList` so `renderItem` receives the item index from the internal `items.map` callback, eliminating per-row `indexOf` (O(n²) work during list render). The drag overlay resolves the active item index with a single `findIndex` when needed.

## Test Plan

- `pnpm --filter antalmanac exec tsc --noEmit` (project has pre-existing errors elsewhere; none in `ScheduleSelect.tsx` or `SortableList.tsx`).
- Manual: open schedule popover, select a schedule, drag-reorder, verify overlay and selection highlight behave as before.

## Issues

(Internal cleanup; no linked issue.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e181e94-6572-4cc7-848d-aa0860fb3e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e181e94-6572-4cc7-848d-aa0860fb3e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

