### PR TITLE
refactor: use MUI slotProps for Alert and AccordionSummary

### DIFF
--- a/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
+++ b/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
@@ -62,19 +62,26 @@ function TbaExpandedCard({ tbaSections, onToggle }: { tbaSections: TbaSection[];
                 alignItems: 'center',
                 py: 0.5,
                 px: 0.5,
-                '& .MuiAlert-icon': {
-                    padding: 0.5,
-                    margin: 0,
+            }}
+            slotProps={{
+                icon: {
+                    sx: {
+                        padding: 0.5,
+                        margin: 0,
+                    },
                 },
-                '& .MuiAlert-message': {
-                    padding: 0.5,
-                    width: '100%',
+                message: {
+                    sx: {
+                        padding: 0.5,
+                        width: '100%',
+                    },
                 },
-
-                '& .MuiAlert-action': {
-                    padding: 0,
-                    margin: 0,
-                    alignSelf: 'flex-start',
+                action: {
+                    sx: {
+                        padding: 0,
+                        margin: 0,
+                        alignSelf: 'flex-start',
+                    },
                 },
             }}
             action={

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SchoolDeptCard.tsx
@@ -19,14 +19,13 @@ export function SchoolDeptCard({ name, type, comment }: SchoolDeptCardProps) {
                         sx={{
                             paddingX: 1,
                             paddingY: 0,
-
-                            /**
-                             * AccordionSummary contains a child "content" which is the actual parent of the Typography below
-                             * Styling to prevent wrap must be applied to the aforementioned parent
-                             */
-                            '& .MuiAccordionSummary-content': {
-                                overflow: 'hidden',
-                                whiteSpace: 'nowrap',
+                        }}
+                        slotProps={{
+                            content: {
+                                sx: {
+                                    overflow: 'hidden',
+                                    whiteSpace: 'nowrap',
+                                },
                             },
                         }}
                     >

--- a/apps/antalmanac/src/components/WarningAlert.tsx
+++ b/apps/antalmanac/src/components/WarningAlert.tsx
@@ -19,11 +19,13 @@ export const WarningAlert = ({ children, closable = false, onClose }: WarningAle
         <Alert
             severity="warning"
             onClose={closable ? handleClose : undefined}
-            sx={{
-                mb: 1,
-                '& .MuiAlert-message': {
-                    display: 'flex',
-                    alignItems: 'center',
+            sx={{ mb: 1 }}
+            slotProps={{
+                message: {
+                    sx: {
+                        display: 'flex',
+                        alignItems: 'center',
+                    },
                 },
             }}
         >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace `sx` descendant selectors targeting internal MUI class names (`MuiAccordionSummary-content`, `MuiAlert-*`) with official `slotProps` on `AccordionSummary` and `Alert` in three components: `SchoolDeptCard`, `WarningAlert`, and `TbaExpandedCard` in `TbaCalendarCard`. Layout and styling values are unchanged so visuals and behavior stay the same.

## Test Plan

- `pnpm lint` (workspace oxlint) passes.
- Manually verify accordion course/dept titles still ellipsis with nowrap; warning alert message vertically centers with root margin; TBA expanded info alert matches prior icon/message/action spacing and alignment.

## Issues

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a4f1877-5672-429d-9c4d-b9e9e9c268b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a4f1877-5672-429d-9c4d-b9e9e9c268b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

