### PR TITLE
refactor: trpc mutations

### DIFF
--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -10,6 +10,7 @@ import { TermSelector } from '$components/RightPane/CoursePane/SearchForm/TermSe
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
+import { trpcReact } from '$lib/api/trpcReact';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import {
@@ -19,7 +20,7 @@ import {
     removeLocalStorageOnFirstSignin,
     removeLocalStorageUserId,
 } from '$lib/localStorage';
-import { ZotcourseResponse, queryZotcourse } from '$lib/zotcourse';
+import { processZotcourseResponse } from '$lib/zotcourse';
 import { BLUE, LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
@@ -86,6 +87,7 @@ export function Import() {
     const isDark = useThemeStore((store) => store.isDark);
 
     const postHog = usePostHog();
+    const { mutateAsync: fetchZotcourse } = trpcReact.zotcourse.getUserData.useMutation();
 
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isDragging, setIsDragging] = useState(false);
@@ -120,7 +122,17 @@ export function Import() {
         switch (effectiveImportSource) {
             case ImportSource.ZOT_COURSE_IMPORT:
                 try {
-                    const zotcourseImport: ZotcourseResponse = await queryZotcourse(zotcourseScheduleName);
+                    if (!zotcourseScheduleName) {
+                        throw new QueryZotcourseError('Cannot import an empty Zotcourse schedule name');
+                    }
+
+                    const response = await fetchZotcourse({ scheduleName: zotcourseScheduleName });
+
+                    if (!response.success) {
+                        throw new QueryZotcourseError('Cannot import an invalid Zotcourse');
+                    }
+
+                    const zotcourseImport = processZotcourseResponse(response.data);
                     sectionCodes = zotcourseImport.codes;
                     for (const event of zotcourseImport.customEvents) {
                         addCustomEvent(event, [currentSchedule]);

--- a/apps/antalmanac/src/components/Header/Save.tsx
+++ b/apps/antalmanac/src/components/Header/Save.tsx
@@ -1,22 +1,62 @@
 import actionTypesStore from '$actions/ActionTypesStore';
-import { saveSchedule } from '$actions/AppStoreActions';
+import { isEmptySchedule } from '$actions/AppStoreActions';
 import { SignInDialog } from '$components/dialogs/SignInDialog';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { trpcReact } from '$lib/api/trpcReact';
+import { getErrorMessage } from '$lib/utils';
 import AppStore from '$stores/AppStore';
+import { deleteTempSaveData } from '$stores/localTempSaveDataHelpers';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
+import { openSnackbar } from '$stores/SnackbarStore';
 import { Close, Save as SaveIcon } from '@mui/icons-material';
 import { Stack, Snackbar, Alert, Link, IconButton, Button } from '@mui/material';
+import { TRPCClientError } from '@trpc/client';
 import { usePostHog } from 'posthog-js/react';
 import { useState, useEffect } from 'react';
 
 export const Save = () => {
     const { sessionIsValid } = useSessionStore();
     const [openSignInDialog, setOpenSignInDialog] = useState(false);
-    const [saving, setSaving] = useState(false);
+    const [autoSaving, setAutoSaving] = useState(false);
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
     const { openAutoSaveWarning, setOpenAutoSaveWarning } = scheduleComponentsToggleStore();
     const postHog = usePostHog();
+
+    const { mutate: saveSchedule, isPending: isSaving } = trpcReact.schedule.save.useMutation({
+        onSuccess: ({ scheduleIdMap }) => {
+            if (scheduleIdMap) {
+                AppStore.schedule.updateScheduleIds(scheduleIdMap);
+            }
+
+            openSnackbar('success', `Schedule saved. Don't forget to sign up for classes on WebReg!`);
+            deleteTempSaveData();
+            logAnalytics(postHog, {
+                category: analyticsEnum.auth,
+                action: analyticsEnum.auth.actions.SAVE_SCHEDULE,
+                customProps: {
+                    autoSave: false,
+                },
+            });
+            AppStore.saveSchedule();
+        },
+        onError: (e) => {
+            if (e instanceof TRPCClientError) {
+                openSnackbar('error', `Schedule could not be saved`);
+            } else {
+                openSnackbar('error', 'Network error or server is down.');
+            }
+
+            logAnalytics(postHog, {
+                category: analyticsEnum.auth,
+                action: analyticsEnum.auth.actions.SAVE_SCHEDULE_FAIL,
+                error: getErrorMessage(e),
+                customProps: {
+                    autoSave: false,
+                },
+            });
+        },
+    });
 
     const handleClickSignIn = () => {
         if (!openSignInDialog) {
@@ -32,12 +72,21 @@ export const Save = () => {
         setOpenAutoSaveWarning(false);
     };
 
-    const saveScheduleData = async () => {
-        if (sessionIsValid) {
-            setSaving(true);
-            await saveSchedule({ postHog });
-            setSaving(false);
+    const saveScheduleData = () => {
+        const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
+
+        if (
+            isEmptySchedule(scheduleSaveState.schedules) &&
+            !confirm(
+                "You are attempting to save empty schedule(s). If this is unintentional, this may overwrite your existing schedules that haven't loaded yet!"
+            )
+        ) {
+            return;
         }
+
+        saveSchedule({
+            userData: scheduleSaveState,
+        });
     };
 
     useEffect(() => {
@@ -53,8 +102,8 @@ export const Save = () => {
     }, []);
 
     useEffect(() => {
-        const handleAutoSaveStart = () => setSaving(true);
-        const handleAutoSaveEnd = () => setSaving(false);
+        const handleAutoSaveStart = () => setAutoSaving(true);
+        const handleAutoSaveEnd = () => setAutoSaving(false);
 
         actionTypesStore.on('autoSaveStart', handleAutoSaveStart);
         actionTypesStore.on('autoSaveEnd', handleAutoSaveEnd);
@@ -64,6 +113,8 @@ export const Save = () => {
             actionTypesStore.off('autoSaveEnd', handleAutoSaveEnd);
         };
     }, []);
+
+    const saving = isSaving || autoSaving;
 
     return (
         <Stack direction="row">

--- a/apps/antalmanac/src/components/Header/Signout.tsx
+++ b/apps/antalmanac/src/components/Header/Signout.tsx
@@ -2,6 +2,7 @@ import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { trpcReact } from '$lib/api/trpcReact';
 import { getErrorMessage } from '$lib/utils';
 import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';
@@ -33,18 +34,10 @@ export function Signout({ onLogoutComplete }: SignoutProps) {
         [sessionIsValid, name, avatar, email]
     );
 
-    const open = Boolean(anchorEl);
-    const handleClick = (event: MouseEvent<HTMLElement>) => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const handleLogout = async () => {
-        setAnchorEl(null);
-
-        try {
-            const logoutUrl = await clearSession();
+    const { mutate: logout } = trpcReact.auth.logout.useMutation({
+        onSuccess: ({ logoutUrl }) => {
+            clearSession();
             onLogoutComplete?.();
-
             logAnalytics(postHog, {
                 category: analyticsEnum.auth,
                 action: analyticsEnum.auth.actions.SIGN_OUT,
@@ -53,8 +46,10 @@ export function Signout({ onLogoutComplete }: SignoutProps) {
             if (logoutUrl) {
                 window.location.href = logoutUrl;
             }
-        } catch (error) {
+        },
+        onError: (error) => {
             console.error('Error during logout', error);
+            clearSession();
             onLogoutComplete?.();
             logAnalytics(postHog, {
                 category: analyticsEnum.auth,
@@ -62,16 +57,26 @@ export function Signout({ onLogoutComplete }: SignoutProps) {
                 error: getErrorMessage(error),
             });
             window.location.reload();
-        } finally {
+        },
+        onSettled: () => {
             postHog?.reset();
-        }
+        },
+    });
+
+    const handleClick = (event: MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleLogout = () => {
+        setAnchorEl(null);
+        logout({ redirectUrl: window.location.origin });
     };
 
     return (
         <div id="load-save-container">
             <ProfileMenuButtons user={user} handleOpen={handleClick} handleSettingsOpen={handleClick} />
             <Popover
-                open={open}
+                open={Boolean(anchorEl)}
                 anchorEl={anchorEl}
                 onClose={() => setAnchorEl(null)}
                 anchorOrigin={{

--- a/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { trpcReact } from '$lib/api/trpcReact';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { Close } from '@mui/icons-material';
 import { Box, Button, CardActions, CardContent, CardHeader, IconButton, Typography } from '@mui/material';
@@ -12,6 +13,15 @@ export function EnrollmentConfirmStep() {
     const confirm = useReviewPromptStore((s) => s.confirm);
     const dismiss = useReviewPromptStore((s) => s.dismiss);
 
+    const { mutate: dismissReview } = trpcReact.review.dismissReview.useMutation();
+
+    const handleDismiss = () => {
+        const candidate = dismiss();
+        if (candidate) {
+            dismissReview({ professorId: candidate.professorId, courseId: candidate.courseId, term: candidate.term });
+        }
+    };
+
     return (
         <>
             <CardHeader
@@ -21,7 +31,7 @@ export function EnrollmentConfirmStep() {
                     </Typography>
                 }
                 action={
-                    <IconButton size="small" onClick={dismiss} aria-label="dismiss">
+                    <IconButton size="small" onClick={handleDismiss} aria-label="dismiss">
                         <Close fontSize="small" />
                     </IconButton>
                 }
@@ -47,7 +57,7 @@ export function EnrollmentConfirmStep() {
             </CardContent>
 
             <CardActions sx={{ justifyContent: 'flex-end' }}>
-                <Button size="small" color="inherit" onClick={dismiss}>
+                <Button size="small" color="inherit" onClick={handleDismiss}>
                     I did not
                 </Button>
 

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { trpcReact } from '$lib/api/trpcReact';
+import { postHog } from '$providers/PostHog';
 import { REVIEW_TAGS } from '$stores/ReviewPromptStore';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
+import { openSnackbar } from '$stores/SnackbarStore';
 import { Close } from '@mui/icons-material';
 import {
     Box,
@@ -53,8 +57,9 @@ function difficultyLabel(difficulty: number): string {
 }
 
 export function ReviewStep() {
-    const courseId = useReviewPromptStore((s) => s.candidate?.courseId ?? '');
-    const professorId = useReviewPromptStore((s) => s.candidate?.professorId ?? '');
+    const candidate = useReviewPromptStore((s) => s.candidate);
+    const courseId = candidate?.courseId ?? '';
+    const professorId = candidate?.professorId ?? '';
     const rating = useReviewPromptStore((s) => s.rating);
     const difficulty = useReviewPromptStore((s) => s.difficulty);
     const selectedTags = useReviewPromptStore((s) => s.selectedTags);
@@ -63,8 +68,63 @@ export function ReviewStep() {
     const textReview = useReviewPromptStore((s) => s.textReview);
     const setTextReview = useReviewPromptStore((s) => s.setTextReview);
     const toggleTag = useReviewPromptStore((s) => s.toggleTag);
-    const submitReview = useReviewPromptStore((s) => s.submitReview);
     const dismiss = useReviewPromptStore((s) => s.dismiss);
+    const resetReview = useReviewPromptStore((s) => s.resetReview);
+
+    const { mutate: dismissReview } = trpcReact.review.dismissReview.useMutation();
+
+    const { mutate: submitReview, isPending: isSubmitting } = trpcReact.review.submitReview.useMutation({
+        onSuccess: () => {
+            if (!candidate) {
+                return;
+            }
+
+            logAnalytics(postHog, {
+                category: analyticsEnum.review,
+                action: analyticsEnum.review.actions.SUBMITTED,
+                customProps: {
+                    courseId: candidate.courseId,
+                    professorId: candidate.professorId,
+                    term: candidate.term,
+                    rating,
+                    difficulty,
+                    tags: selectedTags,
+                },
+            });
+            resetReview();
+            openSnackbar('success', 'Review submitted — thanks for helping other Anteaters!');
+        },
+        onError: () => {
+            openSnackbar('error', 'Failed to submit review. Please try again.');
+        },
+    });
+
+    const handleDismiss = () => {
+        const dismissedCandidate = dismiss();
+        if (dismissedCandidate) {
+            dismissReview({
+                professorId: dismissedCandidate.professorId,
+                courseId: dismissedCandidate.courseId,
+                term: dismissedCandidate.term,
+            });
+        }
+    };
+
+    const handleSubmit = () => {
+        if (!candidate || rating === 0 || difficulty === 0) {
+            return;
+        }
+
+        submitReview({
+            professorId: candidate.professorId,
+            courseId: candidate.courseId,
+            quarter: candidate.term,
+            rating,
+            difficulty,
+            tags: selectedTags,
+            content: textReview.trim() || undefined,
+        });
+    };
 
     return (
         <>
@@ -76,7 +136,7 @@ export function ReviewStep() {
                 }
                 subheader={<Typography color="text.secondary">with {professorId}</Typography>}
                 action={
-                    <IconButton size="small" onClick={dismiss} aria-label="dismiss">
+                    <IconButton size="small" onClick={handleDismiss} aria-label="dismiss">
                         <Close fontSize="small" />
                     </IconButton>
                 }
@@ -148,15 +208,16 @@ export function ReviewStep() {
             </CardContent>
 
             <CardActions sx={{ justifyContent: 'flex-end' }}>
-                <Button size="small" color="inherit" onClick={dismiss}>
+                <Button size="small" color="inherit" onClick={handleDismiss}>
                     Skip
                 </Button>
 
                 <Button
                     size="small"
                     variant="contained"
-                    disabled={rating === 0 || difficulty === 0}
-                    onClick={submitReview}
+                    disabled={rating === 0 || difficulty === 0 || isSubmitting}
+                    loading={isSubmitting}
+                    onClick={handleSubmit}
                 >
                     Submit
                 </Button>

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -100,6 +100,10 @@ export function ReviewStep() {
     });
 
     const handleDismiss = () => {
+        if (isSubmitting) {
+            return;
+        }
+
         const dismissedCandidate = dismiss();
         if (dismissedCandidate) {
             dismissReview({

--- a/apps/antalmanac/src/lib/zotcourse.ts
+++ b/apps/antalmanac/src/lib/zotcourse.ts
@@ -2,37 +2,37 @@ import AppStore from '$stores/AppStore';
 import { RepeatingCustomEvent } from '@packages/antalmanac-types';
 import { createId } from '@paralleldrive/cuid2';
 
-import trpc from './api/trpc';
-import { QueryZotcourseError } from './customErrors';
-
 export interface ZotcourseResponse {
     codes: string[];
     customEvents: RepeatingCustomEvent[];
 }
-export async function queryZotcourse(schedule_name: string) {
-    if (!schedule_name) throw new QueryZotcourseError('Cannot import an empty Zotcourse schedule name');
-    const response = await trpc.zotcourse.getUserData.mutate({ scheduleName: schedule_name });
-    if (!response.success) throw new QueryZotcourseError('Cannot import an invalid Zotcourse');
-    // For custom event, there is no course attribute in each.
-    const codes = response.data
-        .filter((section: { eventType: number }) => section.eventType === 3)
-        .map((section: { course: { code: string } }) => section.course.code) as string[];
+
+type ZotcourseSection =
+    | { eventType: 3; course: { code: string } }
+    | { eventType: 1; title: string; start: string; end: string; dow: number[] }
+    | { eventType: number };
+
+export function processZotcourseResponse(data: ZotcourseSection[]): ZotcourseResponse {
     const days = [false, false, false, false, false, false, false];
-    const customEvents: RepeatingCustomEvent[] = response.data
-        .filter((section: { eventType: number }) => section.eventType === 1)
-        .map((event: { title: string; start: string; end: string; dow: number[] }) => {
-            return {
-                title: event.title,
-                start: event.start,
-                end: event.end,
-                days: days.map((_, index) => event.dow.includes(index)),
-                scheduleIndices: [AppStore.getCurrentScheduleIndex()],
-                customEventID: createId(),
-                color: '#551a8b',
-            };
-        }) as RepeatingCustomEvent[];
-    return {
-        codes: codes,
-        customEvents: customEvents,
-    };
+
+    const codes = data
+        .filter((section): section is { eventType: 3; course: { code: string } } => section.eventType === 3)
+        .map((section) => section.course.code);
+
+    const customEvents: RepeatingCustomEvent[] = data
+        .filter(
+            (section): section is { eventType: 1; title: string; start: string; end: string; dow: number[] } =>
+                section.eventType === 1
+        )
+        .map((event) => ({
+            title: event.title,
+            start: event.start,
+            end: event.end,
+            days: days.map((_, index) => event.dow.includes(index)),
+            scheduleIndices: [AppStore.getCurrentScheduleIndex()],
+            customEventID: createId(),
+            color: '#551a8b',
+        }));
+
+    return { codes, customEvents };
 }

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -2,6 +2,7 @@ import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreAct
 import { LoadingScreen } from '$components/LoadingScreen';
 import { analyticsIdentifyUser } from '$lib/analytics/analytics';
 import trpc from '$lib/api/trpc';
+import { trpcReact } from '$lib/api/trpcReact';
 import {
     getLocalStorageDataCache,
     getLocalStorageFromLoading,
@@ -23,6 +24,9 @@ export function AuthPage() {
     const [searchParams] = useSearchParams();
     const isAuthenticatingRef = useRef(false);
     const postHog = usePostHog();
+    const { mutateAsync: handleGoogleCallback } = trpcReact.auth.handleGoogleCallback.useMutation();
+    const { mutateAsync: flagImported } = trpcReact.schedule.flagImported.useMutation();
+    const { mutateAsync: saveSchedule } = trpcReact.schedule.save.useMutation();
 
     const handleSearchParamsChange = useCallback(async () => {
         // Prevent race condition: only allow one authentication attempt at a time
@@ -49,7 +53,7 @@ export function AuthPage() {
 
             isAuthenticatingRef.current = true;
 
-            const { userId, providerId, newUser } = await trpc.auth.handleGoogleCallback.mutate({
+            const { userId, providerId, newUser } = await handleGoogleCallback({
                 code: code,
                 state: state,
             });
@@ -96,7 +100,7 @@ export function AuthPage() {
                 const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
 
                 if (savedUserId !== '') {
-                    await trpc.schedule.flagImported.mutate({ username: savedUserId });
+                    await flagImported({ username: savedUserId });
                     setLocalStorageImportedUser(savedUserId);
                 }
 
@@ -113,7 +117,7 @@ export function AuthPage() {
                     }
                 }
 
-                await trpc.schedule.save.mutate({
+                await saveSchedule({
                     userData: scheduleSaveState,
                 });
             }
@@ -123,7 +127,7 @@ export function AuthPage() {
             clearSsoCookie();
             window.location.href = '/';
         }
-    }, [searchParams, postHog]);
+    }, [searchParams, postHog, handleGoogleCallback, flagImported, saveSchedule]);
 
     useEffect(() => {
         handleSearchParamsChange();

--- a/apps/antalmanac/src/routes/UnsubscribePage.tsx
+++ b/apps/antalmanac/src/routes/UnsubscribePage.tsx
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpcReact } from '$lib/api/trpcReact';
 import { Box, Button } from '@mui/material';
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -19,20 +19,29 @@ export const Unsubscribe = () => {
 
     const term = `${year} ${quarter}`;
 
-    const handleUnsubscribe = async () => {
+    const { mutate: deleteAllNotifications, isPending: isDeletingAll } =
+        trpcReact.notifications.deleteAllNotifications.useMutation({
+            onSuccess: () => setDone(true),
+            onError: (err) => console.error('Error unsubscribing:', err),
+        });
+
+    const { mutate: deleteNotification, isPending: isDeletingOne } =
+        trpcReact.notifications.deleteNotification.useMutation({
+            onSuccess: () => setDone(true),
+            onError: (err) => console.error('Error unsubscribing:', err),
+        });
+
+    const handleUnsubscribe = () => {
         if (!userId || !sectionCode || !quarter || !year) return;
 
-        try {
-            if (unsubscribeAll === 'true') {
-                await trpc.notifications.deleteAllNotifications.mutate({ userId });
-            } else {
-                await trpc.notifications.deleteNotification.mutate({ userId, sectionCode, term });
-            }
-            setDone(true);
-        } catch (err) {
-            console.error('Error unsubscribing:', err);
+        if (unsubscribeAll === 'true') {
+            deleteAllNotifications({ userId });
+        } else {
+            deleteNotification({ userId, sectionCode, term });
         }
     };
+
+    const isPending = isDeletingAll || isDeletingOne;
 
     return (
         <Box
@@ -48,7 +57,14 @@ export const Unsubscribe = () => {
             <h2>Hello, would you like to unsubscribe from notifications for</h2>
             <h2>{unsubscribeAll === 'true' ? 'ALL courses' : `${deptCode} ${courseNumber} (${instructor})`}</h2>
             {!done ? (
-                <Button variant="contained" color="error" sx={{ mt: 2 }} onClick={handleUnsubscribe}>
+                <Button
+                    variant="contained"
+                    color="error"
+                    sx={{ mt: 2 }}
+                    onClick={handleUnsubscribe}
+                    disabled={isPending}
+                    loading={isPending}
+                >
                     Confirm Unsubscribe
                 </Button>
             ) : (

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -3,7 +3,6 @@ import trpc from '$lib/api/trpc';
 import { termData } from '$lib/termData';
 import { postHog } from '$providers/PostHog';
 import AppStore from '$stores/AppStore';
-import { openSnackbar } from '$stores/SnackbarStore';
 import { create } from 'zustand';
 import { combine } from 'zustand/middleware';
 
@@ -175,7 +174,8 @@ export const useReviewPromptStore = create(
 
         /**
          * User closed the prompt without submitting (X, Skip, "I did not", snackbar click-away, Escape).
-         * Persists the course+professor combo so it is not suggested again and starts the cooldown window.
+         * Updates local state and logs analytics. The caller is responsible for firing the dismissReview
+         * mutation so the combo is not suggested again and the cooldown window starts.
          */
         dismiss: () => {
             const { candidate, step } = get();
@@ -191,16 +191,8 @@ export const useReviewPromptStore = create(
                         dismissedAtStep: step,
                     },
                 });
-                trpc.review.dismissReview
-                    .mutate({
-                        professorId: candidate.professorId,
-                        courseId: candidate.courseId,
-                        term: candidate.term,
-                    })
-                    .catch(() => {
-                        // Non-fatal — worst case the user is prompted again on the next session.
-                    });
             }
+            return candidate;
         },
 
         setRating: (rating: number) => set({ rating }),
@@ -218,39 +210,7 @@ export const useReviewPromptStore = create(
             });
         },
 
-        submitReview: async () => {
-            const { candidate, rating, difficulty, selectedTags, textReview } = get();
-            if (!candidate || rating === 0 || difficulty === 0) return;
-
-            const trimmedReview = textReview.trim();
-
-            try {
-                await trpc.review.submitReview.mutate({
-                    professorId: candidate.professorId,
-                    courseId: candidate.courseId,
-                    quarter: candidate.term,
-                    rating,
-                    difficulty,
-                    tags: selectedTags,
-                    content: trimmedReview || undefined,
-                });
-                set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [], textReview: '' });
-                logAnalytics(postHog, {
-                    category: analyticsEnum.review,
-                    action: analyticsEnum.review.actions.SUBMITTED,
-                    customProps: {
-                        courseId: candidate.courseId,
-                        professorId: candidate.professorId,
-                        term: candidate.term,
-                        rating,
-                        difficulty,
-                        tags: selectedTags,
-                    },
-                });
-                openSnackbar('success', 'Review submitted — thanks for helping other Anteaters!');
-            } catch {
-                openSnackbar('error', 'Failed to submit review. Please try again.');
-            }
-        },
+        resetReview: () =>
+            set({ step: 'hidden', candidate: null, rating: 0, difficulty: 0, selectedTags: [], textReview: '' }),
     }))
 );

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -13,7 +13,7 @@ interface SessionState {
     avatar: string | null;
     sessionIsValid: boolean;
     loadSession: () => Promise<boolean>;
-    clearSession: () => Promise<string | null>;
+    clearSession: () => void;
 
     hasCheckedAuth: boolean;
 }
@@ -69,17 +69,7 @@ export const useSessionStore = create<SessionState>((set) => {
             }
         },
 
-        clearSession: async () => {
-            let logoutUrl: string | null = null;
-            try {
-                const result = await trpc.auth.logout.mutate({
-                    redirectUrl: window.location.origin,
-                });
-                logoutUrl = result.logoutUrl;
-            } catch (error) {
-                console.error('Error during logout:', error);
-            }
-
+        clearSession: () => {
             setWasLoggedIn(false);
             clearSsoCookie();
             set({
@@ -90,8 +80,6 @@ export const useSessionStore = create<SessionState>((set) => {
                 name: null,
                 avatar: null,
             });
-
-            return logoutUrl;
         },
     };
 });


### PR DESCRIPTION
## Summary
- Move component-owned tRPC mutations to React Query for auth/session, review prompt, unsubscribe, manual schedule save, and Zotcourse import flows.
- Keep store/action-owned background persistence on the vanilla tRPC client where React Query lifecycle state is not useful.
- Make Zotcourse parsing a pure helper after moving the fetch mutation into the import component.

## Test Plan
- `pnpm lint`

## Issues
Closes #1730