### PR TITLE
refactor: change BuildingSelect options to single-pass dedupe

### DIFF
--- a/apps/antalmanac/src/components/inputs/BuildingSelect.tsx
+++ b/apps/antalmanac/src/components/inputs/BuildingSelect.tsx
@@ -8,14 +8,19 @@ export interface ExtendedBuilding extends Building {
 
 /**
  * Get unique building names for the MUI Autocomplete.
- * A building with a duplicate name will have a higher index then a `findIndex` for another building with the same name.
+ * When multiple catalogue entries share a name, keep the first one encountered.
  */
-const buildings: ExtendedBuilding[] = Object.entries(buildingCatalogue)
-    .filter(
-        ([_, building], index, array) =>
-            array.findIndex(([_, otherBuilding]) => otherBuilding.name === building.name) === index
-    )
-    .map(([id, building]) => ({ id, ...building }));
+const buildings: ExtendedBuilding[] = (() => {
+    const byName = new Map<string, ExtendedBuilding>();
+
+    for (const [id, building] of Object.entries(buildingCatalogue)) {
+        if (!byName.has(building.name)) {
+            byName.set(building.name, { id, ...building });
+        }
+    }
+
+    return [...byName.values()];
+})();
 
 type BuildingSelectProps = {
     value?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the `filter` / `findIndex` / `map` chain that builds autocomplete options in `BuildingSelect` with a single `Map`-based pass.

- Keeps first-wins dedupe when multiple catalogue entries share a building name
- Drops from O(n²) to O(n) at module load
- Addresses the React Doctor `js-combine-iterations` finding for this file

## Test plan

- [ ] Open a flow that uses `BuildingSelect` (e.g. custom event building picker)
- [ ] Confirm autocomplete still lists unique building names
- [ ] Confirm selecting a building still sets the correct value
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-867edee9-9aae-4c8f-bc57-bca8dd59982b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-867edee9-9aae-4c8f-bc57-bca8dd59982b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

