### PR TITLE
feat: add GitHub Codespaces dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+    "name": "AntAlmanac",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "version": "latest",
+            "moby": true
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+    "forwardPorts": [3000, 5432],
+    "portsAttributes": {
+        "3000": {
+            "label": "AntAlmanac Web",
+            "onAutoForward": "openPreview"
+        },
+        "5432": {
+            "label": "PostgreSQL",
+            "onAutoForward": "silent"
+        }
+    },
+    "postCreateCommand": "bash .devcontainer/post-create.sh",
+    "remoteUser": "node",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "oxc.oxc-vscode",
+                "ms-azuretools.vscode-docker",
+                "bradlc.vscode-tailwindcss",
+                "mikestead.dotenv"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "editor.formatOnSave": false
+            }
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,6 @@
             "extensions": [
                 "oxc.oxc-vscode",
                 "ms-azuretools.vscode-docker",
-                "bradlc.vscode-tailwindcss",
                 "mikestead.dotenv"
             ],
             "settings": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -30,13 +30,22 @@ echo "==> Starting PostgreSQL via docker compose"
 docker compose up -d --build
 
 echo "==> Waiting for PostgreSQL to be ready"
+db_ready=false
 for _ in {1..30}; do
     if docker compose exec -T db pg_isready -U postgres >/dev/null 2>&1; then
+        db_ready=true
         echo "    PostgreSQL is ready"
         break
     fi
     sleep 1
 done
+
+if [ "$db_ready" = false ]; then
+    echo "    PostgreSQL did not become ready within 30s — skipping migrations and data fetch."
+    echo "    Check 'docker compose logs db', then rerun 'pnpm db:migrate' and"
+    echo "    '(cd apps/antalmanac && pnpm get-data)' once the database is up."
+    exit 0
+fi
 
 echo "==> Running database migrations"
 pnpm db:migrate || echo "    db:migrate failed — you can rerun it manually"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Setting up AntAlmanac development environment"
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> Enabling corepack and activating pnpm"
+sudo corepack enable
+corepack prepare pnpm@10.22.0 --activate
+
+echo "==> Installing dependencies"
+pnpm install --frozen-lockfile
+
+copy_env() {
+    local example="$1"
+    local target="${example%.example}"
+    if [ -f "$example" ] && [ ! -f "$target" ]; then
+        cp "$example" "$target"
+        echo "    created $target"
+    fi
+}
+
+echo "==> Seeding .env files from .env.example"
+copy_env apps/antalmanac/.env.example
+copy_env apps/aants/.env.example
+copy_env packages/db/.env.example
+
+echo "==> Starting PostgreSQL via docker compose"
+docker compose up -d --build
+
+echo "==> Waiting for PostgreSQL to be ready"
+for _ in {1..30}; do
+    if docker compose exec -T db pg_isready -U postgres >/dev/null 2>&1; then
+        echo "    PostgreSQL is ready"
+        break
+    fi
+    sleep 1
+done
+
+echo "==> Running database migrations"
+pnpm db:migrate || echo "    db:migrate failed — you can rerun it manually"
+
+echo "==> Fetching static course data (this can take a minute)"
+(cd apps/antalmanac && pnpm get-data) || echo "    get-data failed — you can rerun it manually from apps/antalmanac"
+
+cat <<'EOF'
+
+============================================================
+AntAlmanac dev environment is ready.
+
+Start the dev server with:
+    pnpm dev
+
+Then open the forwarded port 3000 to view the site.
+
+Useful commands:
+    pnpm dev          Start the Next.js dev server
+    pnpm test         Run the test suite
+    pnpm db:studio    Open Drizzle Studio for the local DB
+    pnpm db:migrate   Re-run database migrations
+============================================================
+EOF

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ rather not develop in the cloud. You'll need
 the Dev Containers extension for your editor:
 
 -   VS Code: [`ms-vscode-remote.remote-containers`](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
--   Cursor: [`anysphere.remote-containers`](https://open-vsx.org/extension/anysphere/remote-containers)
+-   Cursor: search for "Dev Containers" (`anysphere.remote-containers`)
+    in the Extensions panel.
 
 Then open the repository and run **Dev Containers: Reopen in Container**
 from the command palette. The same post-create script runs, leaving you

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 
 # Development Environment
 
+## Quickest Start: GitHub Codespaces
+
+You can develop AntAlmanac entirely in the browser (or your local VS Code)
+without installing Node, pnpm, or Docker on your machine.
+
+1. On the [repository page](https://github.com/icssc/AntAlmanac), click
+   **Code → Codespaces → Create codespace on main** (or on your branch).
+2. Wait for the container to build. On first launch the post-create script
+   will install dependencies, start the local PostgreSQL database, run
+   migrations, and fetch the static course data.
+3. Once setup finishes, run:
+
+    ```bash
+    pnpm dev
+    ```
+
+4. Open the forwarded port `3000` (Codespaces will offer a preview link).
+
+Everything below is for setting up a development environment on your own
+machine.
+
 ## Pre-requisites
 
 1. Install `Node.js` (version 22 or higher). This allows you to run JavaScript on your computer (outside of a browser).

--- a/README.md
+++ b/README.md
@@ -112,8 +112,22 @@ in the browser, with no setup required on your own machine.
 
 4. Open the forwarded port `3000` (Codespaces will offer a preview link).
 
+### Using the dev container locally (VS Code or Cursor)
+
+The same `.devcontainer/` configuration also works locally if you'd
+rather not develop in the cloud. You'll need
+[Docker](https://www.docker.com/products/docker-desktop) installed, plus
+the Dev Containers extension for your editor:
+
+-   VS Code: [`ms-vscode-remote.remote-containers`](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+-   Cursor: [`anysphere.remote-containers`](https://open-vsx.org/extension/anysphere/remote-containers)
+
+Then open the repository and run **Dev Containers: Reopen in Container**
+from the command palette. The same post-create script runs, leaving you
+ready to `pnpm dev`.
+
 Everything below is for setting up a development environment on your own
-machine.
+machine without containers.
 
 ## Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ the Dev Containers extension for your editor:
 -   Cursor: search for "Dev Containers" (`anysphere.remote-containers`)
     in the Extensions panel.
 
+We recommend starting from a **fresh clone** of the repository for this.
+A working tree that's already had `pnpm install` or `docker compose up`
+run on your host can leave behind `node_modules/` or volumes from a
+different platform (especially on macOS/Windows), which will conflict
+with the Linux container.
+
 Then open the repository and run **Dev Containers: Reopen in Container**
 from the command palette. The same post-create script runs, leaving you
 ready to `pnpm dev`.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 
 ## Quickest Start: GitHub Codespaces
 
-You can develop AntAlmanac entirely in the browser (or your local VS Code)
-without installing Node, pnpm, or Docker on your machine.
+GitHub Codespaces gives you a fully-configured AntAlmanac dev environment
+in the browser, with no setup required on your own machine.
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=icssc/AntAlmanac)
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ If you ever need help, feel free to ask around on our [Discord server](https://d
 You can develop AntAlmanac entirely in the browser (or your local VS Code)
 without installing Node, pnpm, or Docker on your machine.
 
-1. On the [repository page](https://github.com/icssc/AntAlmanac), click
-   **Code → Codespaces → Create codespace on main** (or on your branch).
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=icssc/AntAlmanac)
+
+1. Click the badge above (or **Code → Codespaces → Create codespace** on
+   the [repository page](https://github.com/icssc/AntAlmanac)).
 2. Wait for the container to build. On first launch the post-create script
    will install dependencies, start the local PostgreSQL database, run
    migrations, and fetch the static course data.


### PR DESCRIPTION
## Summary
Create an easy way to use Github Codespaces, which will make it easier for new developers to start working on AntAlmanac (and fix any machine-specific environment problems).

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/2bb8b621-33ea-4801-8794-5daffac4ae6e" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/895d1d67-21c5-44ed-8b92-a564323b6d22" />



## Test Plan
- Create a new GitHub Codespaces (instructions in [README.md](https://github.com/icssc/AntAlmanac/tree/claude/setup-codespaces-dev-env-2GVjz#:~:text=Quickest%20Start%3A%20GitHub%20Codespaces) of this branch)
- Make sure that this branch is selected under "Dev container configuration" (**only needed until this PR is merged**)
- Wait a few minutes for the development environment to be created
- Run `pnpm dev` in the terminal.