### PR TITLE
refactor(antalmanac): emit JSON instead of TypeScript for term and search data caches

### DIFF
--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -21,13 +21,7 @@ function sanitizeTermName(year: string, quarter: keyof typeof QUARTER_MAP): `${s
     return `${year} ${QUARTER_MAP[quarter]}`;
 }
 
-function toLocalDateCode(dateString: string): string {
-    const [year, month, day] = dateString.split('-').map(Number);
-    // 0-indexed months
-    return `new Date(${year}, ${month - 1}, ${day})`;
-}
-
-function serializeTerm(term: CalendarTerm): string {
+function serializeTerm(term: CalendarTerm) {
     const { year, quarter, instructionStart, finalsStart, socAvailable } = term;
 
     if (!instructionStart || !finalsStart || !socAvailable) {
@@ -38,14 +32,15 @@ function serializeTerm(term: CalendarTerm): string {
     const longName = sanitizeTermName(year, quarter);
     const isSummerTerm = quarter.toLowerCase().includes('summer');
 
-    return `    {
-        shortName: ${JSON.stringify(shortName)},
-        longName: ${JSON.stringify(longName)},
-        startDate: ${toLocalDateCode(instructionStart)},
-        finalsStartDate: ${toLocalDateCode(finalsStart)},
-        socAvailable: ${toLocalDateCode(socAvailable)},
-        isSummerTerm: ${isSummerTerm},
-    }`;
+    return {
+        shortName,
+        longName,
+        // ISO "YYYY-MM-DD" strings so consumers can reconstruct local-timezone Date objects
+        startDate: instructionStart,
+        finalsStartDate: finalsStart,
+        socAvailable,
+        isSummerTerm,
+    };
 }
 
 async function main() {
@@ -59,16 +54,10 @@ async function main() {
         return dateB - dateA;
     });
 
-    const termEntries = sortedTerms.map(serializeTerm).join(',\n');
-    const fileContent = `import type { Term } from '$lib/termData';
-
-export const terms: Term[] = [
-${termEntries}
-];
-    `;
+    const termEntries = sortedTerms.map(serializeTerm);
 
     await mkdir(GENERATED_DIR, { recursive: true });
-    await writeFile(TERM_DATA_FILE, fileContent);
+    await writeFile(TERM_DATA_FILE, JSON.stringify(termEntries, null, 2));
 
     console.log('Term data generated. Written to ', TERM_DATA_FILE);
 }

--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -35,7 +35,6 @@ function serializeTerm(term: CalendarTerm) {
     return {
         shortName,
         longName,
-        // ISO "YYYY-MM-DD" strings so consumers can reconstruct local-timezone Date objects
         startDate: instructionStart,
         finalsStartDate: finalsStart,
         socAvailable,

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -13,7 +13,12 @@ import { GENERATED_DIR, GENERATED_TERMS_DIR, SEARCH_DATA_FILE } from './lib/path
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
 const MAX_COURSES = 10_000;
-const DELAY_MS = 500; // avoid rate limits from AAPI
+
+/**
+ * Delay between GraphQL requests to avoid triggering AAPI rate limits / OOM.
+ * TODO (@kevin): remove once AAPI resolves OOM issues.
+ */
+const DELAY_MS = 500;
 
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',
@@ -42,6 +47,32 @@ function getWebsocCoursesFromResponse(data: WebsocAPIResponse) {
             )
         )
     );
+}
+
+/**
+ * Build a WebSOC GraphQL query for section codes in a given term.
+ * Returns the raw section code, type, and number for every section so
+ * the caller can populate the per-term section-code cache.
+ */
+function buildSectionCodesQuery(year: string, quarter: string): string {
+    return `{
+        websoc(query: { year: "${year}", quarter: ${quarter} }) {
+            schools {
+                departments {
+                    deptCode
+                    courses {
+                        courseTitle
+                        courseNumber
+                        sections {
+                            sectionCode
+                            sectionType
+                            sectionNum
+                        }
+                    }
+                }
+            }
+        }
+    }`;
 }
 
 async function main() {
@@ -83,8 +114,6 @@ async function main() {
         });
     }
     console.log(`Fetched ${deptMap.size} departments.`);
-
-    const QUERY_TEMPLATE = `{websoc(query:{year:"$$YEAR$$",quarter:$$QUARTER$$}){schools{departments{deptCode courses{courseTitle courseNumber sections{sectionCode sectionType sectionNum}}}}}}`;
 
     await mkdir(GENERATED_DIR, { recursive: true });
     await mkdir(GENERATED_TERMS_DIR, { recursive: true });
@@ -151,20 +180,26 @@ async function main() {
 
     await writeFile(
         SEARCH_DATA_FILE,
-        `
-    import type { CourseSearchResult, DepartmentSearchResult } from "@packages/antalmanac-types";
-    export const departments: Array<DepartmentSearchResult & { id: string }> = ${JSON.stringify(
-        Array.from(deptMap.values())
-    )};
-    export const courses: Array<CourseSearchResult & { id: string }> = ${JSON.stringify(
-        Array.from(courseMap.values())
-    )};
-    `
+        JSON.stringify(
+            {
+                departments: Array.from(deptMap.values()),
+                courses: Array.from(courseMap.values()),
+            },
+            null,
+            2
+        )
     );
 
     const refreshShortNames = new Set(activeTerms.map((t) => t.shortName));
     let count = 0;
-    const termPromises = termData.map(async (term, index) => {
+
+    /*
+     * Fetch section-code data one term at a time with a fixed delay between requests.
+     * Sequential execution (rather than staggered Promise.all) ensures we never have
+     * concurrent in-flight GraphQL calls, which matters while AAPI has OOM constraints.
+     */
+    let requestsMade = 0;
+    for (const term of termData) {
         try {
             const [year, quarter] = term.shortName.split(' ');
             const parsedTerm = `${quarter}_${year}`;
@@ -177,47 +212,37 @@ async function main() {
                     console.log(
                         `Skipping ${term.shortName}, cache exists and term is outside enrollment refresh window.`
                     );
-                    return 0;
+                    continue;
                 }
                 console.log(`Updating section-code cache for active term (${term.shortName})...`);
             } catch {
                 console.log(`${term.shortName} doesn't exist in cache, rebuilding.`);
             }
 
-            // TODO (@kevin): remove delay once AAPI resolves OOM issues
-            await new Promise((resolve) => setTimeout(resolve, DELAY_MS * index));
+            // Stagger requests to respect AAPI rate limits / avoid OOM
+            if (requestsMade > 0) {
+                await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+            }
+            requestsMade++;
 
-            const query = QUERY_TEMPLATE.replace('$$YEAR$$', year).replace('$$QUARTER$$', quarter);
+            const query = buildSectionCodesQuery(year, quarter);
             const res = await aapiClient.graphql<SectionCodesGraphQLResponse>(query);
             if (!res) {
                 throw new Error(`Error fetching section codes for ${term.shortName}.`);
             }
 
             const parsedSectionData = parseSectionCodes(res);
+            const numKeys = Object.keys(parsedSectionData).length;
 
-            console.log(
-                `Fetched ${Object.keys(parsedSectionData).length} section codes for ${
-                    term.shortName
-                } from Anteater API.`
-            );
+            console.log(`Fetched ${numKeys} section codes for ${term.shortName} from Anteater API.`);
 
             await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
-            return Object.keys(parsedSectionData).length;
+            count += numKeys;
         } catch (error) {
-            console.error(`ERROR in promise ${index} for term "${term.shortName}":`);
-            console.error(`Term details:`, {
-                shortName: term.shortName,
-                year: term.shortName.split(' ')[0],
-                quarter: term.shortName.split(' ')[1],
-                index,
-            });
-
+            console.error(`ERROR for term "${term.shortName}":`);
             throw error;
         }
-    });
-
-    const results = await Promise.all(termPromises);
-    count = results.reduce((acc, numKeys) => acc + numKeys, 0);
+    }
 
     console.log(`Fetched ${count} section codes for ${termData.length} terms from Anteater API.`);
     console.log('Cache generated.');

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -14,10 +14,7 @@ const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
 const MAX_COURSES = 10_000;
 
-/**
- * Delay between GraphQL requests to avoid triggering AAPI rate limits / OOM.
- * TODO (@kevin): remove once AAPI resolves OOM issues.
- */
+// Delay between GraphQL requests to avoid triggering AAPI rate limits / OOM.
 const DELAY_MS = 500;
 
 const ALIASES: Record<string, string | undefined> = {
@@ -49,11 +46,6 @@ function getWebsocCoursesFromResponse(data: WebsocAPIResponse) {
     );
 }
 
-/**
- * Build a WebSOC GraphQL query for section codes in a given term.
- * Returns the raw section code, type, and number for every section so
- * the caller can populate the per-term section-code cache.
- */
 function buildSectionCodesQuery(year: string, quarter: string): string {
     return `{
         websoc(query: { year: "${year}", quarter: ${quarter} }) {

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -7,7 +7,7 @@ const appRoot = dirname(scriptsDir);
 
 export const GENERATED_DIR = join(appRoot, 'src/generated');
 export const GENERATED_TERMS_DIR = join(GENERATED_DIR, 'terms');
-export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.ts');
+export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.json');
 export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
-export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.ts');
+export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -3,22 +3,37 @@ import { join } from 'node:path';
 
 // eslint-disable-next-line import/no-unresolved
 import _searchData from '$generated/searchData.json';
-import type {
-    CourseSearchResult,
-    DepartmentSearchResult,
-    GESearchResult,
-    SearchResult,
-    SectionSearchResult,
-} from '@packages/antalmanac-types';
+import type { GESearchResult, SearchResult, SectionSearchResult } from '@packages/antalmanac-types';
 import * as fuzzysort from 'fuzzysort';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
 
-const searchData = _searchData as {
-    departments: Array<DepartmentSearchResult & { id: string }>;
-    courses: Array<CourseSearchResult & { id: string }>;
-};
+const departmentSchema = z.object({
+    id: z.string(),
+    type: z.literal('DEPARTMENT'),
+    name: z.string(),
+    alias: z.string().optional(),
+});
+
+const courseSchema = z.object({
+    id: z.string(),
+    type: z.literal('COURSE'),
+    name: z.string(),
+    alias: z.string().optional(),
+    metadata: z.object({
+        department: z.string(),
+        number: z.string(),
+    }),
+    isOffered: z.boolean().optional(),
+});
+
+const searchDataSchema = z.object({
+    departments: z.array(departmentSchema),
+    courses: z.array(courseSchema),
+});
+
+const searchData = searchDataSchema.parse(_searchData);
 
 const MAX_AUTOCOMPLETE_RESULTS = 12;
 

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -2,12 +2,23 @@ import { readFile } from 'fs/promises';
 import { join } from 'node:path';
 
 // eslint-disable-next-line import/no-unresolved
-import * as searchData from '$generated/searchData';
-import type { GESearchResult, SearchResult, SectionSearchResult } from '@packages/antalmanac-types';
+import _searchData from '$generated/searchData.json';
+import type {
+    CourseSearchResult,
+    DepartmentSearchResult,
+    GESearchResult,
+    SearchResult,
+    SectionSearchResult,
+} from '@packages/antalmanac-types';
 import * as fuzzysort from 'fuzzysort';
 import { z } from 'zod';
 
 import { procedure, router } from '../trpc';
+
+const searchData = _searchData as {
+    departments: Array<DepartmentSearchResult & { id: string }>;
+    courses: Array<CourseSearchResult & { id: string }>;
+};
 
 const MAX_AUTOCOMPLETE_RESULTS = 12;
 

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -1,6 +1,7 @@
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import termJson from '$generated/termData.json';
 import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
+import { z } from 'zod';
 
 /**
  * Quarterly Academic Calendar {@link https://www.reg.uci.edu/calendars/quarterly/2023-2024/quarterly23-24.html}
@@ -27,23 +28,29 @@ function parseLocalDate(dateStr: string): Date {
     return new Date(year, month - 1, day);
 }
 
-type RawTerm = {
-    shortName: `${string} ${string}`;
-    longName: string;
-    startDate: string;
-    finalsStartDate: string;
-    socAvailable: string;
-    isSummerTerm: boolean;
-};
+const termSchema = z
+    .object({
+        shortName: z.string().refine((s): s is `${string} ${string}` => s.includes(' '), {
+            message: 'shortName must be "<year> <quarter>"',
+        }),
+        longName: z.string(),
+        startDate: z.string().date(),
+        finalsStartDate: z.string().date(),
+        socAvailable: z.string().date(),
+        isSummerTerm: z.boolean(),
+    })
+    .transform(
+        (t): Term => ({
+            shortName: t.shortName,
+            longName: t.longName,
+            startDate: parseLocalDate(t.startDate),
+            finalsStartDate: parseLocalDate(t.finalsStartDate),
+            socAvailable: parseLocalDate(t.socAvailable),
+            isSummerTerm: t.isSummerTerm,
+        })
+    );
 
-const terms: Term[] = (termJson as RawTerm[]).map((t) => ({
-    shortName: t.shortName,
-    longName: t.longName,
-    startDate: parseLocalDate(t.startDate),
-    finalsStartDate: parseLocalDate(t.finalsStartDate),
-    socAvailable: parseLocalDate(t.socAvailable),
-    isSummerTerm: t.isSummerTerm,
-}));
+const terms: Term[] = z.array(termSchema).parse(termJson);
 
 /**
  * Only include terms that have a SOC available.

--- a/apps/antalmanac/src/lib/termData.ts
+++ b/apps/antalmanac/src/lib/termData.ts
@@ -1,5 +1,5 @@
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
-import { terms } from '$generated/termData';
+import termJson from '$generated/termData.json';
 import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 
 /**
@@ -16,6 +16,34 @@ export type Term = {
     socAvailable: Date;
     isSummerTerm: boolean;
 };
+
+/**
+ * The JSON stores dates as ISO "YYYY-MM-DD" strings. We reconstruct local-timezone
+ * Date objects (mirroring `new Date(year, month-1, day)`) so that date arithmetic
+ * elsewhere in the app is unaffected by the UTC-vs-local distinction.
+ */
+function parseLocalDate(dateStr: string): Date {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    return new Date(year, month - 1, day);
+}
+
+type RawTerm = {
+    shortName: `${string} ${string}`;
+    longName: string;
+    startDate: string;
+    finalsStartDate: string;
+    socAvailable: string;
+    isSummerTerm: boolean;
+};
+
+const terms: Term[] = (termJson as RawTerm[]).map((t) => ({
+    shortName: t.shortName,
+    longName: t.longName,
+    startDate: parseLocalDate(t.startDate),
+    finalsStartDate: parseLocalDate(t.finalsStartDate),
+    socAvailable: parseLocalDate(t.socAvailable),
+    isSummerTerm: t.isSummerTerm,
+}));
 
 /**
  * Only include terms that have a SOC available.


### PR DESCRIPTION
tbh terms should be handled better, but this is an improvement, i think
---

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two follow-up cleanups to the data scripts in `apps/antalmanac`:

**A) Generated JSON instead of generated TypeScript (two commits)**

`scripts/fetch-term-data.ts` now emits `src/generated/termData.json` (an array of plain objects with ISO `YYYY-MM-DD` date strings) instead of `termData.ts` (source fragments with `new Date(...)` literals and a `Term` import from `$lib/termData`).

`src/lib/termData.ts` imports the JSON directly (`resolveJsonModule` was already enabled) and maps each entry back to a real `Date` via `parseLocalDate()`, which replicates the original `new Date(year, month-1, day)` local-timezone semantics. The `Term` type lives exclusively in `$lib/termData` — the circular dependency is eliminated.

`scripts/get-search-data.ts` now writes `src/generated/searchData.json` (`{ departments, courses }`) instead of a TypeScript source file embedding a `JSON.stringify` call. `src/backend/routers/search.ts` imports the JSON as a default import and casts to the `DepartmentSearchResult` / `CourseSearchResult` types from `@packages/antalmanac-types`.

`scripts/lib/paths.ts` updated for both new filenames.

No CI or `.gitignore` changes needed: the composite `cache-generated-data` action already caches `apps/antalmanac/src/generated/**` and runs `get-data` which now produces the JSON files, and the existing `src/generated/*` gitignore rule continues to ignore them as build artifacts.

**B) `get-search-data.ts` internals (second commit)**

- Replaces `QUERY_TEMPLATE` + `String.replace('$$YEAR$$', …)` with a named `buildSectionCodesQuery(year, quarter)` function that expresses the GraphQL query as a readable multi-line template literal.
- Replaces the staggered `Promise.all` + `DELAY_MS * index` pattern with a sequential `for…of` loop. A delay is applied only between actual API requests (cached/skipped terms incur no wait), which is functionally equivalent while guaranteeing zero concurrent in-flight calls — safer for the current AAPI OOM constraint.

## Test Plan

- ✅ `pnpm lint` (oxlint) — 0 warnings, 0 errors
- ✅ `tsc --noEmit` — 0 new errors (only pre-existing GIF/PNG asset import errors unrelated to this PR)
- CI `Generate termData` action runs `pnpm --filter antalmanac get-data` (unchanged script name), which now writes the JSON files; lint job already depends on this step before running

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-020aee6a-a7c1-481e-81c4-572f9044489f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-020aee6a-a7c1-481e-81c4-572f9044489f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

