### PR TITLE
feat: SSR the Header

### DIFF
--- a/apps/antalmanac/src/app/(main)/client.tsx
+++ b/apps/antalmanac/src/app/(main)/client.tsx
@@ -110,7 +110,7 @@ export default function Client() {
             <AuthInitializer />
             <PatchNotes />
 
-            <Stack component="main" height="calc(100svh - 52px)">
+            <Stack component="main" height="calc(100svh - 52px - env(safe-area-inset-top))">
                 {isMobile ? <MobileHome /> : <DesktopHome />}
             </Stack>
 

--- a/apps/antalmanac/src/app/(main)/client.tsx
+++ b/apps/antalmanac/src/app/(main)/client.tsx
@@ -4,7 +4,6 @@ import { undoDelete, redoDelete } from '$actions/AppStoreActions';
 import { AuthInitializer } from '$components/AuthInitializer';
 import { AutoSignIn } from '$components/AutoSignIn';
 import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
-import { Header } from '$components/Header/Header';
 import { KeyboardShortcutsModal } from '$components/KeyboardShortcutsModal/KeyboardShortcutsModal';
 import { NotificationSnackbar } from '$components/NotificationSnackbar';
 import { PatchNotes } from '$components/PatchNotes';
@@ -111,8 +110,7 @@ export default function Client() {
             <AuthInitializer />
             <PatchNotes />
 
-            <Stack component="main" height="calc(100svh + env(safe-area-inset-top))">
-                <Header />
+            <Stack component="main" height="calc(100svh - 52px)">
                 {isMobile ? <MobileHome /> : <DesktopHome />}
             </Stack>
 

--- a/apps/antalmanac/src/app/(main)/layout.tsx
+++ b/apps/antalmanac/src/app/(main)/layout.tsx
@@ -1,15 +1,12 @@
 import { Header } from '$components/Header/Header';
 import { ClientShell } from '$src/app/(main)/client-shell';
 import { SeoContent } from '$src/app/(main)/seo-content';
-import { Suspense } from 'react';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     return (
         <>
             <SeoContent />
-            <Suspense>
-                <Header />
-            </Suspense>
+            <Header />
             <ClientShell />
             {children}
         </>

--- a/apps/antalmanac/src/app/(main)/layout.tsx
+++ b/apps/antalmanac/src/app/(main)/layout.tsx
@@ -1,10 +1,15 @@
+import { Header } from '$components/Header/Header';
 import { ClientShell } from '$src/app/(main)/client-shell';
 import { SeoContent } from '$src/app/(main)/seo-content';
+import { Suspense } from 'react';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     return (
         <>
             <SeoContent />
+            <Suspense>
+                <Header />
+            </Suspense>
             <ClientShell />
             {children}
         </>

--- a/apps/antalmanac/src/components/AuthInitializer.tsx
+++ b/apps/antalmanac/src/components/AuthInitializer.tsx
@@ -8,9 +8,7 @@ import {
     getLocalStorageUserId,
     getWasLoggedIn,
     removeLocalStorageDataCache,
-    removeLocalStorageImportedUser,
     removeLocalStorageUserId,
-    setLocalStorageImportedUser,
     setWasLoggedIn,
 } from '$lib/localStorage';
 import { setSsoCookie } from '$lib/ssoCookie';
@@ -73,7 +71,6 @@ export const AuthInitializer = () => {
         // no changes to save
         if (savedUserId === null && savedData === null) {
             removeLocalStorageDataCache();
-            removeLocalStorageImportedUser();
             return;
         }
 
@@ -82,7 +79,6 @@ export const AuthInitializer = () => {
 
             if (savedUserId) {
                 await trpc.schedule.flagImported.mutate({ username: savedUserId });
-                setLocalStorageImportedUser(savedUserId);
             }
 
             const data = JSON.parse(savedData);
@@ -104,7 +100,14 @@ export const AuthInitializer = () => {
 
             removeLocalStorageDataCache();
 
-            openSnackbar('success', `Unsaved changes have been saved to your account!`);
+            if (savedUserId) {
+                openSnackbar(
+                    'success',
+                    `Schedule from "${savedUserId}" has been saved to your account! All changes made to your schedules will be saved to your account.`
+                );
+            } else {
+                openSnackbar('success', 'Unsaved changes have been saved to your account!');
+            }
         }
     });
 

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -89,7 +89,7 @@ export function AppSwitcher() {
                         },
                     }}
                 >
-                    <Logo />
+                    <Logo width={48} />
                 </Button>
 
                 <Popover

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -18,6 +18,7 @@ import {
     Popover,
     Typography,
 } from '@mui/material';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { MouseEventHandler } from 'react';
 
@@ -36,7 +37,8 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const [plannerLoading, setPlannerLoading] = useState(false);
 
-    const platform = window.location.pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
+    const pathname = usePathname();
+    const platform = pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
 
     const handlePlannerClick: MouseEventHandler<HTMLElement> = (event) => {
         if (plannerLoading) return;

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -8,6 +8,7 @@ import { BLUE, PLANNER_LINK } from '$src/globals';
 import appStore from '$stores/AppStore';
 import { EventNote, Route, UnfoldMore } from '@mui/icons-material';
 import {
+    Box,
     Button,
     ButtonGroup,
     CircularProgress,
@@ -22,10 +23,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { MouseEventHandler } from 'react';
 
-type AppSwitcherProps = {
-    isMobile: boolean;
-};
-
 /** Selected/hover use lighter shades than SETTINGS_POPOVER_BG so feedback is visible */
 const darkMenuSx = {
     '&.Mui-selected': { bgcolor: SETTINGS_POPOVER_MENU_SELECTED_BG },
@@ -33,7 +30,7 @@ const darkMenuSx = {
     '&:hover': { bgcolor: SETTINGS_POPOVER_MENU_HOVER_BG },
 } as const;
 
-export function AppSwitcher({ isMobile }: AppSwitcherProps) {
+export function AppSwitcher() {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const [plannerLoading, setPlannerLoading] = useState(false);
 
@@ -76,9 +73,10 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
 
     const plannerIcon = plannerLoading ? <CircularProgress size={20} color="inherit" /> : <Route />;
 
-    if (isMobile) {
-        return (
-            <>
+    return (
+        <>
+            {/* Mobile layout: logo button → popover menu */}
+            <Box sx={{ display: { xs: 'flex', sm: 'none' }, alignItems: 'center' }}>
                 <Button
                     onClick={(event) => setAnchorEl(event.currentTarget)}
                     endIcon={<UnfoldMore />}
@@ -163,47 +161,46 @@ export function AppSwitcher({ isMobile }: AppSwitcherProps) {
                         </MenuItem>
                     </MenuList>
                 </Popover>
-            </>
-        );
-    }
+            </Box>
 
-    return (
-        <>
-            <Logo />
-            <ButtonGroup variant="outlined" color="inherit">
-                <Button
-                    variant="contained"
-                    startIcon={<EventNote />}
-                    sx={{
-                        boxShadow: 'none',
-                        bgcolor: 'white',
-                        color: BLUE,
-                        fontWeight: 500,
-                        fontSize: 14,
-                        py: 0.4,
-                        '&:hover': { bgcolor: 'grey.100' },
-                    }}
-                >
-                    Scheduler
-                </Button>
-                <Button
-                    component="a"
-                    href={PLANNER_LINK}
-                    startIcon={plannerIcon}
-                    onClick={handlePlannerClick}
-                    disabled={plannerLoading}
-                    sx={{
-                        boxShadow: 'none',
-                        color: 'white',
-                        fontWeight: 500,
-                        fontSize: 14,
-                        py: 0.4,
-                        textDecoration: 'none',
-                    }}
-                >
-                    Planner
-                </Button>
-            </ButtonGroup>
+            {/* Desktop layout: logo + button group */}
+            <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', gap: 1 }}>
+                <Logo />
+                <ButtonGroup variant="outlined" color="inherit">
+                    <Button
+                        variant="contained"
+                        startIcon={<EventNote />}
+                        sx={{
+                            boxShadow: 'none',
+                            bgcolor: 'white',
+                            color: BLUE,
+                            fontWeight: 500,
+                            fontSize: 14,
+                            py: 0.4,
+                            '&:hover': { bgcolor: 'grey.100' },
+                        }}
+                    >
+                        Scheduler
+                    </Button>
+                    <Button
+                        component="a"
+                        href={PLANNER_LINK}
+                        startIcon={plannerIcon}
+                        onClick={handlePlannerClick}
+                        disabled={plannerLoading}
+                        sx={{
+                            boxShadow: 'none',
+                            color: 'white',
+                            fontWeight: 500,
+                            fontSize: 14,
+                            py: 0.4,
+                            textDecoration: 'none',
+                        }}
+                    >
+                        Planner
+                    </Button>
+                </ButtonGroup>
+            </Box>
         </>
     );
 }

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -75,7 +75,6 @@ export function AppSwitcher() {
 
     return (
         <>
-            {/* Mobile layout: logo button → popover menu */}
             <Box sx={{ display: { xs: 'flex', sm: 'none' }, alignItems: 'center' }}>
                 <Button
                     onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -163,7 +162,6 @@ export function AppSwitcher() {
                 </Popover>
             </Box>
 
-            {/* Desktop layout: logo + button group */}
             <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', gap: 1 }}>
                 <Logo />
                 <ButtonGroup variant="outlined" color="inherit">

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -75,7 +75,7 @@ export function AppSwitcher() {
 
     return (
         <>
-            <Box sx={{ display: { xs: 'flex', sm: 'none' }, alignItems: 'center' }}>
+            <Box sx={{ display: { default: 'flex', sm: 'none' }, alignItems: 'center' }}>
                 <Button
                     onClick={(event) => setAnchorEl(event.currentTarget)}
                     endIcon={<UnfoldMore />}
@@ -162,7 +162,7 @@ export function AppSwitcher() {
                 </Popover>
             </Box>
 
-            <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', gap: 1 }}>
+            <Box sx={{ display: { default: 'none', sm: 'flex' }, alignItems: 'center', gap: 1 }}>
                 <Logo />
                 <ButtonGroup variant="outlined" color="inherit">
                     <Button

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -7,31 +7,15 @@ import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
 import { Signout } from '$components/Header/Signout';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { getLocalStorageImportedUser, removeLocalStorageImportedUser } from '$lib/localStorage';
 import { BLUE } from '$src/globals';
 import { useSessionStore } from '$stores/SessionStore';
 import { AppBar, Box, Stack } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export function Header() {
-    const [openSuccessfulSaved, setOpenSuccessfulSaved] = useState(false);
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
-    const [importedUser, setImportedUser] = useState('');
     const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
-
-    useEffect(() => {
-        setImportedUser(getLocalStorageImportedUser() ?? '');
-    }, []);
     const isMobile = useIsMobile();
-
-    const clearStorage = () => {
-        removeLocalStorageImportedUser();
-    };
-
-    const handleCloseSuccessfulSaved = () => {
-        setOpenSuccessfulSaved(false);
-        clearStorage();
-    };
 
     const handleLogoutComplete = () => {
         setOpenSignoutDialog(true);
@@ -41,12 +25,6 @@ export function Header() {
         setOpenSignoutDialog(false);
         window.location.reload();
     };
-
-    useEffect(() => {
-        if (importedUser !== '' && sessionIsValid) {
-            setOpenSuccessfulSaved(true);
-        }
-    }, [importedUser, sessionIsValid]);
 
     return (
         <Box
@@ -87,14 +65,6 @@ export function Header() {
                         {sessionIsValid ? <Signout onLogoutComplete={handleLogoutComplete} /> : <Signin />}
                     </Stack>
 
-                    <AlertDialog
-                        open={openSuccessfulSaved}
-                        title={`Schedule from "${importedUser}" has been saved to your account!`}
-                        severity="success"
-                        onClose={handleCloseSuccessfulSaved}
-                    >
-                        NOTE: All changes made to your schedules will be saved to your account
-                    </AlertDialog>
                     <AlertDialog
                         open={openSignoutDialog}
                         title="Signed out successfully"

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -6,7 +6,6 @@ import { Import } from '$components/Header/Import/Import';
 import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
 import { Signout } from '$components/Header/Signout';
-import { useIsMobile } from '$hooks/useIsMobile';
 import { BLUE } from '$src/globals';
 import { useSessionStore } from '$stores/SessionStore';
 import { AppBar, Box, Stack } from '@mui/material';
@@ -15,8 +14,6 @@ import { useState } from 'react';
 export function Header() {
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
     const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
-    const isMobile = useIsMobile();
-
     const handleLogoutComplete = () => {
         setOpenSignoutDialog(true);
     };
@@ -56,7 +53,7 @@ export function Header() {
                     }}
                 >
                     <Stack direction="row" alignItems="center" gap={1}>
-                        <AppSwitcher isMobile={isMobile} />
+                        <AppSwitcher />
                     </Stack>
 
                     <Stack direction="row" alignItems="center">

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AlertDialog } from '$components/AlertDialog';
 import { AppSwitcher } from '$components/Header/AppSwitcher';
 import { Import } from '$components/Header/Import/Import';
@@ -14,8 +16,12 @@ import { useEffect, useState } from 'react';
 export function Header() {
     const [openSuccessfulSaved, setOpenSuccessfulSaved] = useState(false);
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
-    const importedUser = getLocalStorageImportedUser() ?? '';
+    const [importedUser, setImportedUser] = useState('');
     const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
+
+    useEffect(() => {
+        setImportedUser(getLocalStorageImportedUser() ?? '');
+    }, []);
     const isMobile = useIsMobile();
 
     const clearStorage = () => {

--- a/apps/antalmanac/src/components/Header/Import/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import/Import.tsx
@@ -97,12 +97,14 @@ export function Import() {
                 </Button>
             </Tooltip>
 
-            <ImportDialog
-                open={openImportDialog}
-                onClose={handleClose}
-                onAlertDialog={handleAlertDialog}
-                autoImportUsername={autoImportUsername}
-            />
+            {openImportDialog && (
+                <ImportDialog
+                    open={openImportDialog}
+                    onClose={handleClose}
+                    onAlertDialog={handleAlertDialog}
+                    autoImportUsername={autoImportUsername}
+                />
+            )}
 
             <AlertDialog
                 title={alertDialogTitle}

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -1,4 +1,3 @@
-import { useIsMobile } from '$hooks/useIsMobile';
 import Image from 'next/image';
 
 type Logo = {
@@ -73,15 +72,15 @@ function logoIsForCurrentSeason(logo: Logo) {
 export function Logo() {
     const currentLogo = logos.find((logo) => logoIsForCurrentSeason(logo)) ?? defaultLogo;
 
-    const isMobile = useIsMobile();
     return (
         <Image
             src={currentLogo?.logo}
             height={32}
-            width={isMobile ? 48 : 78}
+            width={78}
             title={currentLogo?.attribution}
             loading="eager"
             alt="logo"
+            style={{ width: 'auto', maxWidth: 78 }}
         />
     );
 }

--- a/apps/antalmanac/src/components/Header/Logo.tsx
+++ b/apps/antalmanac/src/components/Header/Logo.tsx
@@ -69,18 +69,17 @@ function logoIsForCurrentSeason(logo: Logo) {
     return currentDate >= startDate && currentDate <= endDate;
 }
 
-export function Logo() {
+export function Logo({ width = 78 }: { width?: number }) {
     const currentLogo = logos.find((logo) => logoIsForCurrentSeason(logo)) ?? defaultLogo;
 
     return (
         <Image
             src={currentLogo?.logo}
             height={32}
-            width={78}
+            width={width}
             title={currentLogo?.attribution}
             loading="eager"
             alt="logo"
-            style={{ width: 'auto', maxWidth: 78 }}
         />
     );
 }

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -13,6 +13,7 @@ enum LocalStorageKeys {
     columnToggles = 'columnToggles',
     wasLoggedIn = 'wasLoggedIn',
     dataCache = 'dataCache',
+    /** @deprecated Guest import confirmation now uses a snackbar in AuthInitializer. */
     importedUser = 'importedUser',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
@@ -35,18 +36,6 @@ enum LocalStorageKeys {
 }
 
 const LSK = LocalStorageKeys;
-
-export function setLocalStorageImportedUser(value: string) {
-    window.localStorage.setItem(LSK.importedUser, value);
-}
-
-export function getLocalStorageImportedUser() {
-    return window.localStorage.getItem(LSK.importedUser);
-}
-
-export function removeLocalStorageImportedUser() {
-    window.localStorage.removeItem(LSK.importedUser);
-}
 
 export function setLocalStorageDataCache(value: string) {
     window.localStorage.setItem(LSK.dataCache, value);

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -13,12 +13,12 @@ enum LocalStorageKeys {
     columnToggles = 'columnToggles',
     wasLoggedIn = 'wasLoggedIn',
     dataCache = 'dataCache',
-    /** @deprecated Guest import confirmation now uses a snackbar in AuthInitializer. */
-    importedUser = 'importedUser',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
     addedCoursesSkeletonBlueprint = 'addedCoursesSkeletonBlueprint',
 
+    /** @deprecated Guest import confirmation now uses a snackbar in AuthInitializer. */
+    importedUser = 'importedUser',
     /** @deprecated Theme preference is now managed by MUI via modeStorageKey="theme". */
     theme = 'theme',
     /** @deprecated No longer used. Low impact feature. */

--- a/apps/antalmanac/src/stores/SectionThemeStore.ts
+++ b/apps/antalmanac/src/stores/SectionThemeStore.ts
@@ -49,11 +49,13 @@ interface SectionThemeStore {
 }
 
 function readStoredSectionColor(): SectionColorSetting {
+    if (typeof window === 'undefined') return 'custom';
     const raw = getLocalStorageSectionColor();
     return isSectionColorSetting(raw) ? raw : 'custom';
 }
 
 function readStoredAssignments(): AssignmentsByTheme {
+    if (typeof window === 'undefined') return {};
     const raw = getLocalStorageSectionColorAssignments();
     if (!raw) return {};
     try {

--- a/apps/antalmanac/src/stores/SectionThemeStore.ts
+++ b/apps/antalmanac/src/stores/SectionThemeStore.ts
@@ -49,13 +49,11 @@ interface SectionThemeStore {
 }
 
 function readStoredSectionColor(): SectionColorSetting {
-    if (typeof window === 'undefined') return 'custom';
     const raw = getLocalStorageSectionColor();
     return isSectionColorSetting(raw) ? raw : 'custom';
 }
 
 function readStoredAssignments(): AssignmentsByTheme {
-    if (typeof window === 'undefined') return {};
     const raw = getLocalStorageSectionColorAssignments();
     if (!raw) return {};
     try {


### PR DESCRIPTION
## Summary

Moves `<Header />` out of the `ssr: false` `ClientShell` boundary into `layout.tsx` so it renders in the initial HTML before JS loads.

SSR-unsafe patterns fixed:
- `window.location.pathname` → `usePathname()` in AppSwitcher
- `window.localStorage` at render-time → `useEffect` in Header (importedUser moved to AuthInitializer snackbar)
- `SectionThemeStore` accessing `localStorage` during Zustand `create()` → `typeof window` guards
- `useIsMobile()` / `useMediaQuery` → CSS responsive `sx` props (`display: {xs:'flex', sm:'none'}`) to avoid hydration mismatch flicker
- `useCourseSearchParam('term')` → deferred to `ImportDialog` which only mounts on user click (eliminates Suspense requirement)

## Test Plan

- CI: lint, typecheck, deploy-staging all pass
- Verify Header renders in initial HTML (view-source shows `<header>` markup)
- No hydration mismatch flicker on mobile viewports
- Import dialog still works (useSearchParams only called when dialog mounts)

## Issues

Closes #


Link to Devin session: https://app.devin.ai/sessions/9d1581b046d64ccd9c21e628b833a265
Requested by: @KevinWu098