### PR TITLE
Add Turbopack bundle analyzer baseline tooling

### DIFF
--- a/apps/antalmanac/bundle-baselines/main.json
+++ b/apps/antalmanac/bundle-baselines/main.json
@@ -1,0 +1,52 @@
+{
+  "capturedAt": "2026-06-09",
+  "analyzer": "next-experimental-analyze",
+  "nextVersion": "16.2.6",
+  "chunks": [
+    {
+      "name": "64e504f815854219.js",
+      "bytes": 618058,
+      "kilobytes": 603.6
+    },
+    {
+      "name": "29df097d1082f81a.js",
+      "bytes": 410979,
+      "kilobytes": 401.3
+    },
+    {
+      "name": "0dcb8fbb7c502475.js",
+      "bytes": 143238,
+      "kilobytes": 139.9
+    },
+    {
+      "name": "a6dad97d9634a72d.js",
+      "bytes": 112594,
+      "kilobytes": 110
+    },
+    {
+      "name": "b607dc4daafe934d.js",
+      "bytes": 47447,
+      "kilobytes": 46.3
+    },
+    {
+      "name": "14ceeeaa07f3cde1.js",
+      "bytes": 26850,
+      "kilobytes": 26.2
+    },
+    {
+      "name": "turbopack-03041747c8de0c84.js",
+      "bytes": 18251,
+      "kilobytes": 17.8
+    }
+  ],
+  "summary": {
+    "chunkCount": 7,
+    "totalBytes": 1377417,
+    "totalKilobytes": 1345.1,
+    "largestChunk": {
+      "name": "64e504f815854219.js",
+      "bytes": 618058,
+      "kilobytes": 603.6
+    }
+  }
+}

--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -16,7 +16,9 @@
         "fetch-departments": "tsx scripts/fetch-departments.ts",
         "get-data": "tsx scripts/fetch-term-data.ts && tsx scripts/fetch-departments.ts && tsx scripts/get-search-data.ts",
         "update-terms": "tsx scripts/update-terms.ts",
-        "build": "next build"
+        "build": "next build",
+        "analyze": "next experimental-analyze",
+        "analyze:baseline": "next experimental-analyze --output && tsx scripts/print-bundle-baseline.ts --write"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/apps/antalmanac/scripts/print-bundle-baseline.ts
+++ b/apps/antalmanac/scripts/print-bundle-baseline.ts
@@ -1,0 +1,138 @@
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { GENERATED_DIR } from './lib/paths.js';
+
+const APP_ROOT = join(import.meta.dirname, '..');
+const ANALYZE_CHUNKS_DIR = join(APP_ROOT, '.next/diagnostics/analyze/_next/static/chunks');
+const BASELINE_FILE = join(APP_ROOT, 'bundle-baselines/main.json');
+
+interface ChunkEntry {
+    name: string;
+    bytes: number;
+    kilobytes: number;
+}
+
+interface BundleBaseline {
+    capturedAt: string;
+    analyzer: 'next-experimental-analyze';
+    nextVersion: string;
+    chunks: ChunkEntry[];
+    summary: {
+        chunkCount: number;
+        totalBytes: number;
+        totalKilobytes: number;
+        largestChunk: ChunkEntry;
+    };
+}
+
+async function listChunkSizes(directory: string): Promise<ChunkEntry[]> {
+    let files: string[];
+    try {
+        files = await readdir(directory);
+    } catch {
+        throw new Error(
+            `No analyze output found at ${directory}. Run "pnpm analyze:baseline" first (requires generated term/search data).`
+        );
+    }
+
+    const chunks: ChunkEntry[] = [];
+
+    for (const file of files) {
+        if (!file.endsWith('.js')) {
+            continue;
+        }
+
+        const filePath = join(directory, file);
+        const fileStat = await stat(filePath);
+        chunks.push({
+            name: file,
+            bytes: fileStat.size,
+            kilobytes: Number((fileStat.size / 1024).toFixed(1)),
+        });
+    }
+
+    return chunks.sort((a, b) => b.bytes - a.bytes);
+}
+
+async function readPackageVersion(): Promise<string> {
+    const packageJson = JSON.parse(await readFile(join(APP_ROOT, 'package.json'), 'utf8')) as {
+        dependencies?: { next?: string };
+    };
+    return packageJson.dependencies?.next ?? 'unknown';
+}
+
+async function buildBaseline(): Promise<BundleBaseline> {
+    const chunks = await listChunkSizes(ANALYZE_CHUNKS_DIR);
+    const totalBytes = chunks.reduce((sum, chunk) => sum + chunk.bytes, 0);
+
+    return {
+        capturedAt: new Date().toISOString().slice(0, 10),
+        analyzer: 'next-experimental-analyze',
+        nextVersion: await readPackageVersion(),
+        chunks,
+        summary: {
+            chunkCount: chunks.length,
+            totalBytes,
+            totalKilobytes: Number((totalBytes / 1024).toFixed(1)),
+            largestChunk: chunks[0],
+        },
+    };
+}
+
+function printBaseline(baseline: BundleBaseline) {
+    console.log(`Bundle baseline (${baseline.analyzer}, Next ${baseline.nextVersion})`);
+    console.log(`Captured: ${baseline.capturedAt}`);
+    console.log(`Client chunks: ${baseline.summary.chunkCount} files, ${baseline.summary.totalKilobytes} KiB total`);
+    console.log(
+        `Largest chunk: ${baseline.summary.largestChunk.name} (${baseline.summary.largestChunk.kilobytes} KiB)`
+    );
+    console.log('');
+    console.log('Top chunks:');
+
+    for (const chunk of baseline.chunks.slice(0, 10)) {
+        console.log(`  ${chunk.kilobytes.toString().padStart(7)} KiB  ${chunk.name}`);
+    }
+}
+
+async function assertGeneratedDataPresent() {
+    const requiredFiles = ['termData.json', 'searchData.json'];
+    const missing = [];
+
+    for (const file of requiredFiles) {
+        try {
+            await stat(join(GENERATED_DIR, file));
+        } catch {
+            missing.push(file);
+        }
+    }
+
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing generated data: ${missing.join(', ')}. Run "pnpm get-data" with ANTEATER_API_KEY before analyze:baseline.`
+        );
+    }
+}
+
+async function main() {
+    const shouldWrite = process.argv.includes('--write');
+
+    if (shouldWrite) {
+        await assertGeneratedDataPresent();
+    }
+
+    const baseline = await buildBaseline();
+    printBaseline(baseline);
+
+    if (shouldWrite) {
+        await mkdir(join(APP_ROOT, 'bundle-baselines'), { recursive: true });
+        await writeFile(BASELINE_FILE, `${JSON.stringify(baseline, null, 2)}\n`);
+        console.log('');
+        console.log(`Wrote ${BASELINE_FILE}`);
+    }
+}
+
+main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
         "test": "vitest",
         "deploy": "sst deploy --stage production",
         "format": "oxfmt",
-        "lint": "oxlint --deny-warnings"
+        "lint": "oxlint --deny-warnings",
+        "analyze": "pnpm --filter antalmanac analyze",
+        "analyze:baseline": "pnpm --filter antalmanac analyze:baseline"
     },
     "devDependencies": {
         "@total-typescript/tsconfig": "^1.0.4",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds bundle analysis tooling for the AntAlmanac Next.js app using the native Turbopack analyzer (`next experimental-analyze`), which matches our production bundler (Next.js 16 defaults to Turbopack).

**New scripts:**
- `pnpm analyze` — interactive treemap UI (opens in browser)
- `pnpm analyze:baseline` — writes analysis to `.next/diagnostics/analyze` and updates `bundle-baselines/main.json`

**Baseline snapshot (2026-06-09):**
- 7 client chunks, **1,345 KiB total**
- Largest chunk: **604 KiB** (`64e504f815854219.js`)

## Test Plan

- [x] `pnpm analyze:baseline` completes successfully
- [x] `bundle-baselines/main.json` written with chunk size summary
- [x] Lint passes on `print-bundle-baseline.ts`

**To run locally:**
```bash
pnpm get-data   # requires ANTEATER_API_KEY
pnpm analyze:baseline
```

For interactive exploration without writing files:
```bash
pnpm analyze
```

## Notes

`analyze:baseline` requires generated `termData.json` and `searchData.json` (via `pnpm get-data`). The committed baseline was captured against minimal local generated data; re-run after `get-data` in CI/production for a fully representative snapshot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc038415-fa10-4f1f-a0b3-b99184e1c0a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc038415-fa10-4f1f-a0b3-b99184e1c0a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

