### PR TITLE
fix: guard against Invalid Date from malformed custom event time strings

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -177,15 +177,11 @@ export const ScheduleCalendar = memo(() => {
     }, []);
 
     /**
-     * Finds the earliest start time and returns that or 7AM, whichever is earlier.
-     * Filters out NaN values produced by events with invalid dates (e.g. malformed
-     * custom event time strings) so that the resulting Date is always valid and
-     * react-big-calendar never receives an Invalid Date as its `min` prop.
+     * Finds the earliest start time and returns that or 7AM, whichever is earlier
      */
     const startTime = useMemo(() => {
-        const eventStartHours = events.map((event) => event.start.getHours()).filter((h) => !isNaN(h));
-        const earliestHour = eventStartHours.length > 0 ? Math.min(...eventStartHours) : 7;
-        return new Date(2018, 0, 1, Math.min(7, earliestHour));
+        const validHours = events.map((event) => event.start.getHours()).filter(Number.isFinite);
+        return new Date(2018, 0, 1, Math.min(7, ...validHours, 7));
     }, [events]);
 
     const eventStyleGetter = useCallback((event: CalendarEvent | SkeletonEvent) => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -177,11 +177,15 @@ export const ScheduleCalendar = memo(() => {
     }, []);
 
     /**
-     * Finds the earliest start time and returns that or 7AM, whichever is earlier
+     * Finds the earliest start time and returns that or 7AM, whichever is earlier.
+     * Filters out NaN values produced by events with invalid dates (e.g. malformed
+     * custom event time strings) so that the resulting Date is always valid and
+     * react-big-calendar never receives an Invalid Date as its `min` prop.
      */
     const startTime = useMemo(() => {
-        const eventStartHours = events.map((event) => event.start.getHours());
-        return new Date(2018, 0, 1, Math.min(7, Math.min(...eventStartHours)));
+        const eventStartHours = events.map((event) => event.start.getHours()).filter((h) => !isNaN(h));
+        const earliestHour = eventStartHours.length > 0 ? Math.min(...eventStartHours) : 7;
+        return new Date(2018, 0, 1, Math.min(7, earliestHour));
     }, [events]);
 
     const eventStyleGetter = useCallback((event: CalendarEvent | SkeletonEvent) => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -10,7 +10,7 @@ import { useTimeFormatStore } from '$stores/SettingsStore';
 import { Delete } from '@mui/icons-material';
 import { Card, CardActions, CardContent, CardHeader, IconButton, Tooltip } from '@mui/material';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import { format, set } from 'date-fns';
+import { format, isValid, set } from 'date-fns';
 
 interface CustomEventDetailViewProps {
     scheduleNames: string[];
@@ -24,21 +24,12 @@ export function CustomEventDetailView(props: CustomEventDetailViewProps) {
     const fallbackMode = useFallbackStore((state) => state.fallbackMode);
 
     const readableDateAndTimeFormat = (start: string, end: string, days: boolean[]) => {
-        const startHours = parseInt(start.slice(0, 2));
-        const startMinutes = parseInt(start.slice(3, 5));
-        const endHours = parseInt(end.slice(0, 2));
-        const endMinutes = parseInt(end.slice(3, 5));
-
-        // Guard against malformed time strings (e.g. from third-party imports).
-        // Passing NaN to date-fns set() produces an Invalid Date, and the subsequent
-        // format() call would throw RangeError: Invalid time value at Date.toISOString.
-        if (isNaN(startHours) || isNaN(startMinutes) || isNaN(endHours) || isNaN(endMinutes)) {
-            return `${start} — ${end}`;
-        }
-
         const baseDate = new Date(2000, 0, 1);
-        const startTime = set(baseDate, { hours: startHours, minutes: startMinutes });
-        const endTime = set(baseDate, { hours: endHours, minutes: endMinutes });
+        const startTime = set(baseDate, { hours: parseInt(start.slice(0, 2)), minutes: parseInt(start.slice(3, 5)) });
+        const endTime = set(baseDate, { hours: parseInt(end.slice(0, 2)), minutes: parseInt(end.slice(3, 5)) });
+
+        // Fall back to raw strings if the time fields can't be parsed (e.g. empty string in DB).
+        if (!isValid(startTime) || !isValid(endTime)) return `${start} — ${end}`;
 
         const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         const daysString = days.map((includeDate, index) => (includeDate ? dayAbbreviations[index] : '')).join(' ');

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -24,16 +24,21 @@ export function CustomEventDetailView(props: CustomEventDetailViewProps) {
     const fallbackMode = useFallbackStore((state) => state.fallbackMode);
 
     const readableDateAndTimeFormat = (start: string, end: string, days: boolean[]) => {
-        const baseDate = new Date(2000, 0, 1);
-        const startTime = set(baseDate, {
-            hours: parseInt(start.slice(0, 2)),
-            minutes: parseInt(start.slice(3, 5)),
-        });
+        const startHours = parseInt(start.slice(0, 2));
+        const startMinutes = parseInt(start.slice(3, 5));
+        const endHours = parseInt(end.slice(0, 2));
+        const endMinutes = parseInt(end.slice(3, 5));
 
-        const endTime = set(baseDate, {
-            hours: parseInt(end.slice(0, 2)),
-            minutes: parseInt(end.slice(3, 5)),
-        });
+        // Guard against malformed time strings (e.g. from third-party imports).
+        // Passing NaN to date-fns set() produces an Invalid Date, and the subsequent
+        // format() call would throw RangeError: Invalid time value at Date.toISOString.
+        if (isNaN(startHours) || isNaN(startMinutes) || isNaN(endHours) || isNaN(endMinutes)) {
+            return `${start} — ${end}`;
+        }
+
+        const baseDate = new Date(2000, 0, 1);
+        const startTime = set(baseDate, { hours: startHours, minutes: startMinutes });
+        const endTime = set(baseDate, { hours: endHours, minutes: endMinutes });
 
         const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         const daysString = days.map((includeDate, index) => (includeDate ? dayAbbreviations[index] : '')).join(' ');

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/AdvancedSearch/AdvancedSearchTextFields.tsx
@@ -14,7 +14,7 @@ import { useSessionStore } from '$stores/SessionStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import { MenuItem, Box, type SelectChangeEvent, Checkbox, ListItemText, Tooltip, Typography } from '@mui/material';
 import type { Roadmap } from '@packages/antalmanac-types';
-import { format, parse } from 'date-fns';
+import { format, isValid, parse } from 'date-fns';
 import { useState, useEffect, useCallback, type ChangeEvent } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -122,7 +122,9 @@ export function AdvancedSearchTextFields() {
         if (name === 'startTime' || name === 'endTime') {
             // time picker event is Date | null
             if (event instanceof Date || event === null) {
-                const stringTime = event ? format(event, 'HH:mm') : '';
+                // Guard against Invalid Date (e.g. user typing a partial time in the picker).
+                // Calling format() on an Invalid Date throws RangeError: Invalid time value.
+                const stringTime = event && isValid(event) ? format(event, 'HH:mm') : '';
                 if (name === 'startTime') {
                     setStartTime(stringTime);
                 } else {

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -164,6 +164,22 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
 
 export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEvent[] = []): CustomEvent[] {
     return currentCustomEvents.flatMap((customEvent) => {
+        const startHour = parseInt(customEvent.start.slice(0, 2), 10);
+        const startMin = parseInt(customEvent.start.slice(3, 5), 10);
+        const endHour = parseInt(customEvent.end.slice(0, 2), 10);
+        const endMin = parseInt(customEvent.end.slice(3, 5), 10);
+
+        // Skip custom events whose start/end time strings are not parseable as HH:mm.
+        // Malformed time strings (e.g. from third-party imports) would produce NaN hours/minutes,
+        // yielding Invalid Date objects that crash react-big-calendar via Date.toISOString().
+        if (isNaN(startHour) || isNaN(startMin) || isNaN(endHour) || isNaN(endMin)) {
+            console.warn(
+                `Skipping custom event "${customEvent.title}" (ID: ${customEvent.customEventID}): ` +
+                    `unparseable time strings (start="${customEvent.start}", end="${customEvent.end}").`
+            );
+            return [];
+        }
+
         const dayIndicesOccurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
         /**
          * Only include the day strings that the custom event occurs.
@@ -172,11 +188,6 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
          */
         const days = dayIndicesOccurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
         return dayIndicesOccurring.map((dayIndex) => {
-            const startHour = parseInt(customEvent.start.slice(0, 2), 10);
-            const startMin = parseInt(customEvent.start.slice(3, 5), 10);
-            const endHour = parseInt(customEvent.end.slice(0, 2), 10);
-            const endMin = parseInt(customEvent.end.slice(3, 5), 10);
-
             return {
                 customEventID: customEvent.customEventID,
                 color: customEvent.color ?? '#000000',

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -169,16 +169,8 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
         const endHour = parseInt(customEvent.end.slice(0, 2), 10);
         const endMin = parseInt(customEvent.end.slice(3, 5), 10);
 
-        // Skip custom events whose start/end time strings are not parseable as HH:mm.
-        // Malformed time strings (e.g. from third-party imports) would produce NaN hours/minutes,
-        // yielding Invalid Date objects that crash react-big-calendar via Date.toISOString().
-        if (isNaN(startHour) || isNaN(startMin) || isNaN(endHour) || isNaN(endMin)) {
-            console.warn(
-                `Skipping custom event "${customEvent.title}" (ID: ${customEvent.customEventID}): ` +
-                    `unparseable time strings (start="${customEvent.start}", end="${customEvent.end}").`
-            );
-            return [];
-        }
+        // Skip events whose time strings are not in HH:mm format (e.g. empty strings from the DB).
+        if (isNaN(startHour) || isNaN(startMin) || isNaN(endHour) || isNaN(endMin)) return [];
 
         const dayIndicesOccurring = customEvent.days.map((day, index) => (day ? index : undefined)).filter(notNull);
         /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

One of the user's custom events (title: "Badminton", schedule "2026-Spring") has `start: ""` stored in the DB. The `customEvents` table uses `text('start').notNull()`, which prevents SQL `NULL` but allows empty strings.

When `calendarizeCustomEvents` processes this event:
```js
parseInt("".slice(0, 2), 10)  // NaN
new Date(2018, 0, dayIndex, NaN, NaN)  // Invalid Date
```
That `Invalid Date` makes `Math.min(...eventStartHours)` return `NaN`, so `startTime = new Date(2018, 0, 1, NaN)` (also `Invalid Date`). `react-big-calendar` then calls `startTime.toISOString()` internally for element keys → **`RangeError: Invalid time value`**.

## Changes

**`calendarizeHelpers.ts`** — hoist the `parseInt` calls before the per-day loop; skip the entire event if any parsed component is `NaN`. This is the primary fix.

**`CalendarRoot.tsx`** — defence-in-depth: filter non-finite values before `Math.min` so `startTime` is always a valid `Date` even if a bad event slips through.

**`CustomEventDetailView.tsx`** — import `isValid` from date-fns and bail out to raw strings before calling `format()` on a potentially-invalid date.

**`AdvancedSearchTextFields.tsx`** — guard the time-picker `format()` call with `isValid()` so a partially-typed value never throws.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8727dc1a-2c85-4c56-9014-6f9e93e164af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8727dc1a-2c85-4c56-9014-6f9e93e164af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

