### PR TITLE
Always anchor schedule select popover

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -47,6 +47,7 @@ export function SelectSchedulePopover() {
     const theme = useTheme();
     const { openScheduleSelect, setOpenScheduleSelect } = scheduleComponentsToggleStore();
 
+    const [anchorElement, setAnchorElement] = useState(null);
     const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
     const [scheduleMapping, setScheduleMapping] = useState(getScheduleItems());
     const [skeletonMode, setSkeletonMode] = useState(AppStore.getSkeletonMode());
@@ -69,6 +70,10 @@ export function SelectSchedulePopover() {
     const handleScheduleIndexChange = useCallback(() => {
         setCurrentScheduleIndex(AppStore.getCurrentScheduleIndex());
     }, []);
+
+    useEffect(() => {
+        setAnchorElement(anchorElementRef.current);
+    }, [anchorElementRef]);
 
     useEffect(() => {
         AppStore.on('addedCoursesChange', handleScheduleIndexChange);
@@ -148,7 +153,7 @@ export function SelectSchedulePopover() {
 
             <Popover
                 open={openScheduleSelect}
-                anchorEl={anchorElementRef.current}
+                anchorEl={anchorElement}
                 onClose={handleClose}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             >


### PR DESCRIPTION
## Summary

Allows schedule select to open correctly without being clicked on.

Originally part of friends but that got pushed back so I think it would be better to have this as a separate PR.

## Test Plan

Open schedule select and see that it's anchored to the button as before

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
