### PR TITLE
fix: freeze department list auto-updates (disable hourly cron)

### DIFF
--- a/.github/workflows/check_departments.yml
+++ b/.github/workflows/check_departments.yml
@@ -1,9 +1,9 @@
 name: Check and update department list
 
+# Scheduled runs are disabled: the Anteater departments feed often returns truncated
+# names (e.g. "Engrbe*", "Int Dep*"). We keep apps/antalmanac/src/generated/departments.json
+# fixed until names are authoritative. Run manually via workflow_dispatch if you refresh on purpose.
 on:
-    schedule:
-        # Hourly at :04 UTC — offsets this job from check_new_quarter at :00 so two Anteater pulls do not start together.
-        - cron: '4 * * * *'
     workflow_dispatch:
 
 env:

--- a/.github/workflows/check_departments.yml
+++ b/.github/workflows/check_departments.yml
@@ -1,8 +1,8 @@
 name: Check and update department list
 
-# Scheduled runs are disabled: the Anteater departments feed often returns truncated
-# names (e.g. "Engrbe*", "Int Dep*"). We keep apps/antalmanac/src/generated/departments.json
-# fixed until names are authoritative. Run manually via workflow_dispatch if you refresh on purpose.
+# AAPI WebSOC departments endpoint isn't stable, sometimes returning truncated names (e.g. "Engrbe*", "Int Dep*").
+# Cron jobs are disabled until the API is stable.
+# TODO (@KevinWu098): Reenable cron jobs
 on:
     workflow_dispatch:
 

--- a/apps/antalmanac/scripts/fetch-departments.ts
+++ b/apps/antalmanac/scripts/fetch-departments.ts
@@ -10,8 +10,6 @@ import 'dotenv/config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Departments list is intentionally not on a cron schedule — upstream names are often truncated.
-// Refresh via .github/workflows/check_departments.yml (workflow_dispatch) when updating on purpose.
 const DEPARTMENT_YEAR_RANGE = 10;
 const OUTPUT_DIR = join(__dirname, '../src/generated/');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'departments.json');

--- a/apps/antalmanac/scripts/fetch-departments.ts
+++ b/apps/antalmanac/scripts/fetch-departments.ts
@@ -10,7 +10,8 @@ import 'dotenv/config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Production refresh: .github/workflows/check_departments.yml runs hourly at minute 4 UTC (staggered from other hourly jobs).
+// Departments list is intentionally not on a cron schedule — upstream names are often truncated.
+// Refresh via .github/workflows/check_departments.yml (workflow_dispatch) when updating on purpose.
 const DEPARTMENT_YEAR_RANGE = 10;
 const OUTPUT_DIR = join(__dirname, '../src/generated/');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'departments.json');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Disables the hourly schedule on **Check and update department list** because the Anteater departments API often returns truncated display names. The committed `departments.json` is treated as frozen for now. The workflow can still be run manually via **workflow_dispatch** when a deliberate refresh is desired.

## Test Plan

- [x] Verified workflow YAML is valid (cron removed, `workflow_dispatch` retained).
- [x] No runtime code paths changed beyond a comment in `fetch-departments.ts`.

## Issues

Closes #


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de308b53-28aa-40ce-acea-42afb65e0aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de308b53-28aa-40ce-acea-42afb65e0aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

