### PR TITLE
fix: add space after Units label in section details

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DetailsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DetailsCell.tsx
@@ -30,7 +30,7 @@ export const DetailsCell = ({ sectionType, sectionNum, units, sx }: DetailCellPr
         <TableBodyCellContainer sx={sx}>
             <Box sx={SECTION_COLORS[sectionType]}>{sectionType}</Box>
             <Box>Sec: {sectionNum}</Box>
-            <Box>Units:{units}</Box>
+            <Box>Units: {units}</Box>
         </TableBodyCellContainer>
     );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a space after the colon in the section details cell so unit counts render as `Units: 4` instead of `Units:4`, matching the `Sec: …` line.

## Test Plan

- [ ] Open section table details column and confirm units display with correct spacing.

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e59a2852-e063-42ec-9163-32d5eb67ea74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e59a2852-e063-42ec-9163-32d5eb67ea74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

