### PR TITLE
[WIP] Friends PR-2: Friend schedule dialog

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarCourseEventWrapper.tsx
@@ -37,10 +37,10 @@ export const CalendarCourseEventWrapper = memo(function CalendarCourseEventWrapp
                 const courseInfo = props.event as CourseEvent;
                 quickSearch(courseInfo.deptValue, courseInfo.courseNumber, courseInfo.term);
             } else {
-                setSelectedEvent(e, props.event);
+                setSelectedEvent(e, props.event, scheduleSource.scope);
             }
         },
-        [props.event, scheduleSource.readonly, quickSearch, setSelectedEvent]
+        [props.event, scheduleSource.readonly, scheduleSource.scope, quickSearch, setSelectedEvent]
     );
 
     return <div>{isValidElement(children) ? cloneElement(children, { onClick: handleClick }) : children}</div>;

--- a/apps/antalmanac/src/components/Calendar/CalendarEventPopover.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarEventPopover.tsx
@@ -9,8 +9,13 @@ import { useShallow } from 'zustand/react/shallow';
 
 export function CalendarEventPopover() {
     const scheduleSource = useScheduleViewSource();
-    const [anchorEl, selectedEvent, setSelectedEvent] = useSelectedEventStore(
-        useShallow((state) => [state.selectedEventAnchorEl, state.selectedEvent, state.setSelectedEvent])
+    const [anchorEl, selectedEvent, selectedEventScope, setSelectedEvent] = useSelectedEventStore(
+        useShallow((state) => [
+            state.selectedEventAnchorEl,
+            state.selectedEvent,
+            state.selectedEventScope,
+            state.setSelectedEvent,
+        ])
     );
 
     const [scheduleNames, setScheduleNames] = useState(() => scheduleSource.getScheduleNames());
@@ -28,7 +33,7 @@ export function CalendarEventPopover() {
         return scheduleSource.subscribe(updateScheduleNames);
     }, [scheduleSource]);
 
-    if (!selectedEvent || isSkeletonEvent(selectedEvent)) {
+    if (!selectedEvent || isSkeletonEvent(selectedEvent) || selectedEventScope !== scheduleSource.scope) {
         return null;
     }
 

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -6,7 +6,7 @@ import { CustomEventDialog } from '$components/Calendar/Toolbar/CustomEventDialo
 import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import AppStore from '$stores/AppStore';
+import { useScheduleViewSource } from '$lib/schedule/ScheduleViewContext';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { useThemeStore } from '$stores/SettingsStore';
 import {
@@ -48,6 +48,8 @@ interface CalendarPaneToolbarProps {
  */
 export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
     const theme = useTheme();
+    const scheduleSource = useScheduleViewSource();
+    const isEditable = !scheduleSource.readonly;
     const isDark = useThemeStore((store) => store.isDark);
     const { showFinalsSchedule, toggleDisplayFinalsSchedule } = props;
     const fallbackMode = useFallbackStore((state) => state.fallbackMode);
@@ -181,115 +183,123 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
             </Box>
             <Box flexGrow={1} />
 
-            <Box
-                sx={{
-                    display: isMobile ? 'flex' : 'none',
-                    '@container toolbar (max-width: 500px)': {
-                        display: 'flex',
-                    },
-                }}
-            >
-                <Box display="flex" flexDirection="row" gap={0.5}>
-                    <Box display="flex" flexWrap="nowrap" alignItems="center" gap={0.5}>
-                        <IconButton onClick={handleUndo} disabled={fallbackMode}>
-                            <UndoIcon fontSize="small" />
-                        </IconButton>
-                        <IconButton onClick={handleRedo} disabled={fallbackMode}>
-                            <RedoIcon fontSize="small" />
-                        </IconButton>
-                        <CustomEventDialog key="custom" scheduleNames={AppStore.getScheduleNames()} />
-
-                        <Tooltip title="More options">
-                            <IconButton onClick={handleMenuOpen} disabled={fallbackMode}>
-                                <MoreVertIcon fontSize="small" />
+            {isEditable && (
+                <Box
+                    sx={{
+                        display: isMobile ? 'flex' : 'none',
+                        '@container toolbar (max-width: 500px)': {
+                            display: 'flex',
+                        },
+                    }}
+                >
+                    <Box display="flex" flexDirection="row" gap={0.5}>
+                        <Box display="flex" flexWrap="nowrap" alignItems="center" gap={0.5}>
+                            <IconButton onClick={handleUndo} disabled={fallbackMode}>
+                                <UndoIcon fontSize="small" />
                             </IconButton>
-                        </Tooltip>
+                            <IconButton onClick={handleRedo} disabled={fallbackMode}>
+                                <RedoIcon fontSize="small" />
+                            </IconButton>
+                            <CustomEventDialog key="custom" scheduleNames={props.scheduleNames} />
 
-                        <Menu
-                            anchorEl={menuAnchorEl}
-                            open={menuOpen}
-                            onClose={handleMenuClose}
-                            anchorOrigin={{
-                                vertical: 'bottom',
-                                horizontal: 'right',
-                            }}
-                            transformOrigin={{
-                                vertical: 'top',
-                                horizontal: 'right',
-                            }}
-                        >
-                            <MenuItem onClick={handleScreenshot}>
-                                <ListItemIcon>
-                                    <Panorama fontSize="small" />
-                                </ListItemIcon>
-                                <ListItemText>Get Screenshot</ListItemText>
-                            </MenuItem>
-                            <MenuItem onClick={handleDownload}>
-                                <ListItemIcon>
-                                    <Download fontSize="small" />
-                                </ListItemIcon>
-                                <ListItemText>Download Calendar</ListItemText>
-                            </MenuItem>
-                            <MenuItem onClick={handleClearSchedule}>
-                                <ListItemIcon>
-                                    <DeleteOutline fontSize="small" />
-                                </ListItemIcon>
-                                <ListItemText>Clear Schedule</ListItemText>
-                            </MenuItem>
-                        </Menu>
+                            <Tooltip title="More options">
+                                <IconButton onClick={handleMenuOpen} disabled={fallbackMode}>
+                                    <MoreVertIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
 
-                        {/* Hidden button components for mobile menu to trigger */}
-                        <Box sx={{ display: 'none' }}>
-                            <Box ref={screenshotButtonRef}>
-                                <ScreenshotButton />
-                            </Box>
-                            <Box ref={downloadButtonRef}>
-                                <DownloadButton />
-                            </Box>
-                            <Box ref={clearButtonRef}>
-                                <ClearScheduleButton
-                                    size="medium"
-                                    fontSize="small"
-                                    analyticsCategory={analyticsEnum.calendar}
-                                />
+                            <Menu
+                                anchorEl={menuAnchorEl}
+                                open={menuOpen}
+                                onClose={handleMenuClose}
+                                anchorOrigin={{
+                                    vertical: 'bottom',
+                                    horizontal: 'right',
+                                }}
+                                transformOrigin={{
+                                    vertical: 'top',
+                                    horizontal: 'right',
+                                }}
+                            >
+                                <MenuItem onClick={handleScreenshot}>
+                                    <ListItemIcon>
+                                        <Panorama fontSize="small" />
+                                    </ListItemIcon>
+                                    <ListItemText>Get Screenshot</ListItemText>
+                                </MenuItem>
+                                <MenuItem onClick={handleDownload}>
+                                    <ListItemIcon>
+                                        <Download fontSize="small" />
+                                    </ListItemIcon>
+                                    <ListItemText>Download Calendar</ListItemText>
+                                </MenuItem>
+                                <MenuItem onClick={handleClearSchedule}>
+                                    <ListItemIcon>
+                                        <DeleteOutline fontSize="small" />
+                                    </ListItemIcon>
+                                    <ListItemText>Clear Schedule</ListItemText>
+                                </MenuItem>
+                            </Menu>
+
+                            {/* Hidden button components for mobile menu to trigger */}
+                            <Box sx={{ display: 'none' }}>
+                                <Box ref={screenshotButtonRef}>
+                                    <ScreenshotButton />
+                                </Box>
+                                <Box ref={downloadButtonRef}>
+                                    <DownloadButton />
+                                </Box>
+                                <Box ref={clearButtonRef}>
+                                    <ClearScheduleButton
+                                        size="medium"
+                                        fontSize="small"
+                                        analyticsCategory={analyticsEnum.calendar}
+                                    />
+                                </Box>
                             </Box>
                         </Box>
                     </Box>
                 </Box>
-            </Box>
+            )}
 
-            <Box
-                sx={{
-                    display: isMobile ? 'none' : 'flex',
-                    flexWrap: 'nowrap',
-                    alignItems: 'center',
-                    gap: 0.5,
-                    '@container toolbar (max-width: 500px)': {
-                        display: 'none',
-                    },
-                }}
-            >
-                <Box display="flex" flexWrap="wrap" alignItems="center" gap={0.5}>
-                    <ScreenshotButton onScreenshot={props.onScreenshot} />
+            {isEditable && (
+                <Box
+                    sx={{
+                        display: isMobile ? 'none' : 'flex',
+                        flexWrap: 'nowrap',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        '@container toolbar (max-width: 500px)': {
+                            display: 'none',
+                        },
+                    }}
+                >
+                    <Box display="flex" flexWrap="wrap" alignItems="center" gap={0.5}>
+                        <ScreenshotButton onScreenshot={props.onScreenshot} />
 
-                    <DownloadButton />
+                        <DownloadButton />
 
-                    <Tooltip title="Undo last action">
-                        <IconButton onClick={handleUndo} size="medium" disabled={fallbackMode}>
-                            <UndoIcon fontSize="small" />
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Redo last action">
-                        <IconButton onClick={handleRedo} size="medium" disabled={fallbackMode}>
-                            <RedoIcon fontSize="small" />
-                        </IconButton>
-                    </Tooltip>
+                        <Tooltip title="Undo last action">
+                            <IconButton onClick={handleUndo} size="medium" disabled={fallbackMode}>
+                                <UndoIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Redo last action">
+                            <IconButton onClick={handleRedo} size="medium" disabled={fallbackMode}>
+                                <RedoIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
 
-                    <ClearScheduleButton size="medium" fontSize="small" analyticsCategory={analyticsEnum.calendar} />
+                        <ClearScheduleButton
+                            size="medium"
+                            fontSize="small"
+                            analyticsCategory={analyticsEnum.calendar}
+                        />
 
-                    <CustomEventDialog key="custom" scheduleNames={AppStore.getScheduleNames()} />
+                        <CustomEventDialog key="custom" scheduleNames={props.scheduleNames} />
+                    </Box>
                 </Box>
-            </Box>
+            )}
         </Paper>
     );
 });

--- a/apps/antalmanac/src/components/Header/Friends/FriendAvatar.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendAvatar.tsx
@@ -1,0 +1,37 @@
+import { AccountCircle } from '@mui/icons-material';
+import { Avatar, Stack, Typography } from '@mui/material';
+
+interface FriendAvatarProps {
+    name: string | null;
+    email: string | null;
+    avatar: string | null;
+}
+
+export function FriendAvatar({ name, email, avatar }: FriendAvatarProps) {
+    const displayEmail = email ?? '';
+
+    return (
+        <Stack sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1, flex: 1 }}>
+            <Avatar src={avatar || undefined} sx={{ width: 30, height: 30 }}>
+                <AccountCircle />
+            </Avatar>
+
+            <Stack sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                <Typography
+                    variant="body2"
+                    fontWeight={600}
+                    sx={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}
+                >
+                    {name || displayEmail}
+                </Typography>
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}
+                >
+                    {displayEmail}
+                </Typography>
+            </Stack>
+        </Stack>
+    );
+}

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleDialog.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleDialog.tsx
@@ -1,0 +1,80 @@
+import { FriendScheduleView } from '$components/Header/Friends/FriendScheduleView';
+import { FriendScheduleViewProvider } from '$lib/schedule/ScheduleViewContext';
+import FriendsStore from '$stores/FriendsStore';
+import { Close } from '@mui/icons-material';
+import { Box, CircularProgress, Dialog, IconButton, Stack, Typography } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+
+export function FriendScheduleDialog() {
+    const [open, setOpen] = useState(FriendsStore.isDialogOpen());
+    const [friendName, setFriendName] = useState(FriendsStore.getFriendName() ?? 'Friend');
+    const [loading, setLoading] = useState(FriendsStore.isLoading());
+
+    const syncFromStore = useCallback(() => {
+        setOpen(FriendsStore.isDialogOpen());
+        setFriendName(FriendsStore.getFriendName() ?? 'Friend');
+        setLoading(FriendsStore.isLoading());
+    }, []);
+
+    useEffect(() => {
+        FriendsStore.on('friendViewChange', syncFromStore);
+
+        return () => {
+            FriendsStore.off('friendViewChange', syncFromStore);
+        };
+    }, [syncFromStore]);
+
+    const handleClose = () => {
+        FriendsStore.closeFriendView();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            fullWidth
+            maxWidth={false}
+            slotProps={{
+                paper: {
+                    sx: {
+                        width: '80vw',
+                        height: '80vh',
+                        maxWidth: '80vw',
+                        maxHeight: '80vh',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        overflow: 'hidden',
+                    },
+                },
+            }}
+        >
+            <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ px: 2, py: 1.5, borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}
+            >
+                <Typography variant="h6" component="h2" sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }}>
+                    Viewing <strong>{friendName}</strong>&apos;s schedules
+                </Typography>
+                <IconButton aria-label="Close friend schedule view" onClick={handleClose} edge="end">
+                    <Close />
+                </IconButton>
+            </Stack>
+
+            <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                {loading ? (
+                    <Stack flex={1} alignItems="center" justifyContent="center">
+                        <CircularProgress />
+                    </Stack>
+                ) : (
+                    <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+                        <FriendScheduleViewProvider>
+                            <FriendScheduleView />
+                        </FriendScheduleViewProvider>
+                    </Box>
+                )}
+            </Box>
+        </Dialog>
+    );
+}

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleDialog.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleDialog.tsx
@@ -62,17 +62,24 @@ export function FriendScheduleDialog() {
                 </IconButton>
             </Stack>
 
-            <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+            <Box
+                sx={{
+                    flexGrow: 1,
+                    height: 0,
+                    minHeight: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                }}
+            >
                 {loading ? (
                     <Stack flex={1} alignItems="center" justifyContent="center">
                         <CircularProgress />
                     </Stack>
                 ) : (
-                    <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-                        <FriendScheduleViewProvider>
-                            <FriendScheduleView />
-                        </FriendScheduleViewProvider>
-                    </Box>
+                    <FriendScheduleViewProvider>
+                        <FriendScheduleView />
+                    </FriendScheduleViewProvider>
                 )}
             </Box>
         </Dialog>

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleEntry.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleEntry.tsx
@@ -1,0 +1,136 @@
+import { SignInDialog } from '$components/dialogs/SignInDialog';
+import { FriendAvatar } from '$components/Header/Friends/FriendAvatar';
+import { trpc } from '$lib/api/trpc';
+import type { Friend } from '$src/backend/lib/rds.types';
+import { useIsMobile } from '$src/hooks/useIsMobile';
+import FriendsStore from '$stores/FriendsStore';
+import { useSessionStore } from '$stores/SessionStore';
+import { openSnackbar } from '$stores/SnackbarStore';
+import { People } from '@mui/icons-material';
+import { Box, Button, CircularProgress, IconButton, Popover, Typography } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+
+export function FriendScheduleEntry() {
+    const userId = useSessionStore((store) => store.userId);
+    const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
+    const isMobile = useIsMobile();
+
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [openSignInDialog, setOpenSignInDialog] = useState(false);
+    const [friends, setFriends] = useState<Friend[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const open = Boolean(anchorEl);
+
+    const loadFriends = useCallback(async () => {
+        if (!sessionIsValid || !userId) {
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            setFriends(await trpc.friends.getFriends.query());
+        } catch (error) {
+            console.error('Failed to load friends:', error);
+            openSnackbar('error', 'Failed to load friends.');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [sessionIsValid, userId]);
+
+    useEffect(() => {
+        if (open && sessionIsValid && userId) {
+            void loadFriends();
+        }
+    }, [open, sessionIsValid, userId, loadFriends]);
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        if (sessionIsValid && userId) {
+            setAnchorEl(event.currentTarget);
+        } else {
+            setOpenSignInDialog(true);
+        }
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const handleViewSchedule = async (friend: Friend) => {
+        handleClose();
+
+        const friendName = friend.name ?? friend.email ?? 'Friend';
+        const success = await FriendsStore.openFriendView(friend.id, friendName);
+
+        if (!success) {
+            openSnackbar('warning', "This friend hasn't shared any schedules with you.");
+        }
+    };
+
+    return (
+        <>
+            {isMobile ? (
+                <IconButton color="inherit" onClick={handleClick}>
+                    <People />
+                </IconButton>
+            ) : (
+                <Button
+                    variant="text"
+                    startIcon={<People />}
+                    color="inherit"
+                    onClick={handleClick}
+                    sx={{ fontSize: 'inherit' }}
+                >
+                    Friends
+                </Button>
+            )}
+
+            <Popover
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handleClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                slotProps={{ paper: { sx: { width: 320, p: 2 } } }}
+            >
+                <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1.5 }}>
+                    View a friend&apos;s schedule
+                </Typography>
+
+                {isLoading ? (
+                    <Box display="flex" justifyContent="center" py={3}>
+                        <CircularProgress size={24} />
+                    </Box>
+                ) : friends.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                        No friends added yet.
+                    </Typography>
+                ) : (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxHeight: 280, overflowY: 'auto' }}>
+                        {friends.map((friend) => (
+                            <Box
+                                key={friend.id}
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 1,
+                                    p: 1,
+                                    border: 1,
+                                    borderColor: 'divider',
+                                    borderRadius: 1,
+                                }}
+                            >
+                                <FriendAvatar name={friend.name} email={friend.email} avatar={friend.avatar} />
+                                <Button size="small" variant="outlined" onClick={() => handleViewSchedule(friend)}>
+                                    View
+                                </Button>
+                            </Box>
+                        ))}
+                    </Box>
+                )}
+            </Popover>
+
+            <SignInDialog open={openSignInDialog} feature="Friends" onClose={() => setOpenSignInDialog(false)} />
+        </>
+    );
+}

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
@@ -1,0 +1,51 @@
+import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
+import { FriendSchedule } from '$components/RightPane/AddedCourses/FriendSchedule';
+import { useIsMobile } from '$hooks/useIsMobile';
+import { BLUE } from '$src/globals';
+import { Stack } from '@mui/material';
+import Split from 'react-split';
+
+function FriendScheduleDesktopView() {
+    return (
+        <Split
+            sizes={[42.5, 57.5]}
+            minSize={400}
+            expandToMin={false}
+            gutterSize={10}
+            gutterAlign="center"
+            snapOffset={0}
+            dragInterval={1}
+            direction="horizontal"
+            cursor="col-resize"
+            style={{ display: 'flex', flexGrow: 1, marginTop: 4 }}
+            gutterStyle={() => ({
+                backgroundColor: BLUE,
+                width: '10px',
+                paddingRight: '1px',
+            })}
+        >
+            <Stack direction="column">
+                <ScheduleCalendar />
+            </Stack>
+            <Stack direction="column" overflow="auto" padding={1}>
+                <FriendSchedule />
+            </Stack>
+        </Split>
+    );
+}
+
+function FriendScheduleMobileView() {
+    return (
+        <Stack direction="column" flexGrow={1} height="0" gap={1}>
+            <ScheduleCalendar />
+            <Stack direction="column" overflow="auto" padding={1} flexGrow={1}>
+                <FriendSchedule />
+            </Stack>
+        </Stack>
+    );
+}
+
+export function FriendScheduleView() {
+    const isMobile = useIsMobile();
+    return isMobile ? <FriendScheduleMobileView /> : <FriendScheduleDesktopView />;
+}

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
@@ -2,7 +2,7 @@ import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
 import { FriendSchedule } from '$components/RightPane/AddedCourses/FriendSchedule';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { BLUE } from '$src/globals';
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import Split from 'react-split';
 
 function FriendScheduleDesktopView() {
@@ -17,17 +17,17 @@ function FriendScheduleDesktopView() {
             dragInterval={1}
             direction="horizontal"
             cursor="col-resize"
-            style={{ display: 'flex', flexGrow: 1, marginTop: 4 }}
+            style={{ display: 'flex', flex: 1, height: '100%', minHeight: 0, marginTop: 4 }}
             gutterStyle={() => ({
                 backgroundColor: BLUE,
                 width: '10px',
                 paddingRight: '1px',
             })}
         >
-            <Stack direction="column">
+            <Stack direction="column" height="100%" minHeight={0} overflow="hidden">
                 <ScheduleCalendar />
             </Stack>
-            <Stack direction="column" flexGrow={1} minHeight={0} overflow="hidden">
+            <Stack direction="column" height="100%" minHeight={0} overflow="hidden">
                 <FriendSchedule />
             </Stack>
         </Split>
@@ -36,9 +36,9 @@ function FriendScheduleDesktopView() {
 
 function FriendScheduleMobileView() {
     return (
-        <Stack direction="column" flexGrow={1} height="0" gap={1}>
+        <Stack direction="column" flexGrow={1} height={0} minHeight={0} gap={1} overflow="hidden">
             <ScheduleCalendar />
-            <Stack direction="column" flexGrow={1} minHeight={0} overflow="hidden">
+            <Stack direction="column" flexGrow={1} height={0} minHeight={0} overflow="hidden">
                 <FriendSchedule />
             </Stack>
         </Stack>
@@ -47,5 +47,12 @@ function FriendScheduleMobileView() {
 
 export function FriendScheduleView() {
     const isMobile = useIsMobile();
-    return isMobile ? <FriendScheduleMobileView /> : <FriendScheduleDesktopView />;
+
+    return (
+        <Box
+            sx={{ flexGrow: 1, height: 0, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        >
+            {isMobile ? <FriendScheduleMobileView /> : <FriendScheduleDesktopView />}
+        </Box>
+    );
 }

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
@@ -27,7 +27,7 @@ function FriendScheduleDesktopView() {
             <Stack direction="column">
                 <ScheduleCalendar />
             </Stack>
-            <Stack direction="column" overflow="auto" padding={1}>
+            <Stack direction="column" flexGrow={1} minHeight={0} overflow="hidden">
                 <FriendSchedule />
             </Stack>
         </Split>
@@ -38,7 +38,7 @@ function FriendScheduleMobileView() {
     return (
         <Stack direction="column" flexGrow={1} height="0" gap={1}>
             <ScheduleCalendar />
-            <Stack direction="column" overflow="auto" padding={1} flexGrow={1}>
+            <Stack direction="column" flexGrow={1} minHeight={0} overflow="hidden">
                 <FriendSchedule />
             </Stack>
         </Stack>

--- a/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
+++ b/apps/antalmanac/src/components/Header/Friends/FriendScheduleView.tsx
@@ -1,8 +1,10 @@
 import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
 import { FriendSchedule } from '$components/RightPane/AddedCourses/FriendSchedule';
 import { useIsMobile } from '$hooks/useIsMobile';
+import { FriendScheduleTabProvider, type FriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
 import { BLUE } from '$src/globals';
 import { Box, Stack } from '@mui/material';
+import { useCallback, useState } from 'react';
 import Split from 'react-split';
 
 function FriendScheduleDesktopView() {
@@ -47,12 +49,34 @@ function FriendScheduleMobileView() {
 
 export function FriendScheduleView() {
     const isMobile = useIsMobile();
+    const [activeTab, setActiveTab] = useState<FriendScheduleTab>('added');
+    const [mapLocationId, setMapLocationId] = useState<number | undefined>();
+
+    const focusMapLocation = useCallback((buildingId: number) => {
+        setMapLocationId(buildingId);
+        setActiveTab('map');
+    }, []);
 
     return (
-        <Box
-            sx={{ flexGrow: 1, height: 0, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        <FriendScheduleTabProvider
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            mapLocationId={mapLocationId}
+            setMapLocationId={setMapLocationId}
+            focusMapLocation={focusMapLocation}
         >
-            {isMobile ? <FriendScheduleMobileView /> : <FriendScheduleDesktopView />}
-        </Box>
+            <Box
+                sx={{
+                    flexGrow: 1,
+                    height: 0,
+                    minHeight: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                }}
+            >
+                {isMobile ? <FriendScheduleMobileView /> : <FriendScheduleDesktopView />}
+            </Box>
+        </FriendScheduleTabProvider>
     );
 }

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { AlertDialog } from '$components/AlertDialog';
 import { AppSwitcher } from '$components/Header/AppSwitcher';
+import { FriendScheduleEntry } from '$components/Header/Friends/FriendScheduleEntry';
 import { Import } from '$components/Header/Import';
 import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
@@ -76,6 +77,7 @@ export function Header() {
                     </Stack>
 
                     <Stack direction="row" alignItems="center">
+                        <FriendScheduleEntry />
                         <Import key="studylist" />
                         <Save />
                         {sessionIsValid ? <Signout onLogoutComplete={handleLogoutComplete} /> : <Signin />}

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -151,11 +151,17 @@ export function getCustomEventPerBuilding(customEvents: CustomEvent[]) {
     return customEventPerBuilding;
 }
 
+interface CourseMapProps {
+    locationId?: number;
+    onLocationChange?: (locationId: number | undefined) => void;
+}
+
 /**
  * Map of all course locations on UCI campus.
  */
-export default function CourseMap() {
+export default function CourseMap({ locationId, onLocationChange }: CourseMapProps = {}) {
     const scheduleSource = useScheduleViewSource();
+    const useControlledLocation = onLocationChange != null;
     const navigate = useNavigate();
     const map = useRef<Map | null>(null);
     const markerRef = useRef<Marker | null>(null);
@@ -192,7 +198,7 @@ export default function CourseMap() {
         return scheduleSource.subscribe(updateCalendarEvents);
     }, [scheduleSource]);
 
-    const resolvedLocationId = Number(searchParams.get('location') ?? 0);
+    const resolvedLocationId = useControlledLocation ? (locationId ?? 0) : Number(searchParams.get('location') ?? 0);
 
     useEffect(() => {
         const building = resolvedLocationId in buildingCatalogue ? buildingCatalogue[resolvedLocationId] : undefined;
@@ -216,9 +222,14 @@ export default function CourseMap() {
 
     const onBuildingChange = useCallback(
         (building?: ExtendedBuilding | null) => {
+            if (useControlledLocation) {
+                onLocationChange?.(building?.id != null ? Number(building.id) : undefined);
+                return;
+            }
+
             navigate(`/map?location=${building?.id}`);
         },
-        [navigate]
+        [navigate, onLocationChange, useControlledLocation]
     );
 
     const days = useMemo(() => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
@@ -2,12 +2,12 @@ import { AddedSectionsGrid } from '$components/RightPane/AddedCourses/AddedSecti
 import { CoursePaneRoot } from '$components/RightPane/CoursePane/CoursePaneRoot';
 import darkModeLoadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/dark-loading.gif';
 import loadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/loading.gif';
-import { FriendScheduleTabProvider, type FriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
+import { useFriendScheduleTab, type FriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
 import { useThemeStore } from '$stores/SettingsStore';
 import { FormatListBulleted, MyLocation, Search } from '@mui/icons-material';
 import { Box, Paper, Stack, Tab, Tabs } from '@mui/material';
 import Image from 'next/image';
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense } from 'react';
 
 const UCIMap = lazy(() => import('$components/Map/Map'));
 
@@ -18,96 +18,95 @@ const friendScheduleTabIndex: Record<FriendScheduleTab, number> = {
 };
 
 export function FriendSchedule() {
-    const [activeTab, setActiveTab] = useState<FriendScheduleTab>('added');
-    const [mapLocationId, setMapLocationId] = useState<number | undefined>();
+    const friendScheduleTab = useFriendScheduleTab();
     const isDark = useThemeStore((store) => store.isDark);
 
-    return (
-        <FriendScheduleTabProvider activeTab={activeTab} setActiveTab={setActiveTab}>
-            <Stack direction="column" flexGrow={1} height={0} minHeight={0} overflow="hidden">
-                <Paper
-                    elevation={0}
-                    variant="outlined"
-                    square
-                    sx={{
-                        borderRadius: '4px 4px 0 0',
-                        borderWidth: '1px 0px 1px 0px',
-                        flexShrink: 0,
-                    }}
-                >
-                    <Tabs
-                        value={friendScheduleTabIndex[activeTab]}
-                        indicatorColor="secondary"
-                        textColor="secondary"
-                        variant="fullWidth"
-                        centered
-                    >
-                        <Tab
-                            id="friend-search-tab"
-                            icon={<Search />}
-                            iconPosition="start"
-                            label="Search"
-                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
-                            onClick={() => setActiveTab('search')}
-                        />
-                        <Tab
-                            id="friend-added-courses-tab"
-                            icon={<FormatListBulleted />}
-                            iconPosition="start"
-                            label="Added"
-                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
-                            onClick={() => setActiveTab('added')}
-                        />
-                        <Tab
-                            id="friend-map-tab"
-                            icon={<MyLocation />}
-                            iconPosition="start"
-                            label="Map"
-                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
-                            onClick={() => setActiveTab('map')}
-                        />
-                    </Tabs>
-                </Paper>
+    if (!friendScheduleTab) {
+        return null;
+    }
 
-                <Box
-                    flexGrow={1}
-                    height={0}
-                    minHeight={0}
-                    overflow={activeTab === 'map' ? 'hidden' : 'auto'}
-                    display="flex"
-                    flexDirection="column"
-                    padding={1}
-                    sx={{ WebkitOverflowScrolling: 'touch' }}
+    const { activeTab, setActiveTab, mapLocationId, setMapLocationId } = friendScheduleTab;
+
+    return (
+        <Stack direction="column" flexGrow={1} height={0} minHeight={0} overflow="hidden">
+            <Paper
+                elevation={0}
+                variant="outlined"
+                square
+                sx={{
+                    borderRadius: '4px 4px 0 0',
+                    borderWidth: '1px 0px 1px 0px',
+                    flexShrink: 0,
+                }}
+            >
+                <Tabs
+                    value={friendScheduleTabIndex[activeTab]}
+                    indicatorColor="secondary"
+                    textColor="secondary"
+                    variant="fullWidth"
+                    centered
                 >
-                    {activeTab === 'search' ? (
-                        <CoursePaneRoot />
-                    ) : activeTab === 'added' ? (
-                        <AddedSectionsGrid />
-                    ) : (
-                        <Suspense
-                            fallback={
-                                <Box
-                                    sx={{
-                                        height: '100%',
-                                        width: '100%',
-                                        display: 'flex',
-                                        justifyContent: 'center',
-                                        alignItems: 'center',
-                                    }}
-                                >
-                                    <Image
-                                        src={isDark ? darkModeLoadingGif : loadingGif}
-                                        alt="Loading map"
-                                        unoptimized
-                                    />
-                                </Box>
-                            }
-                        >
-                            <UCIMap locationId={mapLocationId} onLocationChange={setMapLocationId} />
-                        </Suspense>
-                    )}
-                </Box>
-            </Stack>
-        </FriendScheduleTabProvider>
+                    <Tab
+                        id="friend-search-tab"
+                        icon={<Search />}
+                        iconPosition="start"
+                        label="Search"
+                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                        onClick={() => setActiveTab('search')}
+                    />
+                    <Tab
+                        id="friend-added-courses-tab"
+                        icon={<FormatListBulleted />}
+                        iconPosition="start"
+                        label="Added"
+                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                        onClick={() => setActiveTab('added')}
+                    />
+                    <Tab
+                        id="friend-map-tab"
+                        icon={<MyLocation />}
+                        iconPosition="start"
+                        label="Map"
+                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                        onClick={() => setActiveTab('map')}
+                    />
+                </Tabs>
+            </Paper>
+
+            <Box
+                flexGrow={1}
+                height={0}
+                minHeight={0}
+                overflow={activeTab === 'map' ? 'hidden' : 'auto'}
+                display="flex"
+                flexDirection="column"
+                padding={1}
+                sx={{ WebkitOverflowScrolling: 'touch' }}
+            >
+                {activeTab === 'search' ? (
+                    <CoursePaneRoot />
+                ) : activeTab === 'added' ? (
+                    <AddedSectionsGrid />
+                ) : (
+                    <Suspense
+                        fallback={
+                            <Box
+                                sx={{
+                                    height: '100%',
+                                    width: '100%',
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                    alignItems: 'center',
+                                }}
+                            >
+                                <Image src={isDark ? darkModeLoadingGif : loadingGif} alt="Loading map" unoptimized />
+                            </Box>
+                        }
+                    >
+                        <UCIMap locationId={mapLocationId} onLocationChange={setMapLocationId} />
+                    </Suspense>
+                )}
+            </Box>
+        </Stack>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
@@ -1,127 +1,111 @@
-import buildingCatalogue from '$lib/locations/buildingCatalogue';
-import FriendsStore from '$stores/FriendsStore';
-import { useTimeFormatStore } from '$stores/SettingsStore';
-import { Box, Card, CardContent, CardHeader, Chip, Paper, TextField, Typography } from '@mui/material';
-import type { ScheduleCourse } from '@packages/antalmanac-types';
-import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import { format, isValid, set } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { AddedSectionsGrid } from '$components/RightPane/AddedCourses/AddedSectionsGrid';
+import { CoursePaneRoot } from '$components/RightPane/CoursePane/CoursePaneRoot';
+import darkModeLoadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/dark-loading.gif';
+import loadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/loading.gif';
+import { FriendScheduleTabProvider, type FriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
+import { useThemeStore } from '$stores/SettingsStore';
+import { FormatListBulleted, MyLocation, Search } from '@mui/icons-material';
+import { Box, Paper, Stack, Tab, Tabs } from '@mui/material';
+import Image from 'next/image';
+import { lazy, Suspense, useState } from 'react';
 
-function formatCustomEventTime(customEvent: RepeatingCustomEvent, isMilitaryTime: boolean) {
-    const baseDate = new Date(2000, 0, 1);
-    const startTime = set(baseDate, {
-        hours: parseInt(customEvent.start.slice(0, 2)),
-        minutes: parseInt(customEvent.start.slice(3, 5)),
-    });
-    const endTime = set(baseDate, {
-        hours: parseInt(customEvent.end.slice(0, 2)),
-        minutes: parseInt(customEvent.end.slice(3, 5)),
-    });
+const UCIMap = lazy(() => import('$components/Map/Map'));
 
-    if (!isValid(startTime) || !isValid(endTime)) {
-        return `${customEvent.start} — ${customEvent.end}`;
-    }
-
-    const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const daysString = customEvent.days
-        .map((includeDate, index) => (includeDate ? dayAbbreviations[index] : ''))
-        .join(' ');
-
-    const timeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm a';
-    return `${format(startTime, timeFormat)} — ${format(endTime, timeFormat)} • ${daysString}`;
-}
-
-function FriendCourseRow({ course }: { course: ScheduleCourse }) {
-    return (
-        <Paper variant="outlined" sx={{ p: 1.5 }}>
-            <Typography variant="subtitle2" fontWeight={600}>
-                {course.deptCode} {course.courseNumber}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-                {course.courseTitle}
-            </Typography>
-            <Box display="flex" flexWrap="wrap" gap={0.5} mt={1}>
-                <Chip size="small" label={course.section.sectionCode} />
-                <Chip size="small" label={course.section.sectionType} />
-            </Box>
-        </Paper>
-    );
-}
+const friendScheduleTabIndex: Record<FriendScheduleTab, number> = {
+    search: 0,
+    added: 1,
+    map: 2,
+};
 
 export function FriendSchedule() {
-    const [courses, setCourses] = useState(() => FriendsStore.schedule.getCurrentCourses());
-    const [customEvents, setCustomEvents] = useState(() => FriendsStore.schedule.getCurrentCustomEvents());
-    const [scheduleNote, setScheduleNote] = useState(() => FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '');
-    const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
-
-    const syncFromStore = useCallback(() => {
-        setCourses(FriendsStore.schedule.getCurrentCourses());
-        setCustomEvents(FriendsStore.schedule.getCurrentCustomEvents());
-        setScheduleNote(FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '');
-    }, []);
-
-    useEffect(() => {
-        FriendsStore.on('scheduleChange', syncFromStore);
-        FriendsStore.on('friendViewChange', syncFromStore);
-
-        return () => {
-            FriendsStore.off('scheduleChange', syncFromStore);
-            FriendsStore.off('friendViewChange', syncFromStore);
-        };
-    }, [syncFromStore]);
+    const [activeTab, setActiveTab] = useState<FriendScheduleTab>('added');
+    const [mapLocationId, setMapLocationId] = useState<number | undefined>();
+    const isDark = useThemeStore((store) => store.isDark);
 
     return (
-        <Box display="flex" flexDirection="column" gap={2}>
-            <Typography variant="h6">Added Courses</Typography>
+        <FriendScheduleTabProvider activeTab={activeTab} setActiveTab={setActiveTab}>
+            <Stack direction="column" flexGrow={1} height="100%" minHeight={0}>
+                <Paper
+                    elevation={0}
+                    variant="outlined"
+                    square
+                    sx={{
+                        borderRadius: '4px 4px 0 0',
+                        borderWidth: '1px 0px 1px 0px',
+                        flexShrink: 0,
+                    }}
+                >
+                    <Tabs
+                        value={friendScheduleTabIndex[activeTab]}
+                        indicatorColor="secondary"
+                        textColor="secondary"
+                        variant="fullWidth"
+                        centered
+                    >
+                        <Tab
+                            id="friend-search-tab"
+                            icon={<Search />}
+                            iconPosition="start"
+                            label="Search"
+                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                            onClick={() => setActiveTab('search')}
+                        />
+                        <Tab
+                            id="friend-added-courses-tab"
+                            icon={<FormatListBulleted />}
+                            iconPosition="start"
+                            label="Added"
+                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                            onClick={() => setActiveTab('added')}
+                        />
+                        <Tab
+                            id="friend-map-tab"
+                            icon={<MyLocation />}
+                            iconPosition="start"
+                            label="Map"
+                            sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                            onClick={() => setActiveTab('map')}
+                        />
+                    </Tabs>
+                </Paper>
 
-            {courses.length === 0 ? (
-                <Typography variant="body2" color="text.secondary">
-                    No courses in this schedule.
-                </Typography>
-            ) : (
-                <Box display="flex" flexDirection="column" gap={1}>
-                    {courses.map((course) => (
-                        <FriendCourseRow key={course.section.sectionCode} course={course} />
-                    ))}
+                <Box
+                    flexGrow={1}
+                    minHeight={0}
+                    overflow={activeTab === 'map' ? 'hidden' : 'auto'}
+                    display="flex"
+                    flexDirection="column"
+                    padding={1}
+                >
+                    {activeTab === 'search' ? (
+                        <CoursePaneRoot />
+                    ) : activeTab === 'added' ? (
+                        <AddedSectionsGrid />
+                    ) : (
+                        <Suspense
+                            fallback={
+                                <Box
+                                    sx={{
+                                        height: '100%',
+                                        width: '100%',
+                                        display: 'flex',
+                                        justifyContent: 'center',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <Image
+                                        src={isDark ? darkModeLoadingGif : loadingGif}
+                                        alt="Loading map"
+                                        unoptimized
+                                    />
+                                </Box>
+                            }
+                        >
+                            <UCIMap locationId={mapLocationId} onLocationChange={setMapLocationId} />
+                        </Suspense>
+                    )}
                 </Box>
-            )}
-
-            {customEvents.length > 0 && (
-                <>
-                    <Typography variant="h6">Custom Events</Typography>
-                    <Box display="flex" flexDirection="column" gap={1}>
-                        {customEvents.map((customEvent) => (
-                            <Card key={customEvent.customEventID}>
-                                <CardHeader
-                                    title={customEvent.title}
-                                    slotProps={{ title: { variant: 'subtitle1' } }}
-                                    subheader={formatCustomEventTime(customEvent, isMilitaryTime)}
-                                    sx={{ padding: 1 }}
-                                />
-                                {customEvent.building != null && customEvent.building !== '' && (
-                                    <CardContent sx={{ paddingX: 1, paddingY: 0 }}>
-                                        {buildingCatalogue[+customEvent.building]?.name ?? customEvent.building}
-                                    </CardContent>
-                                )}
-                            </Card>
-                        ))}
-                    </Box>
-                </>
-            )}
-
-            {scheduleNote.length > 0 && (
-                <Box>
-                    <Typography variant="h6">Schedule Notes</Typography>
-                    <TextField
-                        value={scheduleNote}
-                        multiline
-                        fullWidth
-                        disabled
-                        variant="filled"
-                        InputProps={{ disableUnderline: true }}
-                    />
-                </Box>
-            )}
-        </Box>
+            </Stack>
+        </FriendScheduleTabProvider>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
@@ -1,0 +1,127 @@
+import buildingCatalogue from '$lib/locations/buildingCatalogue';
+import FriendsStore from '$stores/FriendsStore';
+import { useTimeFormatStore } from '$stores/SettingsStore';
+import { Box, Card, CardContent, CardHeader, Chip, Paper, TextField, Typography } from '@mui/material';
+import type { ScheduleCourse } from '@packages/antalmanac-types';
+import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { format, isValid, set } from 'date-fns';
+import { useCallback, useEffect, useState } from 'react';
+
+function formatCustomEventTime(customEvent: RepeatingCustomEvent, isMilitaryTime: boolean) {
+    const baseDate = new Date(2000, 0, 1);
+    const startTime = set(baseDate, {
+        hours: parseInt(customEvent.start.slice(0, 2)),
+        minutes: parseInt(customEvent.start.slice(3, 5)),
+    });
+    const endTime = set(baseDate, {
+        hours: parseInt(customEvent.end.slice(0, 2)),
+        minutes: parseInt(customEvent.end.slice(3, 5)),
+    });
+
+    if (!isValid(startTime) || !isValid(endTime)) {
+        return `${customEvent.start} — ${customEvent.end}`;
+    }
+
+    const dayAbbreviations = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const daysString = customEvent.days
+        .map((includeDate, index) => (includeDate ? dayAbbreviations[index] : ''))
+        .join(' ');
+
+    const timeFormat = isMilitaryTime ? 'HH:mm' : 'h:mm a';
+    return `${format(startTime, timeFormat)} — ${format(endTime, timeFormat)} • ${daysString}`;
+}
+
+function FriendCourseRow({ course }: { course: ScheduleCourse }) {
+    return (
+        <Paper variant="outlined" sx={{ p: 1.5 }}>
+            <Typography variant="subtitle2" fontWeight={600}>
+                {course.deptCode} {course.courseNumber}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+                {course.courseTitle}
+            </Typography>
+            <Box display="flex" flexWrap="wrap" gap={0.5} mt={1}>
+                <Chip size="small" label={course.section.sectionCode} />
+                <Chip size="small" label={course.section.sectionType} />
+            </Box>
+        </Paper>
+    );
+}
+
+export function FriendSchedule() {
+    const [courses, setCourses] = useState(() => FriendsStore.schedule.getCurrentCourses());
+    const [customEvents, setCustomEvents] = useState(() => FriendsStore.schedule.getCurrentCustomEvents());
+    const [scheduleNote, setScheduleNote] = useState(() => FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '');
+    const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
+
+    const syncFromStore = useCallback(() => {
+        setCourses(FriendsStore.schedule.getCurrentCourses());
+        setCustomEvents(FriendsStore.schedule.getCurrentCustomEvents());
+        setScheduleNote(FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '');
+    }, []);
+
+    useEffect(() => {
+        FriendsStore.on('scheduleChange', syncFromStore);
+        FriendsStore.on('friendViewChange', syncFromStore);
+
+        return () => {
+            FriendsStore.off('scheduleChange', syncFromStore);
+            FriendsStore.off('friendViewChange', syncFromStore);
+        };
+    }, [syncFromStore]);
+
+    return (
+        <Box display="flex" flexDirection="column" gap={2}>
+            <Typography variant="h6">Added Courses</Typography>
+
+            {courses.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                    No courses in this schedule.
+                </Typography>
+            ) : (
+                <Box display="flex" flexDirection="column" gap={1}>
+                    {courses.map((course) => (
+                        <FriendCourseRow key={course.section.sectionCode} course={course} />
+                    ))}
+                </Box>
+            )}
+
+            {customEvents.length > 0 && (
+                <>
+                    <Typography variant="h6">Custom Events</Typography>
+                    <Box display="flex" flexDirection="column" gap={1}>
+                        {customEvents.map((customEvent) => (
+                            <Card key={customEvent.customEventID}>
+                                <CardHeader
+                                    title={customEvent.title}
+                                    slotProps={{ title: { variant: 'subtitle1' } }}
+                                    subheader={formatCustomEventTime(customEvent, isMilitaryTime)}
+                                    sx={{ padding: 1 }}
+                                />
+                                {customEvent.building != null && customEvent.building !== '' && (
+                                    <CardContent sx={{ paddingX: 1, paddingY: 0 }}>
+                                        {buildingCatalogue[+customEvent.building]?.name ?? customEvent.building}
+                                    </CardContent>
+                                )}
+                            </Card>
+                        ))}
+                    </Box>
+                </>
+            )}
+
+            {scheduleNote.length > 0 && (
+                <Box>
+                    <Typography variant="h6">Schedule Notes</Typography>
+                    <TextField
+                        value={scheduleNote}
+                        multiline
+                        fullWidth
+                        disabled
+                        variant="filled"
+                        InputProps={{ disableUnderline: true }}
+                    />
+                </Box>
+            )}
+        </Box>
+    );
+}

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
@@ -1,10 +1,9 @@
 import { AddedSectionsGrid } from '$components/RightPane/AddedCourses/AddedSectionsGrid';
-import { CoursePaneRoot } from '$components/RightPane/CoursePane/CoursePaneRoot';
 import darkModeLoadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/dark-loading.gif';
 import loadingGif from '$components/RightPane/CoursePane/SearchForm/Gifs/loading.gif';
 import { useFriendScheduleTab, type FriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
 import { useThemeStore } from '$stores/SettingsStore';
-import { FormatListBulleted, MyLocation, Search } from '@mui/icons-material';
+import { FormatListBulleted, MyLocation } from '@mui/icons-material';
 import { Box, Paper, Stack, Tab, Tabs } from '@mui/material';
 import Image from 'next/image';
 import { lazy, Suspense } from 'react';
@@ -12,9 +11,8 @@ import { lazy, Suspense } from 'react';
 const UCIMap = lazy(() => import('$components/Map/Map'));
 
 const friendScheduleTabIndex: Record<FriendScheduleTab, number> = {
-    search: 0,
-    added: 1,
-    map: 2,
+    added: 0,
+    map: 1,
 };
 
 export function FriendSchedule() {
@@ -47,19 +45,11 @@ export function FriendSchedule() {
                     centered
                 >
                     <Tab
-                        id="friend-search-tab"
-                        icon={<Search />}
-                        iconPosition="start"
-                        label="Search"
-                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
-                        onClick={() => setActiveTab('search')}
-                    />
-                    <Tab
                         id="friend-added-courses-tab"
                         icon={<FormatListBulleted />}
                         iconPosition="start"
                         label="Added"
-                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '50%' }}
                         onClick={() => setActiveTab('added')}
                     />
                     <Tab
@@ -67,7 +57,7 @@ export function FriendSchedule() {
                         icon={<MyLocation />}
                         iconPosition="start"
                         label="Map"
-                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '33%' }}
+                        sx={{ minHeight: 'auto', height: '44px', padding: 3, minWidth: '50%' }}
                         onClick={() => setActiveTab('map')}
                     />
                 </Tabs>
@@ -83,9 +73,7 @@ export function FriendSchedule() {
                 padding={1}
                 sx={{ WebkitOverflowScrolling: 'touch' }}
             >
-                {activeTab === 'search' ? (
-                    <CoursePaneRoot />
-                ) : activeTab === 'added' ? (
+                {activeTab === 'added' ? (
                     <AddedSectionsGrid />
                 ) : (
                     <Suspense

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FriendSchedule.tsx
@@ -24,7 +24,7 @@ export function FriendSchedule() {
 
     return (
         <FriendScheduleTabProvider activeTab={activeTab} setActiveTab={setActiveTab}>
-            <Stack direction="column" flexGrow={1} height="100%" minHeight={0}>
+            <Stack direction="column" flexGrow={1} height={0} minHeight={0} overflow="hidden">
                 <Paper
                     elevation={0}
                     variant="outlined"
@@ -71,11 +71,13 @@ export function FriendSchedule() {
 
                 <Box
                     flexGrow={1}
+                    height={0}
                     minHeight={0}
                     overflow={activeTab === 'map' ? 'hidden' : 'auto'}
                     display="flex"
                     flexDirection="column"
                     padding={1}
+                    sx={{ WebkitOverflowScrolling: 'touch' }}
                 >
                     {activeTab === 'search' ? (
                         <CoursePaneRoot />

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -10,6 +10,7 @@ import { useDraggingItemState } from '$hooks/useDraggingItemState';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { AnalyticsCategory } from '$lib/analytics/analytics';
 import { getCourseCancellationWarning } from '$lib/courseAvailability';
+import { useFriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
 import { useScheduleViewSource } from '$lib/schedule/ScheduleViewContext';
 import { SECTION_TABLE_COLUMNS, type SectionTableColumn, useColumnStore } from '$stores/ColumnStore';
 import { useTimeFormatStore } from '$stores/SettingsStore';
@@ -97,13 +98,16 @@ function SectionTable({
     const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
 
     const scheduleSource = useScheduleViewSource();
+    const friendScheduleTab = useFriendScheduleTab();
     const showActionColumn = !scheduleSource.readonly;
     const activeColumns = useColumnStore((store) => store.activeColumns);
     const displayColumns = useMemo(
         () => (showActionColumn ? activeColumns : activeColumns.filter((column) => column !== 'action')),
         [activeColumns, showActionColumn]
     );
-    const activeTab = useTabStore((store) => store.activeTab);
+    const homeActiveTab = useTabStore((store) => store.activeTab);
+    const showCourseInfoSearchButton =
+        scheduleSource.scope === 'friend' ? friendScheduleTab?.activeTab === 'added' : homeActiveTab === 2;
 
     const handleToggleExpand = () => {
         setOpenContent(!openContent);
@@ -194,9 +198,9 @@ function SectionTable({
                     skeleton
                 )}
 
-                {activeTab !== 2
-                    ? null
-                    : wrapSkeleton(<CourseInfoSearchButton courseDetails={courseDetails} term={term} />, skeleton)}
+                {showCourseInfoSearchButton
+                    ? wrapSkeleton(<CourseInfoSearchButton courseDetails={courseDetails} term={term} />, skeleton)
+                    : null}
 
                 {wrapSkeleton(
                     <CourseInfoButton

--- a/apps/antalmanac/src/components/buttons/MapLink.tsx
+++ b/apps/antalmanac/src/components/buttons/MapLink.tsx
@@ -1,5 +1,7 @@
+import { useFriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
+import { useScheduleViewSource } from '$lib/schedule/ScheduleViewContext';
 import { useTabStore } from '$stores/TabStore';
-import { useCallback } from 'react';
+import { useCallback, type MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 
 interface MapLinkProps {
@@ -7,21 +9,37 @@ interface MapLinkProps {
     room: string;
 }
 
+const linkStyle = { textDecoration: 'none' } as const;
+
 export const MapLink = ({ buildingId, room }: MapLinkProps) => {
+    const scheduleSource = useScheduleViewSource();
+    const friendScheduleTab = useFriendScheduleTab();
     const setActiveTab = useTabStore((store) => store.setActiveTab);
 
-    const focusMap = useCallback(() => {
+    const isFriendMap = scheduleSource.scope === 'friend' && friendScheduleTab != null;
+
+    const handleFriendMapClick = useCallback(
+        (e: MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault();
+            friendScheduleTab?.focusMapLocation(buildingId);
+        },
+        [buildingId, friendScheduleTab]
+    );
+
+    const handleHomeMapClick = useCallback(() => {
         setActiveTab('map');
     }, [setActiveTab]);
 
+    if (isFriendMap) {
+        return (
+            <a href="#" onClick={handleFriendMapClick} style={linkStyle}>
+                {room}
+            </a>
+        );
+    }
+
     return (
-        <Link
-            to={`/map?location=${buildingId}`}
-            onClick={focusMap}
-            style={{
-                textDecoration: 'none',
-            }}
-        >
+        <Link to={`/map?location=${buildingId}`} onClick={handleHomeMapClick} style={linkStyle}>
             {room}
         </Link>
     );

--- a/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
+++ b/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
@@ -4,7 +4,7 @@ import { Stack, Dialog, DialogTitle, DialogContent, Alert } from '@mui/material'
 
 interface SignInDialogProps {
     open: boolean;
-    feature: 'Load' | 'Save' | 'Notification' | 'Planner' | 'PlannerSearch';
+    feature: 'Load' | 'Save' | 'Notification' | 'Planner' | 'PlannerSearch' | 'Friends';
     onClose: () => void;
 }
 
@@ -24,6 +24,8 @@ export function SignInDialog(props: SignInDialogProps) {
                 return 'Sign in to Use Filter by Planner';
             case 'PlannerSearch':
                 return 'Sign in to search with Planner';
+            case 'Friends':
+                return 'Sign in to Use Friends';
             case 'Save':
             default:
                 return 'Save';

--- a/apps/antalmanac/src/hooks/useQuickSearch.tsx
+++ b/apps/antalmanac/src/hooks/useQuickSearch.tsx
@@ -1,4 +1,6 @@
 import RightPaneStore from '$components/RightPane/RightPaneStore';
+import { useFriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
+import { useScheduleViewSource } from '$lib/schedule/ScheduleViewContext';
 import { AATerm } from '$lib/term';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { useTabStore } from '$stores/TabStore';
@@ -7,6 +9,8 @@ import { useNavigate } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
 export function useQuickSearch() {
+    const scheduleSource = useScheduleViewSource();
+    const friendScheduleTab = useFriendScheduleTab();
     const { displaySections, forceUpdate } = useCoursePaneStore(
         useShallow((s) => ({ displaySections: s.displaySections, forceUpdate: s.forceUpdate }))
     );
@@ -15,6 +19,18 @@ export function useQuickSearch() {
 
     return useCallback(
         (deptValue: string, courseNumber: string, term: AATerm) => {
+            RightPaneStore.resetFormValues();
+            RightPaneStore.updateFormValue('deptValue', deptValue);
+            RightPaneStore.updateFormValue('courseNumber', courseNumber);
+            RightPaneStore.setTerm(term);
+            displaySections();
+            forceUpdate();
+
+            if (scheduleSource.scope === 'friend' && friendScheduleTab) {
+                friendScheduleTab.setActiveTab('search');
+                return;
+            }
+
             const queryParams = {
                 term: term.shortName,
                 deptValue: deptValue,
@@ -25,15 +41,9 @@ export function useQuickSearch() {
                 .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
                 .join('&')}`;
 
-            RightPaneStore.resetFormValues();
-            RightPaneStore.updateFormValue('deptValue', deptValue);
-            RightPaneStore.updateFormValue('courseNumber', courseNumber);
-            RightPaneStore.setTerm(term);
             navigate(href, { replace: false });
             setActiveTab('search');
-            displaySections();
-            forceUpdate();
         },
-        [displaySections, forceUpdate, navigate, setActiveTab]
+        [displaySections, forceUpdate, friendScheduleTab, navigate, scheduleSource.scope, setActiveTab]
     );
 }

--- a/apps/antalmanac/src/hooks/useQuickSearch.tsx
+++ b/apps/antalmanac/src/hooks/useQuickSearch.tsx
@@ -1,5 +1,4 @@
 import RightPaneStore from '$components/RightPane/RightPaneStore';
-import { useFriendScheduleTab } from '$lib/schedule/FriendScheduleTabContext';
 import { useScheduleViewSource } from '$lib/schedule/ScheduleViewContext';
 import { AATerm } from '$lib/term';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
@@ -10,7 +9,6 @@ import { useShallow } from 'zustand/react/shallow';
 
 export function useQuickSearch() {
     const scheduleSource = useScheduleViewSource();
-    const friendScheduleTab = useFriendScheduleTab();
     const { displaySections, forceUpdate } = useCoursePaneStore(
         useShallow((s) => ({ displaySections: s.displaySections, forceUpdate: s.forceUpdate }))
     );
@@ -26,8 +24,7 @@ export function useQuickSearch() {
             displaySections();
             forceUpdate();
 
-            if (scheduleSource.scope === 'friend' && friendScheduleTab) {
-                friendScheduleTab.setActiveTab('search');
+            if (scheduleSource.scope === 'friend') {
                 return;
             }
 
@@ -44,6 +41,6 @@ export function useQuickSearch() {
             navigate(href, { replace: false });
             setActiveTab('search');
         },
-        [displaySections, forceUpdate, friendScheduleTab, navigate, scheduleSource.scope, setActiveTab]
+        [displaySections, forceUpdate, navigate, scheduleSource.scope, setActiveTab]
     );
 }

--- a/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
+++ b/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+export type FriendScheduleTab = 'search' | 'added' | 'map';
+
+interface FriendScheduleTabContextValue {
+    activeTab: FriendScheduleTab;
+    setActiveTab: (tab: FriendScheduleTab) => void;
+}
+
+const FriendScheduleTabContext = createContext<FriendScheduleTabContextValue | null>(null);
+
+export function FriendScheduleTabProvider({
+    activeTab,
+    setActiveTab,
+    children,
+}: FriendScheduleTabContextValue & { children: ReactNode }) {
+    return (
+        <FriendScheduleTabContext.Provider value={{ activeTab, setActiveTab }}>
+            {children}
+        </FriendScheduleTabContext.Provider>
+    );
+}
+
+export function useFriendScheduleTab() {
+    return useContext(FriendScheduleTabContext);
+}

--- a/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
+++ b/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
@@ -7,6 +7,9 @@ export type FriendScheduleTab = 'search' | 'added' | 'map';
 interface FriendScheduleTabContextValue {
     activeTab: FriendScheduleTab;
     setActiveTab: (tab: FriendScheduleTab) => void;
+    mapLocationId?: number;
+    setMapLocationId: (locationId: number | undefined) => void;
+    focusMapLocation: (buildingId: number) => void;
 }
 
 const FriendScheduleTabContext = createContext<FriendScheduleTabContextValue | null>(null);
@@ -14,10 +17,15 @@ const FriendScheduleTabContext = createContext<FriendScheduleTabContextValue | n
 export function FriendScheduleTabProvider({
     activeTab,
     setActiveTab,
+    mapLocationId,
+    setMapLocationId,
+    focusMapLocation,
     children,
 }: FriendScheduleTabContextValue & { children: ReactNode }) {
     return (
-        <FriendScheduleTabContext.Provider value={{ activeTab, setActiveTab }}>
+        <FriendScheduleTabContext.Provider
+            value={{ activeTab, setActiveTab, mapLocationId, setMapLocationId, focusMapLocation }}
+        >
             {children}
         </FriendScheduleTabContext.Provider>
     );

--- a/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
+++ b/apps/antalmanac/src/lib/schedule/FriendScheduleTabContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from 'react';
 
-export type FriendScheduleTab = 'search' | 'added' | 'map';
+export type FriendScheduleTab = 'added' | 'map';
 
 interface FriendScheduleTabContextValue {
     activeTab: FriendScheduleTab;

--- a/apps/antalmanac/src/lib/schedule/ScheduleViewContext.tsx
+++ b/apps/antalmanac/src/lib/schedule/ScheduleViewContext.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { friendScheduleViewSource } from '$lib/schedule/friendScheduleViewSource';
 import type { ScheduleViewSource } from '$lib/schedule/ScheduleViewSource';
 import AppStore from '$stores/AppStore';
 import { createContext, useContext, type ReactNode } from 'react';
@@ -8,6 +9,11 @@ const ScheduleViewContext = createContext<ScheduleViewSource>(AppStore);
 
 export function ScheduleViewProvider({ source, children }: { source: ScheduleViewSource; children: ReactNode }) {
     return <ScheduleViewContext.Provider value={source}>{children}</ScheduleViewContext.Provider>;
+}
+
+/** Provider for the friend schedule dialog — calendar reads from FriendsStore, not AppStore. */
+export function FriendScheduleViewProvider({ children }: { children: ReactNode }) {
+    return <ScheduleViewProvider source={friendScheduleViewSource}>{children}</ScheduleViewProvider>;
 }
 
 export function useScheduleViewSource(): ScheduleViewSource {

--- a/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
+++ b/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
@@ -3,6 +3,32 @@ import FriendsStore from '$stores/FriendsStore';
 
 const FRIEND_STORE_EVENTS = ['friendViewChange', 'scheduleChange'] as const;
 
+const friendScheduleListeners = new Set<() => void>();
+let unsubscribeFromFriendsStore: (() => void) | null = null;
+
+function notifyFriendScheduleListeners() {
+    for (const listener of friendScheduleListeners) {
+        listener();
+    }
+}
+
+function ensureFriendsStoreSubscription() {
+    if (unsubscribeFromFriendsStore) {
+        return;
+    }
+
+    for (const event of FRIEND_STORE_EVENTS) {
+        FriendsStore.on(event, notifyFriendScheduleListeners);
+    }
+
+    unsubscribeFromFriendsStore = () => {
+        for (const event of FRIEND_STORE_EVENTS) {
+            FriendsStore.off(event, notifyFriendScheduleListeners);
+        }
+        unsubscribeFromFriendsStore = null;
+    };
+}
+
 export const friendScheduleViewSource: ScheduleViewSource = {
     scope: 'friend',
     readonly: true,
@@ -27,12 +53,13 @@ export const friendScheduleViewSource: ScheduleViewSource = {
     },
 
     subscribe: (onChange) => {
-        for (const event of FRIEND_STORE_EVENTS) {
-            FriendsStore.on(event, onChange);
-        }
+        friendScheduleListeners.add(onChange);
+        ensureFriendsStoreSubscription();
+
         return () => {
-            for (const event of FRIEND_STORE_EVENTS) {
-                FriendsStore.off(event, onChange);
+            friendScheduleListeners.delete(onChange);
+            if (friendScheduleListeners.size === 0 && unsubscribeFromFriendsStore) {
+                unsubscribeFromFriendsStore();
             }
         };
     },

--- a/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
+++ b/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
@@ -1,0 +1,37 @@
+import type { ScheduleViewSource } from '$lib/schedule/ScheduleViewSource';
+import FriendsStore from '$stores/FriendsStore';
+
+const FRIEND_STORE_EVENTS = ['friendViewChange', 'scheduleChange'] as const;
+
+export const friendScheduleViewSource: ScheduleViewSource = {
+    scope: 'friend',
+    readonly: true,
+    appliesCourseVisibility: false,
+
+    get schedule() {
+        return FriendsStore.schedule;
+    },
+
+    getScheduleNames: () => FriendsStore.getFriendScheduleNames(),
+    getCurrentScheduleIndex: () => FriendsStore.schedule.getCurrentScheduleIndex(),
+    getCurrentScheduleId: () => FriendsStore.schedule.getCurrentScheduleId(),
+    getEventsInCalendar: () => FriendsStore.schedule.getCalendarizedEvents(),
+    getFinalEventsInCalendar: () => FriendsStore.schedule.getCalendarizedFinals(),
+    getCurrentScheduleNote: () => FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '',
+    getCurrentCustomEvents: () => FriendsStore.getCurrentFriendSchedule().customEvents,
+
+    changeCurrentSchedule: (index) => {
+        FriendsStore.changeCurrentSchedule(index);
+    },
+
+    subscribe: (onChange) => {
+        for (const event of FRIEND_STORE_EVENTS) {
+            FriendsStore.on(event, onChange);
+        }
+        return () => {
+            for (const event of FRIEND_STORE_EVENTS) {
+                FriendsStore.off(event, onChange);
+            }
+        };
+    },
+};

--- a/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
+++ b/apps/antalmanac/src/lib/schedule/friendScheduleViewSource.ts
@@ -17,6 +17,8 @@ export const friendScheduleViewSource: ScheduleViewSource = {
     getCurrentScheduleId: () => FriendsStore.schedule.getCurrentScheduleId(),
     getEventsInCalendar: () => FriendsStore.schedule.getCalendarizedEvents(),
     getFinalEventsInCalendar: () => FriendsStore.schedule.getCalendarizedFinals(),
+    getCourseEventsInCalendar: () => FriendsStore.schedule.getCalendarizedCourseEvents(),
+    getCustomEventsInCalendar: () => FriendsStore.schedule.getCalendarizedCustomEvents(),
     getCurrentScheduleNote: () => FriendsStore.getCurrentFriendSchedule().scheduleNote ?? '',
     getCurrentCustomEvents: () => FriendsStore.getCurrentFriendSchedule().customEvents,
 

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -1,5 +1,6 @@
 import { AuthInitializer } from '$components/AuthInitializer';
 import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
+import { FriendScheduleDialog } from '$components/Header/Friends/FriendScheduleDialog';
 import { Header } from '$components/Header/Header';
 import { KeyboardShortcutsModal } from '$components/KeyboardShortcutsModal/KeyboardShortcutsModal';
 import { NotificationSnackbar } from '$components/NotificationSnackbar';
@@ -93,6 +94,7 @@ export default function Home() {
 
             <NotificationSnackbar />
             <ReviewPrompt />
+            <FriendScheduleDialog />
             <KeyboardShortcutsModal open={shortcutsOpen} onClose={closeShortcutsModal} />
         </LocalizationProvider>
     );

--- a/apps/antalmanac/src/stores/FriendsStore.ts
+++ b/apps/antalmanac/src/stores/FriendsStore.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'events';
+
+import { trpc } from '$lib/api/trpc';
+import { Schedules } from '$stores/Schedules';
+import type { ShortCourseSchedule } from '@packages/antalmanac-types';
+
+/**
+ * Holds a friend's schedule data separately from the user's AppStore schedule.
+ * Friend schedules are shown in a modal dialog on the home page.
+ */
+class FriendsStore extends EventEmitter {
+    schedule: Schedules;
+
+    private dialogOpen = false;
+
+    private loading = false;
+
+    private friendId: string | null = null;
+
+    private friendName: string | null = null;
+
+    private friendSchedules: ShortCourseSchedule[] = [];
+
+    constructor() {
+        super();
+        this.schedule = new Schedules();
+    }
+
+    isDialogOpen() {
+        return this.dialogOpen;
+    }
+
+    isLoading() {
+        return this.loading;
+    }
+
+    getFriendId() {
+        return this.friendId;
+    }
+
+    getFriendName() {
+        return this.friendName;
+    }
+
+    getFriendScheduleNames(): string[] {
+        return this.friendSchedules.map((schedule) => schedule.scheduleName);
+    }
+
+    getCurrentFriendSchedule(): ShortCourseSchedule {
+        const schedule = this.friendSchedules[this.schedule.getCurrentScheduleIndex()];
+        if (!schedule) {
+            return {
+                id: undefined,
+                scheduleName: '',
+                courses: [],
+                customEvents: [],
+                scheduleNote: '',
+            };
+        }
+        return schedule;
+    }
+
+    async openFriendView(userId: string, friendName: string): Promise<boolean> {
+        this.dialogOpen = true;
+        this.loading = true;
+        this.friendId = userId;
+        this.friendName = friendName;
+        this.emit('friendViewChange');
+
+        try {
+            const data = await trpc.schedule.getFriendUserData.query({ userId });
+
+            if (!data?.userData?.schedules?.length) {
+                this.dialogOpen = false;
+                this.friendId = null;
+                this.friendName = null;
+                return false;
+            }
+
+            this.friendName = data.name ?? data.email ?? friendName;
+            await this.schedule.fromScheduleSaveState(data.userData);
+            this.friendSchedules = data.userData.schedules;
+            this.emit('scheduleChange');
+            return true;
+        } catch {
+            this.dialogOpen = false;
+            this.friendId = null;
+            this.friendName = null;
+            return false;
+        } finally {
+            this.loading = false;
+            this.emit('friendViewChange');
+        }
+    }
+
+    closeFriendView() {
+        this.dialogOpen = false;
+        this.loading = false;
+        this.friendId = null;
+        this.friendName = null;
+        this.friendSchedules = [];
+        this.schedule = new Schedules();
+        this.emit('friendViewChange');
+        this.emit('scheduleChange');
+    }
+
+    changeCurrentSchedule(newScheduleIndex: number) {
+        this.schedule.setCurrentScheduleIndex(newScheduleIndex);
+        this.emit('scheduleChange');
+    }
+}
+
+const friendsStore = new FriendsStore();
+
+export default friendsStore;

--- a/apps/antalmanac/src/stores/SelectedEventStore.ts
+++ b/apps/antalmanac/src/stores/SelectedEventStore.ts
@@ -1,21 +1,33 @@
 import type { CalendarEvent } from '$components/Calendar/CourseCalendarEvent';
+import type { ScheduleViewScope } from '$lib/schedule/ScheduleViewSource';
 import { SyntheticEvent } from 'react';
 import { create } from 'zustand';
 
 interface SelectedEventStore {
     selectedEvent: CalendarEvent | null;
     selectedEventAnchorEl: Element | null;
-    setSelectedEvent: (anchorEl: SyntheticEvent | null, selectedEvent: CalendarEvent | null) => void;
+    selectedEventScope: ScheduleViewScope | null;
+    setSelectedEvent: (
+        anchorEl: SyntheticEvent | null,
+        selectedEvent: CalendarEvent | null,
+        scope?: ScheduleViewScope | null
+    ) => void;
 }
 
 export const useSelectedEventStore = create<SelectedEventStore>((set) => {
     return {
         selectedEvent: null,
         selectedEventAnchorEl: null,
-        setSelectedEvent: (anchorEl: SyntheticEvent | null, selectedEvent: CalendarEvent | null) => {
+        selectedEventScope: null,
+        setSelectedEvent: (
+            anchorEl: SyntheticEvent | null,
+            selectedEvent: CalendarEvent | null,
+            scope: ScheduleViewScope | null = null
+        ) => {
             set({
                 selectedEvent: selectedEvent,
                 selectedEventAnchorEl: anchorEl?.currentTarget,
+                selectedEventScope: selectedEvent ? scope : null,
             });
         },
     };


### PR DESCRIPTION
## Summary
Implementation of Friend Dialog and dealing with read-only + omitting features + ensuring reuse of existing calendar UI. 

- `FriendsStore` — Holds friend schedule data separately from AppStore. Fetches via trpc.schedule.getFriendUserData and drives dialog open/close/loading state.
- `friendScheduleViewSource` — Read-only ScheduleViewSource (scope: 'friend') wired through a new FriendScheduleViewProvider, so ScheduleCalendar, toolbar, and event popover render friend data without touching the user's home schedule.
- Friend schedule dialog — `FriendScheduleDialog` → `FriendScheduleView` (split calendar + course list on desktop, stacked on mobile). Includes a read-only FriendSchedule course list with schedule notes.
- Minimal entry point — Header Friends button opens a popover listing friends with a View action. Unauthenticated users get the sign-in dialog. Full friends management UI (requests, search, unfriend) is deferred to PR3.
- Scope isolation — SelectedEventStore tracks selectedEventScope so event popovers don't bleed between home and friend views. Calendar toolbar hides edit actions (undo/redo, custom events, screenshot, download, clear) in readonly friend view; schedule select and finals toggle remain available.

## Intentional Things Omitted from this PR and will go into PR3
- Friends popover UI (requests tab, friend search, send/cancel requests, unfriend)
- Share-schedule privacy toggles

**`FriendScheduleEntry.tsx` is a thin placeholder UI. It is immediately deleted in PR3**

## Test Plan
- [ ] Home regression: Add/remove courses, switch schedules, open event popover, toggle finals — home schedule unchanged after viewing a friend
- [ ] Sign-in gate: Click Friends while logged out → sign-in dialog appears
- [ ] Friend list: Log in, open Friends popover → friends load; click View on a friend with shared schedules
- [ ] Friend dialog: Dialog opens with loading state, then calendar + course list; switch between friend's schedules via schedule select
- [ ] Readonly UI: No undo/redo, custom event, screenshot, download, or clear buttons in friend dialog; event popover shows course info without delete/color/quick search
- [ ] Scope isolation: Open schedule select or event popover in friend dialog → does not affect home calendar behind the dialog
- [ ] Empty/error cases: Friend with no shared schedules shows appropriate feedback; close dialog returns to normal home view
- [ ] Mobile: Friend dialog layout stacks calendar above course list

## Issues

Depends on #1850
Closes #

<!-- [Optional]
## Future Followup
-->
