### PR TITLE
style: unify textfield styling

### DIFF
--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { LIGHT_BLUE } from '$src/globals';
 import { REVIEW_TAGS } from '$stores/ReviewPromptStore';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { Close } from '@mui/icons-material';
@@ -16,7 +15,6 @@ import {
     Stack,
     TextField,
     Typography,
-    useTheme,
 } from '@mui/material';
 
 function ratingLabel(rating: number): string {
@@ -55,7 +53,6 @@ function difficultyLabel(difficulty: number): string {
 }
 
 export function ReviewStep() {
-    const theme = useTheme();
     const courseId = useReviewPromptStore((s) => s.candidate?.courseId ?? '');
     const professorId = useReviewPromptStore((s) => s.candidate?.professorId ?? '');
     const rating = useReviewPromptStore((s) => s.rating);
@@ -114,6 +111,7 @@ export function ReviewStep() {
                     </Box>
 
                     <TextField
+                        color="secondary"
                         label="Write a review (optional)"
                         multiline
                         minRows={1}
@@ -123,18 +121,10 @@ export function ReviewStep() {
                         onChange={(e) => setTextReview(e.target.value)}
                         slotProps={{
                             htmlInput: { maxLength: 500 },
-                            formHelperText: { sx: { textAlign: 'right', mx: 0 } },
+                            formHelperText: {
+                                sx: { textAlign: 'right', mx: 0, color: 'text.secondary' },
+                            },
                         }}
-                        sx={
-                            theme.palette.mode === 'dark'
-                                ? {
-                                      '& .MuiInputLabel-root': { color: LIGHT_BLUE },
-                                      '& .MuiInputLabel-root.Mui-focused': { color: LIGHT_BLUE },
-                                      '& .MuiInput-underline:before': { borderBottomColor: LIGHT_BLUE },
-                                      '& .MuiInput-underline:after': { borderBottomColor: LIGHT_BLUE },
-                                  }
-                                : {}
-                        }
                         helperText={`${textReview.length}/500`}
                     />
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursePane.tsx
@@ -9,12 +9,11 @@ import { ColumnToggleDropdown } from '$components/RightPane/CoursePane/CoursePan
 import SectionTable from '$components/RightPane/SectionTable/SectionTable';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
-import { LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useTabStore } from '$stores/TabStore';
 import { MenuBook } from '@mui/icons-material';
-import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography, useTheme } from '@mui/material';
+import { Box, Chip, Paper, SxProps, TextField, Tooltip, Typography } from '@mui/material';
 import { AACourse, SCHEDULE_NOTE_MAX_LENGTH } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -144,7 +143,6 @@ function CustomEventsBox() {
 }
 
 function ScheduleNoteBox() {
-    const theme = useTheme();
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
     const [scheduleNote, setScheduleNote] = useState(
         skeletonMode ? AppStore.getCurrentSkeletonSchedule().scheduleNote : AppStore.getCurrentScheduleNote()
@@ -195,6 +193,7 @@ function ScheduleNoteBox() {
 
             <TextField
                 type="text"
+                color="secondary"
                 variant="filled"
                 label="Click here to start typing!"
                 onChange={handleNoteChange}
@@ -214,14 +213,6 @@ function ScheduleNoteBox() {
                     '& .MuiInputBase-root': {
                         cursor: skeletonMode ? 'not-allowed' : 'text',
                     },
-                    ...(theme.palette.mode === 'dark' && {
-                        '& .MuiInputLabel-root': {
-                            color: LIGHT_BLUE,
-                        },
-                        '& .MuiInputLabel-root.Mui-focused': {
-                            color: LIGHT_BLUE,
-                        },
-                    }),
                 }}
             />
         </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Duplicate dark-mode styling for text fields relied on deep `sx` selectors (`MuiInputLabel-root`, standard underlines via `MuiInput-underline:before/after`, and inlined `LIGHT_BLUE`). This updates the **review prompt** (`ReviewStep`) and **schedule notes** (`AddedCoursePane` → `ScheduleNoteBox`) to use MUI-supported `color="secondary"`, which aligns with the app palette: light theme keeps primary and secondary on the same blue; dark theme already maps `secondary.main` to `LIGHT_BLUE`.

Review helper text intentionally stays **`text.secondary`** via `slotProps.formHelperText` so `color="secondary"` does not recolor the `0/500` counter toward the accent. Schedule notes still use filled + `disableUnderline`, skeleton/disabled wiring, and the same cursor rules.

No broad `Theme.tsx` component overrides (`MuiFormLabel` / `MuiInput`) — idle labels and resting underlines follow default MUI behavior for secondary fields.

## Test Plan

- [ ] **Light**: Review prompt optional text field — label, underline on focus, helper text readable.
- [ ] **Dark**: Same — secondary accent reads correctly on focus/hover vs stock idle underline + label tone.
- [ ] **Light/dark**: Added Courses → Schedule Notes — editable note field; skeleton / API unreachable state still disables the field with `not-allowed` cursor on wrapper + input where applicable.

## Issues

(No linked tracker — internal styling consolidation.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0de6c338-58cc-4266-a668-573be8d7d138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0de6c338-58cc-4266-a668-573be8d7d138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

