### PR TITLE
perf: skip auth lookup on in-app navigation to search tab

### DIFF
--- a/apps/antalmanac/src/app/(main)/page.tsx
+++ b/apps/antalmanac/src/app/(main)/page.tsx
@@ -12,18 +12,19 @@ import { redirect } from 'next/navigation';
 import { userAgent } from 'next/server';
 
 export default async function Page({ searchParams }: PageProps<'/'>) {
-    const resolvedSearchParams = await searchParams;
     const requestHeaders = await headers();
-    const session = await auth.api.getSession({ headers: requestHeaders });
-
-    const { device } = userAgent({ headers: requestHeaders });
-    const isMobile = device.type === 'mobile' || device.type === 'tablet';
 
     // Skip on in-app tab clicks (RSC fetches); redirect only on full document loads.
     const fetchMode = requestHeaders.get('sec-fetch-mode');
     if (fetchMode != null && fetchMode !== 'navigate') {
         return null;
     }
+
+    const resolvedSearchParams = await searchParams;
+    const session = await auth.api.getSession({ headers: requestHeaders });
+
+    const { device } = userAgent({ headers: requestHeaders });
+    const isMobile = device.type === 'mobile' || device.type === 'tablet';
 
     if (resolvedSearchParams[COURSE_SEARCH_PLANNER_KEY] != null) {
         return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the `sec-fetch-mode` guard in the `/` page so in-app tab navigations to Search return immediately, without running `auth.api.getSession()` or parsing search params.

After the React Router → Next.js migration, clicking the Search tab triggers an RSC fetch for `/`. The page already skipped redirect logic for soft navigations, but it still awaited session lookup and search param parsing before bailing out — making Search tab switches noticeably slower than other tabs.

## Change

Move the `sec-fetch-mode` check to run right after `headers()`, before:

- `await searchParams`
- `auth.api.getSession()`
- `userAgent()` parsing

Full document loads (`sec-fetch-mode: navigate`) are unchanged and still run the logged-in default-tab redirect logic.

## Test plan

- [ ] Click Added → Search tab: tab should switch faster (no session roundtrip in Network tab for `/` RSC fetch)
- [ ] Cold load `/` while logged in with no search params: still redirects to Added (desktop) or Calendar (mobile)
- [ ] Cold load `/` with manual search params: still stays on Search
- [ ] Planner search URLs: still unaffected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-618b1c1b-405f-4195-93b4-3f6679b4caf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-618b1c1b-405f-4195-93b4-3f6679b4caf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

