### PR TITLE
refactor: remove google ID storage and usage

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -79,22 +79,6 @@ export class RDS {
             .then((res) => res[0]);
     }
 
-    /**
-     * Retrieves a google ID by their user ID from the database.
-     *
-     * @param db - The database to use for the query.
-     * @param userId - The ID of the user to retrieve.
-     * @returns The google ID if found, otherwise null.
-     */
-    static async getGoogleIdByUserId(db: DatabaseOrTransaction, userId: string): Promise<string | null> {
-        return db
-            .select({ providerAccountId: accounts.providerAccountId })
-            .from(accounts)
-            .where(eq(accounts.userId, userId))
-            .limit(1)
-            .then((res) => (res.length > 0 ? res[0].providerAccountId : null));
-    }
-
     static async registerUserAccount(
         db: DatabaseOrTransaction,
         accountType: Account['accountType'],

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -78,9 +78,7 @@ export function AdvancedSearchTextFields() {
     const { plannerRoadmaps, updateTakenCourses } = usePlannerStore(
         useShallow((s) => ({ plannerRoadmaps: s.plannerRoadmaps, updateTakenCourses: s.updateTakenCourses }))
     );
-    const { sessionIsValid, googleId } = useSessionStore(
-        useShallow((s) => ({ sessionIsValid: s.sessionIsValid, googleId: s.googleId }))
-    );
+    const { sessionIsValid } = useSessionStore(useShallow((s) => ({ sessionIsValid: s.sessionIsValid })));
     const [signInOpen, setSignInOpen] = useState(false);
 
     const syncFieldStates = useCallback(() => {
@@ -205,11 +203,7 @@ export function AdvancedSearchTextFields() {
     }, []);
 
     useEffect(() => {
-        if (!googleId) {
-            return;
-        }
-
-        updateTakenCourses(googleId, excludeRoadmapCourses);
+        updateTakenCourses(excludeRoadmapCourses);
 
         if (!excludeRoadmapCourses) return;
         if (!plannerRoadmaps || plannerRoadmaps.length === 0) return;

--- a/apps/antalmanac/src/stores/PlannerStore.ts
+++ b/apps/antalmanac/src/stores/PlannerStore.ts
@@ -11,8 +11,8 @@ interface PlannerStore {
     plannerRoadmaps: Roadmap[];
     isPlannerLoading: boolean;
 
-    loadPlannerRoadmaps: (googleId: string) => Promise<void>;
-    updateTakenCourses: (googleId: string, selectedRoadmapId: string) => void;
+    loadPlannerRoadmaps: () => Promise<void>;
+    updateTakenCourses: (selectedRoadmapId: string) => void;
 }
 
 function roadmapQuarterToYearAndQuarter(startYear: number, quarterName: string): { year: number; quarter: string } {
@@ -58,11 +58,7 @@ export const usePlannerStore = create<PlannerStore>((set, get) => {
         plannerRoadmaps: [],
         isPlannerLoading: false,
 
-        loadPlannerRoadmaps: async (googleId) => {
-            if (!googleId) {
-                set({ plannerRoadmaps: [] });
-                return;
-            }
+        loadPlannerRoadmaps: async () => {
             set({ isPlannerLoading: true });
             try {
                 const data = await trpc.roadmap.fetchUserPlannerRoadmaps.query();
@@ -75,9 +71,9 @@ export const usePlannerStore = create<PlannerStore>((set, get) => {
             set({ isPlannerLoading: false });
         },
 
-        updateTakenCourses: (googleId, selectedRoadmapId) => {
+        updateTakenCourses: (selectedRoadmapId) => {
             const roadmaps = get().plannerRoadmaps;
-            if (!googleId || !selectedRoadmapId || roadmaps.length === 0) {
+            if (!selectedRoadmapId || roadmaps.length === 0) {
                 set({ userTakenCourses: new Set(), filterTakenCourses: false });
                 return;
             }

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -16,9 +16,6 @@ interface SessionState {
     clearSession: () => Promise<string | null>;
 
     hasCheckedAuth: boolean;
-
-    googleId: string | null;
-    setGoogleId: (id: string) => void;
 }
 
 export const useSessionStore = create<SessionState>((set) => {
@@ -33,16 +30,10 @@ export const useSessionStore = create<SessionState>((set) => {
         avatar: null,
         sessionIsValid: false,
         hasCheckedAuth: false,
-        googleId: null,
 
         loadSession: async () => {
             try {
-                const { users, accounts } = await trpc.auth.getUserAndAccount.query();
-
-                let googleId = accounts?.providerAccountId ?? null;
-                if (googleId?.startsWith('google_')) {
-                    googleId = googleId.slice('google_'.length);
-                }
+                const { users } = await trpc.auth.getUserAndAccount.query();
 
                 set({
                     sessionIsValid: true,
@@ -52,10 +43,9 @@ export const useSessionStore = create<SessionState>((set) => {
                     email: users.email ?? null,
                     name: users.name ?? null,
                     avatar: users.avatar ?? null,
-                    googleId,
                 });
 
-                usePlannerStore.getState().loadPlannerRoadmaps(googleId);
+                usePlannerStore.getState().loadPlannerRoadmaps();
 
                 setWasLoggedIn(true);
                 return true;
@@ -74,7 +64,6 @@ export const useSessionStore = create<SessionState>((set) => {
                     email: null,
                     name: null,
                     avatar: null,
-                    googleId: null,
                 });
                 return false;
             }
@@ -100,12 +89,9 @@ export const useSessionStore = create<SessionState>((set) => {
                 email: null,
                 name: null,
                 avatar: null,
-                googleId: null,
             });
 
             return logoutUrl;
         },
-
-        setGoogleId: (id) => set({ googleId: id }),
     };
 });

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -6,7 +6,6 @@ import { ScheduleSaveStateSchema } from './schedule';
  * Users are stored in one shared table.
  *
  * All users can be queried by their `id`.
- * Google users can be queried via the `googleId` column.
  */
 export const UserSchema = z.object({
     /**
@@ -16,12 +15,6 @@ export const UserSchema = z.object({
      * TODO: Handle case where existing ID conflicts with the Google ID.
      */
     id: z.string(),
-
-    /**
-     * Some users will have a Google ID from logging in via Google OAuth.
-     * They can still use their ID to log in.
-     */
-    googleId: z.string().optional(),
 
     /**
      * Users can view other users' schedules, even anonymously.


### PR DESCRIPTION
## Summary

Remove googleId now that it isn't used anywhere (Planner roadmaps are fetched by email now).

## Test Plan

- Auth and Planner features still work
- Nothing depends on google ID

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
