### PR TITLE
feat: refetch search/WebSOC caches for all active quarters

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -57,10 +57,6 @@ async function main() {
     console.log('Generating cache for fuzzy search.');
 
     const activeTerms = termData.filter((t) => canTermEnrollmentChange(t.shortName));
-    if (activeTerms.length === 0) {
-        console.log('No terms in an active enrollment window; skipping search data generation.');
-        return;
-    }
 
     console.log('Fetching courses from Anteater API...');
     const courses: Course[] = [];
@@ -101,66 +97,70 @@ async function main() {
     await mkdir(join(__dirname, '../src/generated/'), { recursive: true });
     await mkdir(join(__dirname, '../src/generated/terms/'), { recursive: true });
 
-    /*
-     * WebSOC may receive updates sooner than the course catalogue updates, notably for a
-     * new academic year (i.e. Fall term). Querying WebSOC to build course data ensures all
-     * available courses are represented.
-     *
-     * Fetch WebSOC for each term where {@link canTermEnrollmentChange} is true and merge the
-     * course lists: overlapping registration periods mean several quarters need data at once.
-     */
-    console.log(`Fetching WebSoc REST for union with catalogue: ${activeTerms.map((t) => t.shortName).join(', ')}`);
+    if (activeTerms.length > 0) {
+        /*
+         * WebSOC may receive updates sooner than the course catalogue updates, notably for a
+         * new academic year (i.e. Fall term). Querying WebSOC to build course data ensures all
+         * available courses are represented.
+         *
+         * Fetch WebSOC for each term where {@link canTermEnrollmentChange} is true and merge the
+         * course lists: overlapping registration periods mean several quarters need data at once.
+         */
+        console.log(`Fetching WebSoc REST for union with catalogue: ${activeTerms.map((t) => t.shortName).join(', ')}`);
 
-    const fromWebsoc = new Map<
-        string,
-        Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
-    >();
-    for (let i = 0; i < activeTerms.length; i++) {
-        if (i > 0) {
-            await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+        const fromWebsoc = new Map<
+            string,
+            Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
+        >();
+        for (let i = 0; i < activeTerms.length; i++) {
+            if (i > 0) {
+                await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+            }
+            const [year, quarter] = activeTerms[i].shortName.split(' ');
+            const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
+                `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
+                    year,
+                    quarter,
+                }).toString()}`,
+                { isApiKeyRequired: true }
+            );
+            const chunk = getWebsocCoursesFromResponse(websocRest.data);
+            for (const [key, course] of chunk) {
+                fromWebsoc.set(key, course);
+            }
         }
-        const [year, quarter] = activeTerms[i].shortName.split(' ');
-        const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
-            `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
-                year,
-                quarter,
-            }).toString()}`,
-            { isApiKeyRequired: true }
-        );
-        const chunk = getWebsocCoursesFromResponse(websocRest.data);
-        for (const [key, course] of chunk) {
-            fromWebsoc.set(key, course);
-        }
-    }
 
-    let addedFromWebsoc = 0;
-    for (const [key, course] of fromWebsoc) {
-        if (catalogueKeys.has(key)) {
-            continue;
-        }
-        addedFromWebsoc += 1;
-        const id = `ws:${course.deptCode}:${course.courseNumber}`;
-        const name = (course.courseTitle ?? '').trim() || `${course.deptCode} ${course.courseNumber}`;
-        courseMap.set(id, {
-            id,
-            type: 'COURSE',
-            name,
-            alias: ALIASES[course.deptCode],
-            metadata: {
-                department: course.deptCode,
-                number: course.courseNumber,
-            },
-        });
-        if (!deptMap.has(course.deptCode)) {
-            deptMap.set(course.deptCode, {
-                id: course.deptCode,
-                type: 'DEPARTMENT',
-                name: (course.deptName ?? '').trim() || course.deptCode,
+        let addedFromWebsoc = 0;
+        for (const [key, course] of fromWebsoc) {
+            if (catalogueKeys.has(key)) {
+                continue;
+            }
+            addedFromWebsoc += 1;
+            const id = `ws:${course.deptCode}:${course.courseNumber}`;
+            const name = (course.courseTitle ?? '').trim() || `${course.deptCode} ${course.courseNumber}`;
+            courseMap.set(id, {
+                id,
+                type: 'COURSE',
+                name,
                 alias: ALIASES[course.deptCode],
+                metadata: {
+                    department: course.deptCode,
+                    number: course.courseNumber,
+                },
             });
+            if (!deptMap.has(course.deptCode)) {
+                deptMap.set(course.deptCode, {
+                    id: course.deptCode,
+                    type: 'DEPARTMENT',
+                    name: (course.deptName ?? '').trim() || course.deptCode,
+                    alias: ALIASES[course.deptCode],
+                });
+            }
         }
+        console.log(`WebSoc union: ${fromWebsoc.size} courses in schedule, ${addedFromWebsoc} not in catalogue.`);
+    } else {
+        console.log('No active enrollment terms; skipping WebSOC union.');
     }
-    console.log(`WebSoc union: ${fromWebsoc.size} courses in schedule, ${addedFromWebsoc} not in catalogue.`);
 
     await writeFile(
         join(__dirname, '../src/generated/searchData.ts'),

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -2,7 +2,7 @@ import { access, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { getTermsNeedingScheduleRefresh } from '$lib/termData';
+import { canTermEnrollmentChange } from '$lib/termData';
 import type {
     Course,
     CourseSearchResult,
@@ -55,6 +55,13 @@ function getWebsocCoursesFromResponse(data: WebsocAPIResponse) {
 
 async function main() {
     console.log('Generating cache for fuzzy search.');
+
+    const activeTerms = termData.filter((t) => canTermEnrollmentChange(t.shortName));
+    if (activeTerms.length === 0) {
+        console.log('No terms in an active enrollment window; skipping search data generation.');
+        return;
+    }
+
     console.log('Fetching courses from Anteater API...');
     const courses: Course[] = [];
     for (let skip = 0; skip < MAX_COURSES; skip += 100) {
@@ -99,25 +106,21 @@ async function main() {
      * new academic year (i.e. Fall term). Querying Websoc to build course data ensures all
      * available courses are represented.
      *
-     * Refresh every term still in its enrollment window (see getTermsNeedingScheduleRefresh),
-     * not only termData[0]: terms are sorted by latest instruction start, so concurrent
-     * registration (e.g. Summer sessions + Fall) requires merging multiple quarters.
+     * Refresh every term where {@link canTermEnrollmentChange} is true, not only termData[0]:
+     * terms are sorted by latest instruction start, so concurrent registration (e.g. Summer
+     * sessions + Fall) requires merging multiple quarters.
      */
-    const activeTerms = getTermsNeedingScheduleRefresh();
-    const termsForCatalogueUnion = activeTerms.length > 0 ? activeTerms : [termData[0]];
-    console.log(
-        `Fetching WebSoc REST for union with catalogue: ${termsForCatalogueUnion.map((t) => t.shortName).join(', ')}`
-    );
+    console.log(`Fetching WebSoc REST for union with catalogue: ${activeTerms.map((t) => t.shortName).join(', ')}`);
 
     const fromWebsoc = new Map<
         string,
         Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
     >();
-    for (let i = 0; i < termsForCatalogueUnion.length; i++) {
+    for (let i = 0; i < activeTerms.length; i++) {
         if (i > 0) {
             await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
         }
-        const [year, quarter] = termsForCatalogueUnion[i].shortName.split(' ');
+        const [year, quarter] = activeTerms[i].shortName.split(' ');
         const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
             `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
                 year,

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -2,18 +2,14 @@ import { access, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { getTermsNeedingScheduleRefresh } from '$lib/termData';
 import type {
     Course,
     CourseSearchResult,
     DepartmentSearchResult,
     CoursesFilteredAPIResult,
 } from '@packages/antalmanac-types';
-import type {
-    WebsocAPIResponse,
-    WebsocAPIResult,
-    WebsocCourse,
-    WebsocDepartment,
-} from '@packages/anteater-api-types';
+import type { WebsocAPIResponse, WebsocAPIResult, WebsocCourse, WebsocDepartment } from '@packages/anteater-api-types';
 
 import { fetchAnteaterAPI, queryGraphQL } from '../src/backend/lib/helpers';
 import { parseSectionCodes, SectionCodesGraphQLResponse, termData } from '../src/backend/lib/term-section-codes';
@@ -102,18 +98,38 @@ async function main() {
      * WebSOC may receive updates sooner than the course catalogue updates, notably for a
      * new academic year (i.e. Fall term). Querying Websoc to build course data ensures all
      * available courses are represented.
+     *
+     * Refresh every term still in its enrollment window (see getTermsNeedingScheduleRefresh),
+     * not only termData[0]: terms are sorted by latest instruction start, so concurrent
+     * registration (e.g. Summer sessions + Fall) requires merging multiple quarters.
      */
-    const latestTerm = termData[0];
-    const [latestYear, latestQuarter] = latestTerm.shortName.split(' ');
-    console.log(`Fetching WebSoc REST for ${latestTerm.shortName} (union with catalogue)...`);
-    const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
-        `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
-            year: latestYear,
-            quarter: latestQuarter,
-        }).toString()}`,
-        { isApiKeyRequired: true }
+    const activeTerms = getTermsNeedingScheduleRefresh();
+    const termsForCatalogueUnion = activeTerms.length > 0 ? activeTerms : [termData[0]];
+    console.log(
+        `Fetching WebSoc REST for union with catalogue: ${termsForCatalogueUnion.map((t) => t.shortName).join(', ')}`
     );
-    const fromWebsoc = getWebsocCoursesFromResponse(websocRest.data);
+
+    const fromWebsoc = new Map<
+        string,
+        Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
+    >();
+    for (let i = 0; i < termsForCatalogueUnion.length; i++) {
+        if (i > 0) {
+            await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+        }
+        const [year, quarter] = termsForCatalogueUnion[i].shortName.split(' ');
+        const websocRest = await fetchAnteaterAPI<WebsocAPIResult>(
+            `https://anteaterapi.com/v2/rest/websoc?${new URLSearchParams({
+                year,
+                quarter,
+            }).toString()}`,
+            { isApiKeyRequired: true }
+        );
+        const chunk = getWebsocCoursesFromResponse(websocRest.data);
+        for (const [key, course] of chunk) {
+            fromWebsoc.set(key, course);
+        }
+    }
 
     let addedFromWebsoc = 0;
     for (const [key, course] of fromWebsoc) {
@@ -149,15 +165,15 @@ async function main() {
         `
     import type { CourseSearchResult, DepartmentSearchResult } from "@packages/antalmanac-types";
     export const departments: Array<DepartmentSearchResult & { id: string }> = ${JSON.stringify(
-            Array.from(deptMap.values())
-        )};
+        Array.from(deptMap.values())
+    )};
     export const courses: Array<CourseSearchResult & { id: string }> = ${JSON.stringify(
-            Array.from(courseMap.values())
-        )};
+        Array.from(courseMap.values())
+    )};
     `
     );
 
-    const currentTerm = termData[0];
+    const refreshShortNames = new Set(activeTerms.map((t) => t.shortName));
     let count = 0;
     const termPromises = termData.map(async (term, index) => {
         try {
@@ -168,12 +184,13 @@ async function main() {
             try {
                 await access(fileName);
 
-                if (currentTerm.longName != term.longName) {
-                    console.log(`Skipping ${term.shortName}, cache already exists.`);
+                if (!refreshShortNames.has(term.shortName)) {
+                    console.log(
+                        `Skipping ${term.shortName}, cache exists and term is outside enrollment refresh window.`
+                    );
                     return 0;
-                } else {
-                    console.log(`Updating data for current term (${term.shortName})...`);
                 }
+                console.log(`Updating section-code cache for active term (${term.shortName})...`);
             } catch {
                 console.log(`${term.shortName} doesn't exist in cache, rebuilding.`);
             }

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -103,12 +103,11 @@ async function main() {
 
     /*
      * WebSOC may receive updates sooner than the course catalogue updates, notably for a
-     * new academic year (i.e. Fall term). Querying Websoc to build course data ensures all
+     * new academic year (i.e. Fall term). Querying WebSOC to build course data ensures all
      * available courses are represented.
      *
-     * Refresh every term where {@link canTermEnrollmentChange} is true, not only termData[0]:
-     * terms are sorted by latest instruction start, so concurrent registration (e.g. Summer
-     * sessions + Fall) requires merging multiple quarters.
+     * Fetch WebSOC for each term where {@link canTermEnrollmentChange} is true and merge the
+     * course lists: overlapping registration periods mean several quarters need data at once.
      */
     console.log(`Fetching WebSoc REST for union with catalogue: ${activeTerms.map((t) => t.shortName).join(', ')}`);
 

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -92,6 +92,19 @@ export function canTermEnrollmentChange(termShortName: Term['shortName']) {
     return openEnrollmentTerms.has(termShortName);
 }
 
+/**
+ * Terms whose WebSOC-derived search caches should be refreshed (schedule may still change).
+ * Uses the same enrollment drop-deadline window as {@link canTermEnrollmentChange}
+ * (Friday of week 2 for 10-week quarters, Friday of week 1 for 5-week summer sessions),
+ * which includes quarters whose instruction has not started yet.
+ *
+ * Calendar terms are ordered with the latest instruction start first (`fetch-term-data`), so the
+ * “latest” term alone is not sufficient when multiple quarters overlap in registration.
+ */
+export function getTermsNeedingScheduleRefresh(): Term[] {
+    return termData.filter((term) => canTermEnrollmentChange(term.shortName));
+}
+
 function getOpenEnrollmentTerms() {
     const openEnrollmentTerms: Set<Term['shortName']> = new Set();
 

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -92,19 +92,6 @@ export function canTermEnrollmentChange(termShortName: Term['shortName']) {
     return openEnrollmentTerms.has(termShortName);
 }
 
-/**
- * Terms whose WebSOC-derived search caches should be refreshed (schedule may still change).
- * Uses the same enrollment drop-deadline window as {@link canTermEnrollmentChange}
- * (Friday of week 2 for 10-week quarters, Friday of week 1 for 5-week summer sessions),
- * which includes quarters whose instruction has not started yet.
- *
- * Calendar terms are ordered with the latest instruction start first (`fetch-term-data`), so the
- * “latest” term alone is not sufficient when multiple quarters overlap in registration.
- */
-export function getTermsNeedingScheduleRefresh(): Term[] {
-    return termData.filter((term) => canTermEnrollmentChange(term.shortName));
-}
-
 function getOpenEnrollmentTerms() {
     const openEnrollmentTerms: Set<Term['shortName']> = new Set();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`get-search-data.ts` only refreshed WebSOC union data and per-term section caches for `termData[0]`. Generated calendar terms are sorted by **latest instruction start first** (`fetch-term-data.ts`), so during overlapping registration (e.g. Summer sessions plus Fall) only the chronologically latest quarter (Fall) was updated.

This change filters `termData` with the existing **`canTermEnrollmentChange`** (week 2 Friday for 10-week quarters, week 1 Friday for 5-week summer; includes quarters whose instruction has not started yet).

- WebSOC REST catalogue union merges all such quarters (with rate-limit spacing between requests).
- Per-term section JSON files are refreshed when `canTermEnrollmentChange(term.shortName)` is true.
- If no term passes that check, the script logs and **returns immediately** (no catalogue/WebSOC work).

## Test Plan

- `pnpm lint`
- Full vitest run requires generated `src/generated/termData.ts` (not present in this workspace snapshot).

## Issues

<!-- Link issue if filed -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47cf43de-6274-4b11-a71c-ac4bfafd348e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47cf43de-6274-4b11-a71c-ac4bfafd348e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

