### PR TITLE
refactor: remove unnecessary useEffects in three components

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -94,7 +94,8 @@ export function AdvancedSearchTextFields() {
         setExcludeRoadmapCourses(formData.excludeRoadmapCourses);
         setExcludeRestrictionCodes(formData.excludeRestrictionCodes);
         setDays(formData.days);
-    }, []);
+        updateTakenCourses(formData.excludeRoadmapCourses);
+    }, [updateTakenCourses]);
 
     useEffect(() => {
         RightPaneStore.on('formDataChange', syncFieldStates);
@@ -179,6 +180,7 @@ export function AdvancedSearchTextFields() {
                 break;
             case 'excludeRoadmapCourses':
                 setExcludeRoadmapCourses(stringValue);
+                updateTakenCourses(stringValue);
                 break;
             case 'excludeRestrictionCodes':
                 setExcludeRestrictionCodes(stringValue);
@@ -203,12 +205,13 @@ export function AdvancedSearchTextFields() {
     }, []);
 
     useEffect(() => {
-        updateTakenCourses(excludeRoadmapCourses);
+        const currentExclude = RightPaneStore.getFormData().excludeRoadmapCourses;
+        updateTakenCourses(currentExclude);
 
-        if (!excludeRoadmapCourses) return;
+        if (!currentExclude) return;
         if (!plannerRoadmaps || plannerRoadmaps.length === 0) return;
 
-        const exists = plannerRoadmaps.some((r) => r.id.toString() === excludeRoadmapCourses);
+        const exists = plannerRoadmaps.some((r) => r.id.toString() === currentExclude);
 
         if (!exists) {
             openSnackbar('warning', 'Invalid roadmap selection. All courses shown.');
@@ -216,7 +219,7 @@ export function AdvancedSearchTextFields() {
             RightPaneStore.updateFormValue('excludeRoadmapCourses', '');
             replaceUrlSearchParams((params) => params.delete('excludeRoadmapCourses'));
         }
-    }, [plannerRoadmaps, excludeRoadmapCourses]);
+    }, [plannerRoadmaps, updateTakenCourses]);
 
     return (
         <>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
@@ -2,7 +2,7 @@ import { LabeledAutocomplete } from '$components/RightPane/CoursePane/SearchForm
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import generatedDepartments from '$generated/departments.json';
 import { getLocalStorageRecentlySearched, setLocalStorageRecentlySearched } from '$lib/localStorage';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 
 const ALL_DEPARTMENTS: Record<string, string> = {
     ALL: 'ALL: Include All Departments',
@@ -33,6 +33,7 @@ export function DepartmentSearchBar() {
 
     const [value, setValue] = useState(() => RightPaneStore.getFormData().deptValue);
     const [recentSearches, setRecentSearches] = useState<typeof options>(() => parseLocalStorageRecentlySearched());
+    const recentSearchesRef = useRef(recentSearches);
 
     const resetField = useCallback(() => {
         setValue(() => RightPaneStore.getFormData().deptValue);
@@ -60,17 +61,19 @@ export function DepartmentSearchBar() {
 
             if (newValue === 'ALL') return;
 
-            if (recentSearches.includes(newValue)) {
-                setRecentSearches((prev) =>
-                    prev.sort((a, b) => {
-                        return a === newValue ? -1 : b === newValue ? 1 : 0;
-                    })
-                );
+            let nextRecentSearches: string[];
+            if (recentSearchesRef.current.includes(newValue)) {
+                nextRecentSearches = [...recentSearchesRef.current].sort((a, b) => {
+                    return a === newValue ? -1 : b === newValue ? 1 : 0;
+                });
             } else {
-                setRecentSearches((prev) => [newValue, ...prev].slice(0, 5));
+                nextRecentSearches = [newValue, ...recentSearchesRef.current].slice(0, 5);
             }
+            recentSearchesRef.current = nextRecentSearches;
+            setRecentSearches(nextRecentSearches);
+            setLocalStorageRecentlySearched(JSON.stringify(nextRecentSearches));
         },
-        [recentSearches, options]
+        [options]
     );
 
     useEffect(() => {
@@ -80,10 +83,6 @@ export function DepartmentSearchBar() {
             RightPaneStore.off('formReset', resetField);
         };
     }, [resetField]);
-
-    useEffect(() => {
-        setLocalStorageRecentlySearched(JSON.stringify(recentSearches));
-    }, [recentSearches]);
 
     return (
         <LabeledAutocomplete

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
@@ -97,26 +97,33 @@ export function GradesPopover(props: GradesPopoverProps) {
     };
 
     useEffect(() => {
-        if (loading === false) {
-            return;
-        }
+        let canceled = false;
+        setLoading(true);
+        setInstructorData(undefined);
+        setOverallData(undefined);
 
         const fetches: Promise<unknown>[] = [
             getGradeData(deptCode, courseNumber, '').then((result) => {
-                if (result) setOverallData(result);
+                if (!canceled && result) setOverallData(result);
             }),
         ];
 
         if (instructor) {
             fetches.push(
                 getGradeData(deptCode, courseNumber, instructor).then((result) => {
-                    if (result) setInstructorData(result);
+                    if (!canceled && result) setInstructorData(result);
                 })
             );
         }
 
-        Promise.all(fetches).finally(() => setLoading(false));
-    }, [loading, deptCode, courseNumber, instructor]);
+        Promise.all(fetches).finally(() => {
+            if (!canceled) setLoading(false);
+        });
+
+        return () => {
+            canceled = true;
+        };
+    }, [deptCode, courseNumber, instructor]);
 
     return (
         <Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited all 74 `useEffect` call sites in the codebase and addressed three clear, high-value opportunities to remove or tighten effects.

---

### 1. `DepartmentSearchBar` — remove localStorage write effect

**Before:** A `useEffect([recentSearches])` called `setLocalStorageRecentlySearched` whenever `recentSearches` state changed — a classic "sync derived state to external storage" anti-pattern.

**After:** `setLocalStorageRecentlySearched` is called directly inside `handleChange` at the same point where `setRecentSearches` is invoked (write-through). A `useRef` tracks the current list so the memoized callback can read it without adding `recentSearches` to the `useCallback` dependency array.

One `useEffect` removed.

---

### 2. `GradesPopover` — fix stale-`loading` dep bug

**Before:** The fetch effect included `loading` in its dependency array and guarded with `if (loading === false) return`. Once the initial fetch completed, `loading` became `false` and the guard prevented the effect from ever re-running — meaning changing `deptCode`, `courseNumber`, or `instructor` props **silently showed stale data**.

**After:**
- `loading` removed from the dep array (effect now depends only on `[deptCode, courseNumber, instructor]`).
- State is reset at the start of each run (`setLoading(true)`, `setInstructorData/setOverallData(undefined)`).
- A `canceled` flag is set in the cleanup function so in-flight promises that race a prop change or unmount never update state.

No useEffect removed, but the existing one is now correct.

---

### 3. `AdvancedSearchTextFields` — narrow roadmap-validation effect deps

**Before:** `useEffect([plannerRoadmaps, excludeRoadmapCourses])` did two things:
1. Called `updateTakenCourses(excludeRoadmapCourses)` — needs to run whenever the user changes the selection.
2. Validated that the selected roadmap still exists — only needs to run when `plannerRoadmaps` changes.

Because both were coupled, the effect re-ran on every roadmap-selection change even though validation is only meaningful when the roadmap list itself changes.

**After:**
- `updateTakenCourses(stringValue)` moved into the `excludeRoadmapCourses` branch of `changeHandlerFactory` (covers user selections).
- `updateTakenCourses(formData.excludeRoadmapCourses)` added to `syncFieldStates` (covers form resets / `formDataChange` events).
- The effect dep array narrowed to `[plannerRoadmaps, updateTakenCourses]`; the current roadmap selection is read from `RightPaneStore.getFormData()` inside the effect to avoid closing over stale local state.

`excludeRoadmapCourses` removed from the effect's dependency array.

---

## Testing

- `pnpm lint` — ✅ 0 warnings, 0 errors (oxlint)
- `npx tsc --noEmit` — ✅ no errors in changed files (pre-existing errors in unrelated generated/image imports)
- `pnpm test --run` — ✅ 10/10 tests passing; 5 pre-existing failures due to missing generated files unrelated to this change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-238af2ef-e87c-41ab-a361-d1c5535e1de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-238af2ef-e87c-41ab-a361-d1c5535e1de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

