### PR TITLE
refactor: migrate theme to MUI CSS variables and color scheme

### DIFF
--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -115,7 +115,7 @@ type ActionType =
 class ActionTypesStore extends EventEmitter {
     async autoSaveSchedule(_action: ActionType) {
         const sessionStore = useSessionStore.getState();
-        const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() === 'true';
+        const autoSave = getLocalStorageAutoSave() === 'true';
 
         if (!sessionStore.sessionIsValid || !sessionStore.userId) {
             if (autoSave) {

--- a/apps/antalmanac/src/actions/ActionTypesStore.ts
+++ b/apps/antalmanac/src/actions/ActionTypesStore.ts
@@ -115,7 +115,7 @@ type ActionType =
 class ActionTypesStore extends EventEmitter {
     async autoSaveSchedule(_action: ActionType) {
         const sessionStore = useSessionStore.getState();
-        const autoSave = getLocalStorageAutoSave() === 'true';
+        const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() === 'true';
 
         if (!sessionStore.sessionIsValid || !sessionStore.userId) {
             if (autoSave) {

--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -129,6 +129,9 @@ const appTheme = createTheme({
     },
     components: {
         MuiAppBar: {
+            defaultProps: {
+                enableColorOnDark: true,
+            },
             styleOverrides: {
                 root: {
                     backgroundImage: 'none',

--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { BLUE, DARK_PAPER_BG, LIGHT_BLUE } from '$src/globals';
-import { useThemeStore } from '$stores/SettingsStore';
 import { CssBaseline, type PaletteOptions } from '@mui/material';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider, type ThemeVars } from '@mui/material/styles';
 import { Roboto } from 'next/font/google';
-import { useEffect, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
 const roboto = Roboto({
     weight: ['300', '400', '500', '700'],
@@ -14,8 +11,8 @@ const roboto = Roboto({
     display: 'swap',
 });
 
-const lightTheme: PaletteOptions = {
-    primary: { main: BLUE }, // #305db7
+const lightPalette: PaletteOptions = {
+    primary: { main: BLUE, contrastText: '#fff' },
     secondary: { main: BLUE },
     settingsSegment: {
         border: '#d3d4d5',
@@ -47,8 +44,8 @@ const darkPaperOverride = {
     color: '#fff',
 };
 
-const darkTheme: PaletteOptions = {
-    primary: { main: BLUE }, // #305db7
+const darkPalette: PaletteOptions = {
+    primary: { main: BLUE, contrastText: '#fff' },
     secondary: { main: LIGHT_BLUE },
     settingsSegment: {
         border: '#888888',
@@ -74,11 +71,11 @@ const darkTheme: PaletteOptions = {
     },
 };
 
-interface Props {
-    children?: React.ReactNode;
-}
-
 declare module '@mui/material/styles' {
+    interface Theme {
+        vars: ThemeVars;
+    }
+
     interface BreakpointOverrides {
         xxs: true;
         default: true;
@@ -115,161 +112,138 @@ declare module '@mui/material/styles' {
     }
 }
 
-/**
- * sets and provides the MUI theme for the app
- */
+const appTheme = createTheme({
+    cssVariables: {
+        colorSchemeSelector: 'class',
+    },
+    colorSchemes: {
+        light: {
+            palette: lightPalette,
+        },
+        dark: {
+            palette: darkPalette,
+        },
+    },
+    typography: {
+        fontFamily: roboto.style.fontFamily,
+    },
+    components: {
+        MuiAppBar: {
+            styleOverrides: {
+                root: {
+                    backgroundImage: 'none',
+                },
+            },
+        },
+        MuiButton: {
+            styleOverrides: {
+                root: ({ ownerState }) => ({
+                    ...(ownerState.variant === 'contained' &&
+                        ownerState.color === 'primary' && {
+                            backgroundColor: BLUE,
+                            ':hover': {
+                                backgroundColor: '#003A75',
+                            },
+                        }),
+                    ...(ownerState.variant === 'contained' &&
+                        ownerState.color === 'secondary' && {
+                            backgroundColor: '#E0E0E0',
+                            color: '#212529',
+                            ':hover': {
+                                backgroundColor: '#D5D5D5',
+                            },
+                        }),
+                }),
+            },
+        },
+        MuiLink: {
+            defaultProps: {
+                color: 'secondary',
+            },
+            styleOverrides: {
+                root: ({ theme }) => [
+                    {
+                        color: BLUE,
+                        ':visited': { color: LIGHT_BLUE },
+                    },
+                    theme.applyStyles('dark', {
+                        color: LIGHT_BLUE,
+                        ':visited': { color: LIGHT_BLUE },
+                    }),
+                ],
+            },
+        },
+        // NB: https://github.com/mui/material-ui/issues/43683#issuecomment-2492787970
+        MuiDialog: {
+            styleOverrides: {
+                paper: ({ theme }) => [{ backgroundImage: 'none' }, theme.applyStyles('dark', darkPaperOverride)],
+            },
+        },
+        MuiDrawer: {
+            styleOverrides: {
+                paper: {
+                    backgroundImage: 'none',
+                },
+            },
+        },
+        MuiInputLabel: {
+            defaultProps: {
+                variant: 'standard',
+            },
+        },
+        MuiPopover: {
+            styleOverrides: {
+                paper: ({ theme }) => [{ backgroundImage: 'none' }, theme.applyStyles('dark', darkPaperOverride)],
+            },
+        },
+        MuiMenu: {
+            styleOverrides: {
+                paper: ({ theme }) => [{ backgroundImage: 'none' }, theme.applyStyles('dark', darkPaperOverride)],
+            },
+        },
+        MuiSelect: {
+            defaultProps: {
+                variant: 'standard',
+            },
+        },
+        MuiTextField: {
+            defaultProps: {
+                variant: 'standard',
+            },
+        },
+        MuiAlert: {
+            styleOverrides: {
+                standardWarning: {
+                    backgroundColor: '#FFEA99',
+                    color: '#302800ff',
+                },
+            },
+        },
+    },
+    breakpoints: {
+        /**
+         * Based on Tailwind's breakpoints.
+         * @see https://tailwindcss.com/docs/screens
+         */
+        values: {
+            default: 0,
+            xxs: 400,
+            xs: 640,
+            sm: 800,
+            md: 1024,
+            lg: 1280,
+            xl: 1536,
+        },
+    },
+});
+
+interface Props {
+    children?: React.ReactNode;
+}
+
 export function AppThemeProvider(props: Props) {
-    const [isDark, syncSystemTheme] = useThemeStore(useShallow((store) => [store.isDark, store.syncSystemTheme]));
-
-    useEffect(() => {
-        const onChange = (e: MediaQueryListEvent) => {
-            syncSystemTheme(e.matches);
-        };
-
-        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-
-        mediaQueryList.addEventListener('change', onChange);
-
-        return () => {
-            mediaQueryList.removeEventListener('change', onChange);
-        };
-    }, [syncSystemTheme]);
-
-    const theme = useMemo(
-        () =>
-            createTheme({
-                typography: {
-                    fontFamily: roboto.style.fontFamily,
-                },
-                components: {
-                    MuiAppBar: {
-                        styleOverrides: {
-                            root: {
-                                backgroundImage: 'none',
-                            },
-                        },
-                    },
-                    MuiButton: {
-                        styleOverrides: {
-                            root: ({ ownerState }) => ({
-                                ...(ownerState.variant === 'contained' &&
-                                    ownerState.color === 'primary' && {
-                                        backgroundColor: BLUE,
-                                        ':hover': {
-                                            backgroundColor: '#003A75',
-                                        },
-                                    }),
-                                ...(ownerState.variant === 'contained' &&
-                                    ownerState.color === 'secondary' && {
-                                        backgroundColor: '#E0E0E0',
-                                        color: '#212529',
-                                        ':hover': {
-                                            backgroundColor: '#D5D5D5',
-                                        },
-                                    }),
-                            }),
-                        },
-                    },
-                    MuiCssBaseline: {
-                        styleOverrides: {
-                            a: {
-                                color: isDark ? LIGHT_BLUE : BLUE,
-                            },
-                        },
-                    },
-                    // NB: https://github.com/mui/material-ui/issues/43683#issuecomment-2492787970
-                    MuiDialog: {
-                        styleOverrides: {
-                            paper: {
-                                backgroundImage: 'none',
-                                ...(isDark && darkPaperOverride),
-                            },
-                        },
-                    },
-                    MuiDrawer: {
-                        styleOverrides: {
-                            paper: {
-                                backgroundImage: 'none',
-                            },
-                        },
-                    },
-                    MuiInputLabel: {
-                        defaultProps: {
-                            variant: 'standard',
-                        },
-                    },
-                    MuiPaper: {
-                        styleOverrides: {
-                            root: ({ theme }) => ({
-                                ...(theme.palette.mode === 'dark' && {
-                                    backgroundImage: 'none',
-                                    background: theme.palette.background.paper,
-                                    backgroundColor: theme.palette.background.paper,
-                                    color: theme.palette.text.primary,
-                                }),
-                            }),
-                        },
-                    },
-                    MuiPopover: {
-                        styleOverrides: {
-                            paper: {
-                                backgroundImage: 'none',
-                                ...(isDark && darkPaperOverride),
-                            },
-                        },
-                    },
-                    MuiMenu: {
-                        styleOverrides: {
-                            paper: {
-                                backgroundImage: 'none',
-                                ...(isDark && darkPaperOverride),
-                            },
-                        },
-                    },
-                    MuiSelect: {
-                        defaultProps: {
-                            variant: 'standard',
-                        },
-                    },
-                    MuiTextField: {
-                        defaultProps: {
-                            variant: 'standard',
-                        },
-                    },
-                    MuiAlert: {
-                        styleOverrides: {
-                            standardWarning: {
-                                backgroundColor: '#FFEA99',
-                                color: '#302800ff',
-                            },
-                        },
-                    },
-                },
-                breakpoints: {
-                    /**
-                     * Based on Tailwind's breakpoints.
-                     * @see https://tailwindcss.com/docs/screens
-                     */
-                    values: {
-                        default: 0,
-                        xxs: 400,
-                        xs: 640,
-                        sm: 800,
-                        md: 1024,
-                        lg: 1280,
-                        xl: 1536,
-                    },
-                },
-                palette: {
-                    mode: isDark ? 'dark' : 'light',
-                    ...(isDark ? darkTheme : lightTheme),
-                },
-            }),
-        [isDark]
-    );
-
     return (
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={appTheme} defaultMode="system" modeStorageKey="theme" disableTransitionOnChange>
             <CssBaseline />
             {props.children}
         </ThemeProvider>

--- a/apps/antalmanac/src/app/layout.tsx
+++ b/apps/antalmanac/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Providers } from '$src/app/providers';
 import { ANTALMANAC_DESCRIPTION, ANTALMANAC_TITLE } from '$src/app/seo-constants';
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import type { WebApplication, WebSite, WithContext } from 'schema-dts';
@@ -79,8 +80,9 @@ const siteSchema: WithContext<WebSite> = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="en">
+        <html lang="en" suppressHydrationWarning>
             <body>
+                <InitColorSchemeScript attribute="class" modeStorageKey="theme" defaultMode="system" />
                 <script
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{ __html: JSON.stringify([webAppSchema, siteSchema]) }}

--- a/apps/antalmanac/src/components/AlertDialog.tsx
+++ b/apps/antalmanac/src/components/AlertDialog.tsx
@@ -1,5 +1,4 @@
-import { LIGHT_BLUE } from '$src/globals';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Alert, Box, Dialog, DialogContent, type AlertColor, DialogActions, Button } from '@mui/material';
 
 interface AlertDialogProps {
@@ -11,15 +10,10 @@ interface AlertDialogProps {
     onClose?: () => void;
 }
 export const AlertDialog = ({ open, title, children, severity = 'info', onClose }: AlertDialogProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     return (
         <Dialog open={open} onClose={onClose}>
-            <DialogContent
-                sx={{
-                    fontSize: 'small',
-                    ...(isDark && { '& a, & a:hover, & a:visited': { color: LIGHT_BLUE } }),
-                }}
-            >
+            <DialogContent sx={{ fontSize: 'small' }}>
                 <Alert
                     severity={severity}
                     variant={isDark ? 'outlined' : 'standard'}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -10,6 +10,7 @@ import { TbaCalendarCard } from '$components/Calendar/TbaCalendarCard';
 import { CalendarToolbar } from '$components/Calendar/Toolbar/CalendarToolbar';
 import { isCourseEvent, isSkeletonEvent, type CalendarEvent, type SkeletonEvent } from '$components/Calendar/types';
 import { EmptyState } from '$components/EmptyState';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useSectionThemeAssignments } from '$hooks/useSectionThemeAssignments';
 import { removeLocalStorageSkeletonBlueprint, setLocalStorageSkeletonBlueprint } from '$lib/localStorage';
@@ -21,7 +22,7 @@ import { useHiddenCoursesStore } from '$stores/HiddenCoursesStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { useScheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { scheduleSectionKey } from '$stores/scheduleHelpers';
-import { useThemeStore, useTimeFormatStore } from '$stores/SettingsStore';
+import { useTimeFormatStore } from '$stores/SettingsStore';
 import { CalendarMonth } from '@mui/icons-material';
 import { Box, Backdrop, useTheme } from '@mui/material';
 import { VisibilityState } from '@packages/antalmanac-types';
@@ -72,7 +73,7 @@ export const ScheduleCalendar = memo(() => {
     const [hoveredCalendarizedCourses, hoveredCalendarizedFinal] = useHoveredStore(
         useShallow((state) => [state.hoveredCalendarizedCourses, state.hoveredCalendarizedFinal])
     );
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const { setting, palette, assignments } = useSectionThemeAssignments();
 
@@ -146,7 +147,7 @@ export const ScheduleCalendar = memo(() => {
         }
     }, [eventsInCalendar, openLoadingSchedule]);
 
-    const skeletonColor = theme.palette.action.disabledBackground;
+    const skeletonColor = theme.vars.palette.action.disabledBackground;
 
     const events = useMemo(
         () => (openLoadingSchedule ? createSkeletonEvents(skeletonColor) : getEventsForCalendar()),
@@ -175,7 +176,7 @@ export const ScheduleCalendar = memo(() => {
             const style =
                 visibility === VisibilityState.Outlined
                     ? {
-                          backgroundColor: theme.palette.background.default,
+                          backgroundColor: theme.vars.palette.background.default,
                           border: `2px solid ${event.color}`,
                           borderRadius: '4px',
                           color: event.color,
@@ -209,7 +210,7 @@ export const ScheduleCalendar = memo(() => {
             }
 
             const style = {
-                backgroundColor: isDark ? theme.palette.background.paper : '',
+                backgroundColor: isDark ? theme.vars.palette.background.paper : '',
             };
 
             return { style };

--- a/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
+++ b/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
@@ -1,8 +1,8 @@
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
 import { scheduleSectionKey } from '$stores/scheduleHelpers';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Close, InfoOutlined } from '@mui/icons-material';
 import { IconButton, Alert, AlertTitle, Box, Typography, Fade, useTheme } from '@mui/material';
 import type { AATerm } from '@packages/antalmanac-types';
@@ -49,18 +49,18 @@ function TbaCircleButton({ onClick }: { onClick: () => void }) {
 
 function TbaExpandedCard({ tbaSections, onToggle }: { tbaSections: TbaSection[]; onToggle: () => void }) {
     const theme = useTheme();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const isMobile = useIsMobile();
     return (
         <Alert
-            icon={<InfoOutlined fontSize="small" sx={{ color: isDark ? theme.palette.common.white : BLUE }} />}
+            icon={<InfoOutlined fontSize="small" sx={{ color: isDark ? theme.vars.palette.common.white : BLUE }} />}
             severity="info"
             variant="outlined"
             sx={{
                 width: '100%',
-                bgcolor: theme.palette.background.paper,
+                bgcolor: theme.vars.palette.background.paper,
                 borderColor: BLUE,
-                color: isDark ? theme.palette.common.white : 'inherit',
+                color: isDark ? theme.vars.palette.common.white : 'inherit',
                 borderWidth: 2,
                 alignItems: 'center',
                 py: 0.5,

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -4,11 +4,11 @@ import { DownloadButton } from '$components/buttons/Download';
 import { ScreenshotButton } from '$components/buttons/Screenshot';
 import { CustomEventDialog } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import AppStore from '$stores/AppStore';
 import { useFallbackStore } from '$stores/FallbackStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import {
     Undo as UndoIcon,
     Redo as RedoIcon,
@@ -48,7 +48,7 @@ interface CalendarPaneToolbarProps {
  */
 export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
     const theme = useTheme();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const { showFinalsSchedule, toggleDisplayFinalsSchedule } = props;
     const fallbackMode = useFallbackStore((state) => state.fallbackMode);
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('xxs'));
@@ -150,15 +150,15 @@ export const CalendarToolbar = memo((props: CalendarPaneToolbarProps) => {
                             size="small"
                             sx={{
                                 border: '1px solid',
-                                borderColor: showFinalsSchedule ? theme.palette.primary.main : 'inherit',
+                                borderColor: showFinalsSchedule ? theme.vars.palette.primary.main : 'inherit',
                                 borderRadius: '4px',
                                 padding: '3px',
                                 ...(showFinalsSchedule &&
                                     isDark && {
-                                        backgroundColor: theme.palette.primary.main,
+                                        backgroundColor: theme.vars.palette.primary.main,
                                         color: '#fff',
                                         '&:hover': {
-                                            backgroundColor: theme.palette.primary.dark,
+                                            backgroundColor: theme.vars.palette.primary.dark,
                                         },
                                     }),
                             }}

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -210,7 +210,7 @@ export function SelectSchedulePopover() {
                                                         justifyContent: 'flex-start',
                                                         background:
                                                             index === currentScheduleIndex
-                                                                ? theme.palette.action.selected
+                                                                ? theme.vars.palette.action.selected
                                                                 : undefined,
                                                     }}
                                                     onClick={() => handleScheduleChange(index, postHog)}

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,10 +1,10 @@
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { type AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import { courseColorKey, customEventColorKey, getPalette, resolveAssignment } from '$lib/sectionThemes';
 import AppStore from '$stores/AppStore';
 import { colorPickerPresetColors } from '$stores/scheduleHelpers';
 import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, type PopoverProps, Tooltip } from '@mui/material';
 import { type CustomEventId, type AATerm } from '@packages/antalmanac-types';
@@ -40,7 +40,7 @@ export const ColorPicker = memo(function ColorPicker({
     const activeSectionColor = useSectionThemeStore(selectActiveSectionColor);
     const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
     const setManualColor = useSectionThemeStore((s) => s.setManualColor);
-    const isDark = useThemeStore((s) => s.isDark);
+    const isDark = useIsDarkMode();
 
     const postHog = usePostHog();
 

--- a/apps/antalmanac/src/components/EmptyState.tsx
+++ b/apps/antalmanac/src/components/EmptyState.tsx
@@ -39,12 +39,12 @@ export function EmptyState({
             className={className}
             sx={sx}
         >
-            <Icon sx={{ fontSize: 48, color: 'text.secondary' }} aria-hidden="true" />
-            <Typography variant="h6" color="text.primary">
+            <Icon sx={{ fontSize: 48, color: (theme) => theme.vars.palette.text.secondary }} aria-hidden="true" />
+            <Typography variant="h6" sx={{ color: (theme) => theme.vars.palette.text.primary }}>
                 {title}
             </Typography>
             {description && (
-                <Typography variant="body2" color="text.secondary" maxWidth={360}>
+                <Typography variant="body2" sx={{ color: (theme) => theme.vars.palette.text.secondary }} maxWidth={360}>
                     {description}
                 </Typography>
             )}

--- a/apps/antalmanac/src/components/Header/AppSwitcher.tsx
+++ b/apps/antalmanac/src/components/Header/AppSwitcher.tsx
@@ -4,9 +4,9 @@ import {
     SETTINGS_POPOVER_MENU_SELECTED_BG,
 } from '$components/Header/headerStyles';
 import { Logo } from '$components/Header/Logo';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { BLUE, PLANNER_LINK } from '$src/globals';
 import appStore from '$stores/AppStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { EventNote, Route, UnfoldMore } from '@mui/icons-material';
 import {
     Button,
@@ -36,7 +36,7 @@ const darkMenuSx = {
 export function AppSwitcher({ isMobile }: AppSwitcherProps) {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const [plannerLoading, setPlannerLoading] = useState(false);
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const platform = window.location.pathname.split('/')[1] === 'planner' ? 'Planner' : 'Scheduler';
 

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -56,6 +56,7 @@ export function Header() {
             <AppBar
                 position="static"
                 color="primary"
+                enableColorOnDark
                 sx={{
                     height: 52,
                     px: 1,

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -56,7 +56,6 @@ export function Header() {
             <AppBar
                 position="static"
                 color="primary"
-                enableColorOnDark
                 sx={{
                     height: 52,
                     px: 1,

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -14,12 +14,12 @@ import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import { getLocalStorageDataCache, getLocalStorageUserId, removeLocalStorageUserId } from '$lib/localStorage';
 import { processZotcourseResponse } from '$lib/zotcourse';
-import { BLUE, LIGHT_BLUE } from '$src/globals';
+import { BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { useScheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
-import { useDevModeStore, useThemeStore } from '$stores/SettingsStore';
+import { useDevModeStore } from '$stores/SettingsStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import { CloudUpload, ContentPasteGo } from '@mui/icons-material';
 import {
@@ -35,6 +35,7 @@ import {
     FormControl,
     FormControlLabel,
     InputLabel,
+    Link as MuiLink,
     Paper,
     Radio,
     RadioGroup,
@@ -46,7 +47,7 @@ import {
     Typography,
 } from '@mui/material';
 import { type AATerm, type AACourse, type ShortCourseSchedule } from '@packages/antalmanac-types';
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { usePostHog } from 'posthog-js/react';
 import { type ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
@@ -91,8 +92,6 @@ export function Import() {
 
     const effectiveImportSource =
         !devMode && importSource === ImportSource.JSON_IMPORT ? ImportSource.STUDY_LIST_IMPORT : importSource;
-
-    const isDark = useThemeStore((store) => store.isDark);
 
     const postHog = usePostHog();
     const { mutateAsync: fetchZotcourse } = trpcReact.zotcourse.getUserData.useMutation();
@@ -696,14 +695,14 @@ export function Import() {
                         }}
                         textColor="secondary"
                         indicatorColor="secondary"
-                        sx={{ borderBottom: 1, borderColor: 'divider' }}
+                        sx={(theme) => ({ borderBottom: 1, borderColor: theme.vars.palette.divider })}
                     >
                         <Tab label="Import" value="import" />
                         <Tab label="Export" value="export" />
                     </Tabs>
                 )}
                 <DialogTitle>{dialogTab === 'export' ? 'Export Schedules' : 'Import Schedule'}</DialogTitle>
-                <DialogContent sx={isDark ? { '& a': { color: LIGHT_BLUE } } : undefined}>
+                <DialogContent>
                     {dialogTab === 'export' ? (
                         <>
                             <DialogContentText sx={{ mb: 2 }}>
@@ -744,30 +743,30 @@ export function Import() {
                                         sx={{ marginBottom: 1 }}
                                     />
                                     <Box
-                                        sx={{
+                                        sx={(theme) => ({
                                             maxHeight: 300,
                                             overflow: 'auto',
                                             border: '1px solid',
-                                            borderColor: 'divider',
+                                            borderColor: theme.vars.palette.divider,
                                             borderRadius: 1,
                                             p: 1,
-                                        }}
+                                        })}
                                     >
                                         <Stack spacing={1}>
                                             {exportSchedules.map((schedule, index) => (
                                                 <Paper
                                                     key={index}
-                                                    sx={{
+                                                    sx={(theme) => ({
                                                         p: 1.5,
                                                         border: '2px solid',
                                                         borderColor: exportSelectedIndices.has(index)
-                                                            ? 'secondary.main'
+                                                            ? theme.vars.palette.secondary.main
                                                             : 'transparent',
                                                         backgroundColor: exportSelectedIndices.has(index)
-                                                            ? 'action.selected'
-                                                            : 'background.paper',
+                                                            ? theme.vars.palette.action.selected
+                                                            : theme.vars.palette.background.paper,
                                                         transition: 'all 0.2s ease-in-out',
-                                                    }}
+                                                    })}
                                                 >
                                                     <FormControlLabel
                                                         control={
@@ -792,7 +791,13 @@ export function Import() {
                                                                 <Typography variant="body2" fontWeight="medium">
                                                                     {schedule.scheduleName}
                                                                 </Typography>
-                                                                <Typography variant="caption" color="text.secondary">
+                                                                <Typography
+                                                                    variant="caption"
+                                                                    sx={{
+                                                                        color: (theme) =>
+                                                                            theme.vars.palette.text.secondary,
+                                                                    }}
+                                                                >
                                                                     {schedule.courses.length} course(s),{' '}
                                                                     {schedule.customEvents.length} custom event(s)
                                                                 </Typography>
@@ -850,9 +855,24 @@ export function Import() {
                                         Paste the contents of your Study List below to import it into AntAlmanac.
                                         <br />
                                         To find your Study List, go to{' '}
-                                        <a href={'https://www.reg.uci.edu/cgi-bin/webreg-redirect.sh'}>WebReg</a> or{' '}
-                                        <a href={'https://www.reg.uci.edu/access/student/welcome/'}>StudentAccess</a>,
-                                        and click on Study List once you&apos;ve logged in. Copy everything below the
+                                        <MuiLink
+                                            href="https://www.reg.uci.edu/cgi-bin/webreg-redirect.sh"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            underline="hover"
+                                        >
+                                            WebReg
+                                        </MuiLink>{' '}
+                                        or{' '}
+                                        <MuiLink
+                                            href="https://www.reg.uci.edu/access/student/welcome/"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            underline="hover"
+                                        >
+                                            StudentAccess
+                                        </MuiLink>
+                                        , and click on Study List once you&apos;ve logged in. Copy everything below the
                                         column names (Code, Dept, etc.) under the Enrolled Classes section.
                                     </DialogContentText>
                                     <InputLabel style={{ fontSize: '9px' }}>Study List</InputLabel>
@@ -957,49 +977,62 @@ export function Import() {
                                         aria-label="Upload JSON schedule file"
                                     >
                                         <Paper
-                                            sx={{
+                                            sx={(theme) => ({
                                                 border: '2px dashed',
                                                 borderColor:
-                                                    isDragging || selectedFileName ? 'secondary.main' : 'divider',
-                                                backgroundColor: isDragging ? 'action.hover' : 'background.paper',
+                                                    isDragging || selectedFileName
+                                                        ? theme.vars.palette.secondary.main
+                                                        : theme.vars.palette.divider,
+                                                backgroundColor: isDragging
+                                                    ? theme.vars.palette.action.hover
+                                                    : theme.vars.palette.background.paper,
                                                 padding: 3,
                                                 textAlign: 'center',
                                                 transition: 'all 0.2s ease-in-out',
                                                 '&:hover': {
-                                                    borderColor: 'secondary.main',
-                                                    backgroundColor: 'action.hover',
+                                                    borderColor: theme.vars.palette.secondary.main,
+                                                    backgroundColor: theme.vars.palette.action.hover,
                                                 },
-                                            }}
+                                            })}
                                         >
                                             <Stack spacing={2} alignItems="center">
                                                 <CloudUpload
-                                                    sx={{
+                                                    sx={(theme) => ({
                                                         fontSize: 48,
                                                         color:
                                                             isDragging || selectedFileName
-                                                                ? 'secondary.main'
-                                                                : 'text.secondary',
-                                                    }}
+                                                                ? theme.vars.palette.secondary.main
+                                                                : theme.vars.palette.text.secondary,
+                                                    })}
                                                 />
                                                 {selectedFileName ? (
                                                     <>
                                                         <Typography
                                                             variant="body1"
-                                                            sx={{ color: 'secondary.main' }}
+                                                            sx={{ color: (theme) => theme.vars.palette.secondary.main }}
                                                             fontWeight="medium"
                                                         >
                                                             {selectedFileName}
                                                         </Typography>
-                                                        <Typography variant="body2" color="text.secondary">
+                                                        <Typography
+                                                            variant="body2"
+                                                            sx={{ color: (theme) => theme.vars.palette.text.secondary }}
+                                                        >
                                                             Click to select a different file
                                                         </Typography>
                                                     </>
                                                 ) : (
                                                     <>
-                                                        <Typography variant="body1" color="text.primary">
+                                                        <Typography
+                                                            variant="body1"
+                                                            sx={{ color: (theme) => theme.vars.palette.text.primary }}
+                                                        >
                                                             Drag and drop your JSON file here
                                                         </Typography>
-                                                        <Typography variant="body2" color="text.secondary">
+                                                        <Typography
+                                                            variant="body2"
+                                                            sx={{ color: (theme) => theme.vars.palette.text.secondary }}
+                                                        >
                                                             or click to browse
                                                         </Typography>
                                                     </>
@@ -1048,30 +1081,30 @@ export function Import() {
                                                 sx={{ marginBottom: 1 }}
                                             />
                                             <Box
-                                                sx={{
+                                                sx={(theme) => ({
                                                     maxHeight: 300,
                                                     overflow: 'auto',
                                                     border: '1px solid',
-                                                    borderColor: 'divider',
+                                                    borderColor: theme.vars.palette.divider,
                                                     borderRadius: 1,
                                                     p: 1,
-                                                }}
+                                                })}
                                             >
                                                 <Stack spacing={1}>
                                                     {importedSchedules.map((schedule, index) => (
                                                         <Paper
                                                             key={index}
-                                                            sx={{
+                                                            sx={(theme) => ({
                                                                 p: 1.5,
                                                                 border: '2px solid',
                                                                 borderColor: selectedScheduleIndices.has(index)
-                                                                    ? 'secondary.main'
+                                                                    ? theme.vars.palette.secondary.main
                                                                     : 'transparent',
                                                                 backgroundColor: selectedScheduleIndices.has(index)
-                                                                    ? 'action.selected'
-                                                                    : 'background.paper',
+                                                                    ? theme.vars.palette.action.selected
+                                                                    : theme.vars.palette.background.paper,
                                                                 transition: 'all 0.2s ease-in-out',
-                                                            }}
+                                                            })}
                                                         >
                                                             <FormControlLabel
                                                                 control={
@@ -1098,7 +1131,10 @@ export function Import() {
                                                                         </Typography>
                                                                         <Typography
                                                                             variant="caption"
-                                                                            color="text.secondary"
+                                                                            sx={{
+                                                                                color: (theme) =>
+                                                                                    theme.vars.palette.text.secondary,
+                                                                            }}
                                                                         >
                                                                             {schedule.courses.length} course(s),{' '}
                                                                             {schedule.customEvents.length} custom
@@ -1189,7 +1225,10 @@ export function Import() {
             >
                 {alertDialogSeverity === 'error' ? (
                     <Box>
-                        If you think this is a mistake please submit a <Link href="/feedback">bug report</Link>
+                        If you think this is a mistake please submit a{' '}
+                        <MuiLink component={NextLink} href="/feedback" underline="hover">
+                            bug report
+                        </MuiLink>
                     </Box>
                 ) : (
                     <Stack direction="row" justifyContent="center">

--- a/apps/antalmanac/src/components/Header/Settings/SectionColorSelector.tsx
+++ b/apps/antalmanac/src/components/Header/Settings/SectionColorSelector.tsx
@@ -1,7 +1,7 @@
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { getPalette, SECTION_THEMES, type SectionColorSetting, type SectionThemeId } from '$lib/sectionThemes';
 import AppStore from '$stores/AppStore';
 import { useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import {
     Check,
     Colorize,
@@ -14,7 +14,6 @@ import {
     type SvgIconComponent,
 } from '@mui/icons-material';
 import { Box, Button, ListItemText, Menu, MenuItem, Stack, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useRef, useState } from 'react';
 
@@ -45,7 +44,6 @@ function getCustomSwatches(isDark: boolean): string[] {
 }
 
 function Swatches({ colors }: { colors: string[] }) {
-    const theme = useTheme();
     if (colors.length === 0) return null;
     return (
         <Stack direction="row" gap={0.5} sx={{ flexShrink: 0 }}>
@@ -57,7 +55,8 @@ function Swatches({ colors }: { colors: string[] }) {
                         height: 14,
                         borderRadius: '3px',
                         backgroundColor: c,
-                        border: `1px solid ${theme.palette.divider}`,
+                        border: 1,
+                        borderColor: (theme) => theme.vars.palette.divider,
                     }}
                 />
             ))}
@@ -73,9 +72,7 @@ function Swatches({ colors }: { colors: string[] }) {
  * hovers, committing on click and reverting on dismiss. No modal.
  */
 export function SectionColorSelector() {
-    const muiTheme = useTheme();
-    const isDark = useThemeStore((s) => s.isDark);
-    const accent = muiTheme.palette.secondary.main;
+    const isDark = useIsDarkMode();
 
     const sectionColor = useSectionThemeStore((s) => s.sectionColor);
     const setSectionColor = useSectionThemeStore((s) => s.setSectionColor);
@@ -164,7 +161,7 @@ export function SectionColorSelector() {
                         openMenu();
                     }
                 }}
-                sx={{
+                sx={(theme) => ({
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
@@ -173,22 +170,30 @@ export function SectionColorSelector() {
                     minHeight: 42,
                     boxSizing: 'border-box',
                     padding: '8px 12px',
-                    border: `1px solid ${muiTheme.palette.divider}`,
+                    border: 1,
+                    borderColor: theme.vars.palette.divider,
                     borderRadius: 1,
                     cursor: 'pointer',
-                    backgroundColor: muiTheme.palette.settingsSegment.background,
-                    '&:hover': { backgroundColor: muiTheme.palette.settingsSegment.hoverBackground },
-                }}
+                    backgroundColor: theme.vars.palette.settingsSegment.background,
+                    '&:hover': { backgroundColor: theme.vars.palette.settingsSegment.hoverBackground },
+                })}
             >
                 <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
-                    <ActiveIcon fontSize="medium" sx={{ color: accent }} />
-                    <Typography noWrap sx={{ fontWeight: 'bold', fontSize: '1.1rem', color: accent }}>
+                    <ActiveIcon fontSize="medium" sx={{ color: (theme) => theme.vars.palette.secondary.main }} />
+                    <Typography
+                        noWrap
+                        sx={{
+                            fontWeight: 'bold',
+                            fontSize: '1.1rem',
+                            color: (theme) => theme.vars.palette.secondary.main,
+                        }}
+                    >
                         {activeOption.name}
                     </Typography>
                 </Stack>
                 <Stack direction="row" alignItems="center" gap={1}>
                     <Swatches colors={activeOption.swatches} />
-                    <ExpandMore fontSize="small" sx={{ color: accent }} />
+                    <ExpandMore fontSize="small" sx={{ color: (theme) => theme.vars.palette.secondary.main }} />
                 </Stack>
             </Box>
 
@@ -215,7 +220,7 @@ export function SectionColorSelector() {
                             <Check
                                 sx={{
                                     fontSize: 18,
-                                    color: accent,
+                                    color: (theme) => theme.vars.palette.secondary.main,
                                     flexShrink: 0,
                                     visibility: isSelected ? 'visible' : 'hidden',
                                 }}
@@ -235,7 +240,12 @@ export function SectionColorSelector() {
                     size="small"
                     color="inherit"
                     onClick={() => resetTheme(sectionColor as SectionThemeId)}
-                    sx={{ alignSelf: 'flex-start', textTransform: 'none', color: 'text.secondary', px: 0.5 }}
+                    sx={{
+                        alignSelf: 'flex-start',
+                        textTransform: 'none',
+                        color: (theme) => theme.vars.palette.text.secondary,
+                        px: 0.5,
+                    }}
                 >
                     Restore Theme Colors
                 </Button>

--- a/apps/antalmanac/src/components/Header/Settings/SettingsMenu.tsx
+++ b/apps/antalmanac/src/components/Header/Settings/SettingsMenu.tsx
@@ -3,7 +3,7 @@ import { ExperimentalMenu } from '$components/Header/Settings/ExperimentalMenu';
 import { SectionColorSelector } from '$components/Header/Settings/SectionColorSelector';
 import { ThemeSelector } from '$components/Header/Settings/ThemeSelector';
 import { TimeSelector } from '$components/Header/Settings/TimeSelector';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { AccountCircle } from '@mui/icons-material';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import type { UserProfile } from '@packages/db/src/schema/auth/user';
@@ -14,7 +14,7 @@ interface UserProfileSectionProps {
 }
 
 function UserProfileSection({ user }: UserProfileSectionProps) {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     if (!user) {
         return null;

--- a/apps/antalmanac/src/components/Header/Settings/ThemeSelector.tsx
+++ b/apps/antalmanac/src/components/Header/Settings/ThemeSelector.tsx
@@ -1,27 +1,35 @@
-import { useThemeStore } from '$stores/SettingsStore';
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { LightMode, SettingsBrightness, DarkMode } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { useColorScheme } from '@mui/material/styles';
 import { usePostHog } from 'posthog-js/react';
-import { useShallow } from 'zustand/react/shallow';
 
 const THEME_OPTIONS = [
     { value: 'light', label: 'Light', icon: <LightMode fontSize="medium" /> },
     { value: 'system', label: 'System', icon: <SettingsBrightness fontSize="medium" /> },
     { value: 'dark', label: 'Dark', icon: <DarkMode fontSize="medium" /> },
-];
+] as const;
+
+type ThemeSetting = (typeof THEME_OPTIONS)[number]['value'];
 
 export function ThemeSelector() {
-    const theme = useTheme();
-    const accentColor = theme.palette.secondary.main;
-    const segment = theme.palette.settingsSegment;
-
-    const [themeSetting, setTheme] = useThemeStore(useShallow((store) => [store.themeSetting, store.setAppTheme]));
+    const { mode, setMode } = useColorScheme();
     const postHog = usePostHog();
 
-    const handleThemeChange = (value: 'light' | 'dark' | 'system') => {
-        setTheme(value, postHog);
+    const handleThemeChange = (value: ThemeSetting) => {
+        setMode(value);
+        logAnalytics(postHog, {
+            category: analyticsEnum.nav,
+            action: analyticsEnum.nav.actions.CHANGE_THEME,
+            customProps: {
+                themeSetting: value,
+            },
+        });
     };
+
+    if (!mode) {
+        return null;
+    }
 
     return (
         <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -30,20 +38,21 @@ export function ThemeSelector() {
             </Typography>
 
             <Box
-                sx={{
+                sx={(theme) => ({
                     display: 'flex',
-                    border: `1px solid ${theme.palette.divider}`,
+                    border: 1,
+                    borderColor: theme.vars.palette.divider,
                     borderRadius: 1,
-                }}
+                })}
             >
                 {THEME_OPTIONS.map((tab, index) => {
-                    const isSelected = themeSetting === tab.value;
+                    const isSelected = mode === tab.value;
 
                     return (
                         <Box
                             key={tab.value}
-                            onClick={() => handleThemeChange(tab.value as 'light' | 'dark' | 'system')}
-                            sx={{
+                            onClick={() => handleThemeChange(tab.value)}
+                            sx={(theme) => ({
                                 flex: 1,
                                 display: 'flex',
                                 alignItems: 'center',
@@ -56,17 +65,24 @@ export function ThemeSelector() {
                                 cursor: 'pointer',
                                 fontWeight: 'bold',
                                 fontSize: '1.1rem',
-                                backgroundColor: isSelected ? theme.palette.primary.main : segment.background,
-                                color: isSelected ? theme.palette.primary.contrastText : accentColor,
-                                borderRight: index < 2 ? `1px solid ${theme.palette.divider}` : 'none',
+                                backgroundColor: isSelected
+                                    ? theme.vars.palette.primary.main
+                                    : theme.vars.palette.settingsSegment.background,
+                                color: isSelected
+                                    ? theme.vars.palette.primary.contrastText
+                                    : theme.vars.palette.secondary.main,
+                                borderRight: index < 2 ? 1 : 0,
+                                borderColor: theme.vars.palette.divider,
                                 borderTopLeftRadius: tab.value === 'light' ? 2 : 0,
                                 borderBottomLeftRadius: tab.value === 'light' ? 2 : 0,
                                 borderTopRightRadius: tab.value === 'dark' ? 2 : 0,
                                 borderBottomRightRadius: tab.value === 'dark' ? 2 : 0,
                                 '&:hover': {
-                                    backgroundColor: isSelected ? theme.palette.primary.main : segment.hoverBackground,
+                                    backgroundColor: isSelected
+                                        ? theme.vars.palette.primary.main
+                                        : theme.vars.palette.settingsSegment.hoverBackground,
                                 },
-                            }}
+                            })}
                         >
                             {tab.icon}
                             {tab.label}

--- a/apps/antalmanac/src/components/Header/Settings/TimeSelector.tsx
+++ b/apps/antalmanac/src/components/Header/Settings/TimeSelector.tsx
@@ -1,43 +1,39 @@
 import { useTimeFormatStore } from '$stores/SettingsStore';
-import { Box, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { Box, Typography, type SxProps, type Theme } from '@mui/material';
 import { useShallow } from 'zustand/react/shallow';
 
 export function TimeSelector() {
-    const theme = useTheme();
-    const accentColor = theme.palette.secondary.main;
-    const segment = theme.palette.settingsSegment;
-
     const [isMilitaryTime, setTimeFormat] = useTimeFormatStore(
         useShallow((store) => [store.isMilitaryTime, store.setTimeFormat])
     );
-
-    const borderColor = theme.palette.divider;
-    const inactiveHoverBackgroundColor = segment.hoverBackground;
 
     const handleTimeFormatChange = (event: React.MouseEvent<HTMLDivElement>) => {
         const value = event.currentTarget.getAttribute('data-value');
         setTimeFormat(value === 'true');
     };
 
-    const getSegmentSx = (selected: boolean, position: 'left' | 'right') => ({
-        flex: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '8px 20px',
-        cursor: 'pointer',
-        fontWeight: 'bold',
-        fontSize: '1.1rem',
-        backgroundColor: selected ? theme.palette.primary.main : segment.background,
-        color: selected ? theme.palette.primary.contrastText : accentColor,
-        ...(position === 'left' ? { borderRight: `1px solid ${borderColor}` } : null),
-        ...(position === 'left' ? { borderTopLeftRadius: 4, borderBottomLeftRadius: 4 } : null),
-        ...(position === 'right' ? { borderTopRightRadius: 4, borderBottomRightRadius: 4 } : null),
-        '&:hover': {
-            backgroundColor: selected ? theme.palette.primary.main : inactiveHoverBackgroundColor,
-        },
-    });
+    const getSegmentSx =
+        (selected: boolean, position: 'left' | 'right'): SxProps<Theme> =>
+        (theme) => ({
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '8px 20px',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            fontSize: '1.1rem',
+            backgroundColor: selected ? theme.vars.palette.primary.main : theme.vars.palette.settingsSegment.background,
+            color: selected ? theme.vars.palette.primary.contrastText : theme.vars.palette.secondary.main,
+            ...(position === 'left' ? { borderRight: 1, borderColor: theme.vars.palette.divider } : null),
+            ...(position === 'left' ? { borderTopLeftRadius: 4, borderBottomLeftRadius: 4 } : null),
+            ...(position === 'right' ? { borderTopRightRadius: 4, borderBottomRightRadius: 4 } : null),
+            '&:hover': {
+                backgroundColor: selected
+                    ? theme.vars.palette.primary.main
+                    : theme.vars.palette.settingsSegment.hoverBackground,
+            },
+        });
 
     return (
         <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -45,11 +41,12 @@ export function TimeSelector() {
                 Time
             </Typography>
             <Box
-                sx={{
+                sx={(theme) => ({
                     display: 'flex',
-                    border: `1px solid ${borderColor}`,
+                    border: 1,
+                    borderColor: theme.vars.palette.divider,
                     borderRadius: '4px',
-                }}
+                })}
             >
                 <Box data-value="false" onClick={handleTimeFormatChange} sx={getSegmentSx(!isMilitaryTime, 'left')}>
                     12 Hour

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -4,10 +4,10 @@ import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
 import { SignInAlertDialog } from '$components/SignInAlertDialog';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { trpc } from '$lib/api/trpc';
 import { getLocalStorageUserId } from '$lib/localStorage';
 import { useScheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { AccountCircle, ExpandMore } from '@mui/icons-material';
 import {
     Alert,
@@ -32,7 +32,7 @@ import { useCallback, useState, type KeyboardEvent } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 export const Signin = () => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const { openLoadingSchedule, setOpenLoadingSchedule } = useScheduleComponentsToggleStore(
         useShallow((state) => ({
@@ -53,11 +53,9 @@ export const Signin = () => {
     const handleOpen = useCallback(() => {
         setIsOpen(true);
         setSettingsAnchorEl(null);
-        if (typeof Storage !== 'undefined') {
-            const savedUserID = getLocalStorageUserId();
-            if (savedUserID !== null) {
-                setUserID(savedUserID);
-            }
+        const savedUserID = getLocalStorageUserId();
+        if (savedUserID !== null) {
+            setUserID(savedUserID);
         }
     }, []);
 

--- a/apps/antalmanac/src/components/Header/Signout.tsx
+++ b/apps/antalmanac/src/components/Header/Signout.tsx
@@ -1,9 +1,9 @@
 import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { signOut } from '$lib/auth/authClient';
 import { useSessionStore } from '$stores/SessionStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { Divider, ListItemIcon, ListItemText, MenuItem, Popover } from '@mui/material';
 import type { UserProfile } from '@packages/db/src/schema/auth/user';
@@ -26,7 +26,7 @@ export function Signout({ onLogoutComplete }: SignoutProps) {
         }))
     );
     const postHog = usePostHog();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const user = useMemo<UserProfile | null>(
         () =>

--- a/apps/antalmanac/src/components/Header/headerStyles.ts
+++ b/apps/antalmanac/src/components/Header/headerStyles.ts
@@ -13,7 +13,7 @@ export const SETTINGS_POPOVER_MENU_HOVER_BG = '#4a4a4a';
  * Single source of truth so popover styles stay in sync.
  */
 export function getSettingsPopoverPaperSx(isDark: boolean): SxProps<Theme> {
-    return {
+    return (theme) => ({
         width: {
             xs: 300,
             sm: 300,
@@ -22,8 +22,8 @@ export function getSettingsPopoverPaperSx(isDark: boolean): SxProps<Theme> {
         p: '16px 20px',
         borderRadius: 2,
         border: '1px solid',
-        borderColor: 'background.default',
-        bgcolor: isDark ? SETTINGS_POPOVER_BG : 'background.paper',
-        color: isDark ? 'white' : 'text.primary',
-    };
+        borderColor: theme.vars.palette.background.default,
+        bgcolor: isDark ? SETTINGS_POPOVER_BG : theme.vars.palette.background.paper,
+        color: isDark ? 'white' : theme.vars.palette.text.primary,
+    });
 }

--- a/apps/antalmanac/src/components/HorizontalRightDivider.tsx
+++ b/apps/antalmanac/src/components/HorizontalRightDivider.tsx
@@ -15,7 +15,7 @@ export const HorizontalRightDivider = ({ children, sx }: HorizontalRightDividerP
                 (theme) => ({
                     margin: 1,
                     '&::before': { width: 0 },
-                    '&::after': { borderColor: theme.palette.text.primary },
+                    '&::after': { borderColor: theme.vars.palette.text.primary },
                 }),
                 sx
             )}

--- a/apps/antalmanac/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.tsx
+++ b/apps/antalmanac/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import {
     KEYBOARD_SHORTCUT_SECTIONS,
     formatShortcutKeys,
@@ -7,21 +8,12 @@ import {
     type ShortcutKey,
     type ShortcutSectionIcon,
 } from '$lib/keyboardShortcuts';
-import { useThemeStore } from '$stores/SettingsStore';
 import { ChatBubbleOutlineOutlined, Close, Keyboard, SearchOutlined, SettingsOutlined } from '@mui/icons-material';
-import { Box, Dialog, IconButton, Stack, Typography, useMediaQuery, useTheme, alpha } from '@mui/material';
+import { Box, Dialog, IconButton, Stack, Typography, useMediaQuery, useTheme, alpha, type Theme } from '@mui/material';
 import { useCallback, useEffect } from 'react';
 
-/** Accent blue: theme maps light → primary (BLUE), dark → secondary (LIGHT_BLUE) — matches links & app chrome */
-function useShortcutsAccentColor() {
-    const theme = useTheme();
-    const isDark = useThemeStore((store) => store.isDark);
-    return isDark ? theme.palette.secondary.main : theme.palette.primary.main;
-}
-
 function SectionHeaderIcon({ icon }: { icon: ShortcutSectionIcon }) {
-    const accent = useShortcutsAccentColor();
-    const sx = { fontSize: 'small' as const, color: accent };
+    const sx = { fontSize: 'small' as const, color: (theme: Theme) => theme.vars.palette.secondary.main };
     switch (icon) {
         case 'general':
             return <SettingsOutlined sx={sx} aria-hidden />;
@@ -33,11 +25,11 @@ function SectionHeaderIcon({ icon }: { icon: ShortcutSectionIcon }) {
 }
 
 function Kbd({ children }: { children: React.ReactNode }) {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     return (
         <Box
             component="kbd"
-            sx={{
+            sx={(theme) => ({
                 display: 'inline-flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -50,11 +42,13 @@ function Kbd({ children }: { children: React.ReactNode }) {
                 fontSize: 'inherit',
                 fontWeight: 600,
                 lineHeight: 1.2,
-                color: 'text.primary',
-                bgcolor: (t) => (isDark ? alpha(t.palette.common.white, 0.1) : alpha(t.palette.text.primary, 0.06)),
+                color: theme.vars.palette.text.primary,
+                bgcolor: isDark
+                    ? alpha(theme.vars.palette.common.white, 0.1)
+                    : alpha(theme.vars.palette.text.primary, 0.06),
                 border: '1px solid',
-                borderColor: 'divider',
-            }}
+                borderColor: theme.vars.palette.divider,
+            })}
         >
             {children}
         </Box>
@@ -73,10 +67,10 @@ function KeyCombo({ keys }: { keys: ShortcutKey[] }) {
                         <Typography
                             component="span"
                             variant="caption"
-                            sx={{
-                                color: 'text.disabled',
+                            sx={(theme) => ({
+                                color: theme.vars.palette.text.disabled,
                                 fontWeight: 600,
-                            }}
+                            })}
                         >
                             +
                         </Typography>
@@ -91,7 +85,7 @@ function KeyCombo({ keys }: { keys: ShortcutKey[] }) {
 function ShortcutRow({ description, keys, isLast }: { description: string; keys: ShortcutKey[]; isLast: boolean }) {
     return (
         <Box
-            sx={{
+            sx={(theme) => ({
                 display: 'flex',
                 flexDirection: 'row',
                 alignItems: 'center',
@@ -99,19 +93,19 @@ function ShortcutRow({ description, keys, isLast }: { description: string; keys:
                 gap: 1.5,
                 py: 1,
                 borderBottom: isLast ? 'none' : '1px solid',
-                borderColor: 'divider',
-            }}
+                borderColor: theme.vars.palette.divider,
+            })}
         >
             <Typography
                 variant="body1"
-                sx={{
+                sx={(theme) => ({
                     lineHeight: 1.45,
-                    color: 'text.secondary',
+                    color: theme.vars.palette.text.secondary,
                     flex: 1,
                     minWidth: 0,
                     pr: { sm: 2 },
                     overflowWrap: 'anywhere',
-                }}
+                })}
             >
                 {description}
             </Typography>
@@ -138,31 +132,29 @@ function SectionBlock({
     icon: ShortcutSectionIcon;
     children: React.ReactNode;
 }) {
-    const accent = useShortcutsAccentColor();
-
     return (
         <Box sx={{ mb: 2, '&:last-child': { mb: 0 } }}>
             <Stack
                 direction="row"
                 alignItems="center"
                 gap={1}
-                sx={{
+                sx={(theme) => ({
                     pb: 1,
                     mb: 0.5,
                     borderBottom: '1px solid',
-                    borderColor: 'divider',
-                }}
+                    borderColor: theme.vars.palette.divider,
+                })}
             >
                 <SectionHeaderIcon icon={icon} />
                 <Typography
                     component="h2"
                     variant="caption"
-                    sx={{
+                    sx={(theme) => ({
                         fontWeight: 700,
                         letterSpacing: '0.1em',
                         textTransform: 'uppercase',
-                        color: accent,
-                    }}
+                        color: theme.vars.palette.secondary.main,
+                    })}
                 >
                     {title}
                 </Typography>
@@ -182,10 +174,9 @@ interface KeyboardShortcutsModalProps {
  */
 export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModalProps) {
     const theme = useTheme();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const isFullScreenLayout = useMediaQuery(theme.breakpoints.down('md'));
     const mac = isMacPlatform();
-    const accent = isDark ? theme.palette.secondary.main : theme.palette.primary.main;
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent) => {
@@ -214,12 +205,12 @@ export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModal
             slotProps={{
                 backdrop: {
                     sx: {
-                        backgroundColor: (t) => alpha(t.palette.common.black, isDark ? 0.55 : 0.36),
+                        backgroundColor: (t) => alpha(t.vars.palette.common.black, isDark ? 0.55 : 0.36),
                         backdropFilter: 'blur(6px)',
                     },
                 },
                 paper: {
-                    sx: {
+                    sx: (t) => ({
                         borderRadius: isFullScreenLayout ? 0 : 3,
                         ...(isFullScreenLayout
                             ? {
@@ -234,34 +225,34 @@ export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModal
                         overflow: 'hidden',
                         display: 'flex',
                         flexDirection: 'column',
-                        bgcolor: 'background.paper',
+                        bgcolor: t.vars.palette.background.paper,
                         border: isFullScreenLayout ? 'none' : '1px solid',
-                        borderColor: 'divider',
-                        boxShadow: isFullScreenLayout ? 'none' : (t) => (isDark ? t.shadows[16] : t.shadows[8]),
+                        borderColor: t.vars.palette.divider,
+                        boxShadow: isFullScreenLayout ? 'none' : isDark ? t.shadows[16] : t.shadows[8],
                         pt: isFullScreenLayout ? 'env(safe-area-inset-top, 0px)' : undefined,
                         pb: isFullScreenLayout ? 'env(safe-area-inset-bottom, 0px)' : undefined,
-                    },
+                    }),
                 },
             }}
         >
             <Box
-                sx={{
+                sx={(t) => ({
                     flexShrink: 0,
                     px: 3,
                     py: 2,
                     borderBottom: '1px solid',
-                    borderColor: 'divider',
-                }}
+                    borderColor: t.vars.palette.divider,
+                })}
             >
                 <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
                     <Stack direction="row" alignItems="flex-start" gap={1.5} sx={{ minWidth: 0 }}>
                         <Keyboard
-                            sx={{
+                            sx={(t) => ({
                                 fontSize: 30,
-                                color: accent,
+                                color: t.vars.palette.secondary.main,
                                 flexShrink: 0,
                                 mt: 0.25,
-                            }}
+                            })}
                         />
                         <Box sx={{ minWidth: 0 }}>
                             <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap" useFlexGap>
@@ -269,17 +260,17 @@ export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModal
                                     component="h1"
                                     variant="h5"
                                     id="keyboard-shortcuts-title"
-                                    sx={{
+                                    sx={(t) => ({
                                         fontWeight: 700,
                                         lineHeight: 1.2,
-                                        color: 'text.primary',
-                                    }}
+                                        color: t.vars.palette.text.primary,
+                                    })}
                                 >
                                     Shortcuts
                                 </Typography>
                                 <Box
                                     component="span"
-                                    sx={{
+                                    sx={(t) => ({
                                         px: 1,
                                         py: 0.35,
                                         borderRadius: 1,
@@ -287,32 +278,24 @@ export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModal
                                         fontWeight: 700,
                                         textTransform: 'uppercase',
                                         letterSpacing: '0.06em',
-                                        color: accent,
-                                        bgcolor: (t) =>
-                                            alpha(
-                                                isDark ? t.palette.secondary.main : t.palette.primary.main,
-                                                isDark ? 0.2 : 0.12
-                                            ),
+                                        color: t.vars.palette.secondary.main,
+                                        bgcolor: alpha(t.vars.palette.secondary.main, isDark ? 0.2 : 0.12),
                                         border: '1px solid',
-                                        borderColor: (t) =>
-                                            alpha(
-                                                isDark ? t.palette.secondary.main : t.palette.primary.main,
-                                                isDark ? 0.4 : 0.28
-                                            ),
-                                    }}
+                                        borderColor: alpha(t.vars.palette.secondary.main, isDark ? 0.4 : 0.28),
+                                    })}
                                 >
                                     {mac ? 'Mac' : 'Windows'}
                                 </Box>
                             </Stack>
                             <Typography
                                 variant="caption"
-                                sx={{
+                                sx={(t) => ({
                                     mt: 0.75,
                                     fontFamily:
                                         'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
-                                    color: 'text.secondary',
+                                    color: t.vars.palette.text.secondary,
                                     letterSpacing: '0.02em',
-                                }}
+                                })}
                             >
                                 {mac ? '⌘' : 'Ctrl'} + / to toggle
                             </Typography>
@@ -321,19 +304,19 @@ export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModal
                     <IconButton
                         aria-label="Close"
                         onClick={onClose}
-                        sx={{
-                            color: 'text.secondary',
+                        sx={(t) => ({
+                            color: t.vars.palette.text.secondary,
                             minWidth: 44,
                             minHeight: 44,
                             mr: -0.75,
                             borderRadius: 1.5,
                             border: '1px solid',
-                            borderColor: 'divider',
-                            bgcolor: (t) => alpha(t.palette.text.primary, isDark ? 0.06 : 0.04),
+                            borderColor: t.vars.palette.divider,
+                            bgcolor: alpha(t.vars.palette.text.primary, isDark ? 0.06 : 0.04),
                             '&:hover': {
-                                bgcolor: 'action.hover',
+                                bgcolor: t.vars.palette.action.hover,
                             },
-                        }}
+                        })}
                     >
                         <Close fontSize="small" />
                     </IconButton>

--- a/apps/antalmanac/src/components/Map/Marker.tsx
+++ b/apps/antalmanac/src/components/Map/Marker.tsx
@@ -137,7 +137,9 @@ export const LocationMarker = forwardRef(
                             <Button
                                 variant="contained"
                                 color="primary"
-                                startIcon={<DirectionsWalkIcon sx={{ color: 'common.white' }} />}
+                                startIcon={
+                                    <DirectionsWalkIcon sx={{ color: (theme) => theme.vars.palette.common.white }} />
+                                }
                                 href={`${GOOGLE_MAPS_URL}${lat},${lng}`}
                                 target="_blank"
                                 sx={{
@@ -151,7 +153,7 @@ export const LocationMarker = forwardRef(
                                         fontSize: '1.25rem',
                                         letterSpacing: 1.25,
                                         fontWeight: 500,
-                                        color: 'common.white',
+                                        color: (theme) => theme.vars.palette.common.white,
                                     }}
                                 >
                                     Directions

--- a/apps/antalmanac/src/components/NotificationSnackbar.tsx
+++ b/apps/antalmanac/src/components/NotificationSnackbar.tsx
@@ -53,7 +53,7 @@ export const NotificationSnackbar = () => {
                 onClose={handleClose}
                 sx={(theme) => ({
                     width: '100%',
-                    color: theme.palette.common.white,
+                    color: theme.vars.palette.common.white,
                     display: 'flex',
                     alignItems: 'center',
                 })}

--- a/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
@@ -44,18 +44,18 @@ export function EnrollmentConfirmStep() {
             />
 
             <CardContent sx={{ paddingTop: 0 }}>
-                <Typography variant="body1" color="text.secondary">
+                <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                     Did you take{' '}
-                    <Box component="span" fontWeight={600} color="text.primary">
+                    <Box component="span" fontWeight={600} sx={{ color: (theme) => theme.vars.palette.text.primary }}>
                         {courseId}
                     </Box>{' '}
                     {courseTitle && <>({courseTitle}) </>}
                     in{' '}
-                    <Box component="span" fontWeight={600} color="text.primary">
+                    <Box component="span" fontWeight={600} sx={{ color: (theme) => theme.vars.palette.text.primary }}>
                         {term?.shortName}
                     </Box>{' '}
                     with{' '}
-                    <Box component="span" fontWeight={600} color="text.primary">
+                    <Box component="span" fontWeight={600} sx={{ color: (theme) => theme.vars.palette.text.primary }}>
                         {professorId}
                     </Box>
                     ?

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -152,7 +152,11 @@ export function ReviewStep() {
                         How was {courseId}?
                     </Typography>
                 }
-                subheader={<Typography color="text.secondary">with {professorId}</Typography>}
+                subheader={
+                    <Typography sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
+                        with {professorId}
+                    </Typography>
+                }
                 action={
                     <IconButton size="small" onClick={handleDismiss} aria-label="dismiss">
                         <Close fontSize="small" />
@@ -164,24 +168,34 @@ export function ReviewStep() {
                 <Stack spacing={2}>
                     <Box display="flex" flexDirection="row" gap={8}>
                         <Box display="flex" flexDirection="column" gap={0.5}>
-                            <Typography color="text.secondary">Overall Quality</Typography>
+                            <Typography sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
+                                Overall Quality
+                            </Typography>
                             <Box display="flex" flexDirection="column" gap={1}>
                                 <Rating value={rating} onChange={(_e, value) => setRating(value ?? 0)} size="large" />
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography
+                                    variant="caption"
+                                    sx={{ color: (theme) => theme.vars.palette.text.secondary }}
+                                >
                                     {ratingLabel(rating)}
                                 </Typography>
                             </Box>
                         </Box>
 
                         <Box display="flex" flexDirection="column" gap={0.5}>
-                            <Typography color="text.secondary">Difficulty (low → high)</Typography>
+                            <Typography sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
+                                Difficulty (low → high)
+                            </Typography>
                             <Box display="flex" flexDirection="column" gap={1}>
                                 <Rating
                                     value={difficulty}
                                     onChange={(_e, value) => setDifficulty(value ?? 0)}
                                     size="large"
                                 />
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography
+                                    variant="caption"
+                                    sx={{ color: (theme) => theme.vars.palette.text.secondary }}
+                                >
                                     {difficultyLabel(difficulty)}
                                 </Typography>
                             </Box>
@@ -200,14 +214,18 @@ export function ReviewStep() {
                         slotProps={{
                             htmlInput: { maxLength: 500 },
                             formHelperText: {
-                                sx: { textAlign: 'right', mx: 0, color: 'text.secondary' },
+                                sx: {
+                                    textAlign: 'right',
+                                    mx: 0,
+                                    color: (theme) => theme.vars.palette.text.secondary,
+                                },
                             },
                         }}
                         helperText={`${textReview.length}/500`}
                     />
 
                     <Box display="flex" flexDirection="column" gap={0.5}>
-                        <Typography color="text.secondary">Tags</Typography>
+                        <Typography sx={{ color: (theme) => theme.vars.palette.text.secondary }}>Tags</Typography>
                         <Box display="flex" flexWrap="wrap" gap={0.75}>
                             {REVIEW_TAGS.map((tag) => (
                                 <Chip

--- a/apps/antalmanac/src/components/ReviewPrompt/SuccessStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/SuccessStep.tsx
@@ -43,9 +43,13 @@ export function SuccessStep() {
             <CardContent sx={{ paddingTop: 0 }}>
                 <Box display="flex" alignItems="center" gap={1}>
                     <CheckCircleOutline color="success" fontSize="small" />
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                         Thanks for reviewing{' '}
-                        <Box component="span" fontWeight={600} color="text.primary">
+                        <Box
+                            component="span"
+                            fontWeight={600}
+                            sx={{ color: (theme) => theme.vars.palette.text.primary }}
+                        >
                             {courseId}
                         </Box>{' '}
                         with {professorId}.

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsDialog.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsDialog.tsx
@@ -1,10 +1,10 @@
 import { SignInDialog } from '$components/dialogs/SignInDialog';
 import { NotificationEmailTooltip } from '$components/RightPane/AddedCourses/Notifications/NotificationEmailTooltip';
 import { NotificationsTabs } from '$components/RightPane/AddedCourses/Notifications/NotificationsTabs';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { LIGHT_BLUE } from '$src/globals';
 import { useSessionStore } from '$stores/SessionStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Notifications } from '@mui/icons-material';
 import {
     Box,
@@ -26,7 +26,7 @@ interface NotificationsDialogProps {
 }
 
 export function NotificationsDialog({ disabled, buttonSx }: NotificationsDialogProps) {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const [open, setOpen] = useState(false);
     const [signInOpen, setSignInOpen] = useState<boolean>(false);
     const postHog = usePostHog();
@@ -83,18 +83,17 @@ export function NotificationsDialog({ disabled, buttonSx }: NotificationsDialogP
                 <DialogContent
                     sx={
                         isDark
-                            ? {
-                                  '& a, & a:hover, & a:visited': { color: LIGHT_BLUE },
-                                  '& .MuiTab-root': { color: 'text.secondary' },
+                            ? (theme) => ({
+                                  '& .MuiTab-root': { color: theme.vars.palette.text.secondary },
                                   '& .MuiTab-root.Mui-selected': { color: LIGHT_BLUE },
                                   '& .MuiTabs-indicator': { backgroundColor: LIGHT_BLUE },
                                   '& .MuiCheckbox-root.Mui-checked': { color: LIGHT_BLUE },
-                                  '& .MuiChip-label': { color: 'text.primary' },
+                                  '& .MuiChip-label': { color: theme.vars.palette.text.primary },
                                   '& .MuiTablePagination-actions .MuiIconButton-root': {
-                                      color: 'text.primary',
+                                      color: theme.vars.palette.text.primary,
                                   },
-                                  '& .MuiTablePagination-selectIcon': { color: 'text.primary' },
-                              }
+                                  '& .MuiTablePagination-selectIcon': { color: theme.vars.palette.text.primary },
+                              })
                             : undefined
                     }
                 >

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
@@ -1,7 +1,7 @@
 import { NotificationsTable } from '$components/RightPane/AddedCourses/Notifications/NotificationsTable';
 import { type Notification, useNotificationStore } from '$stores/NotificationStore';
 import { NotificationAddOutlined } from '@mui/icons-material';
-import { Box, CircularProgress, Paper, Tab, Tabs, Typography, useTheme } from '@mui/material';
+import { Box, CircularProgress, Paper, Tab, Tabs, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -21,7 +21,6 @@ function groupNotificationsByTerm(notifications: Partial<Record<string, Notifica
 }
 
 export function NotificationsTabs() {
-    const theme = useTheme();
     const { initialized, notifications } = useNotificationStore(
         useShallow((store) => ({ initialized: store.initialized, notifications: store.notifications }))
     );
@@ -48,7 +47,10 @@ export function NotificationsTabs() {
             <Box
                 sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 4 }}
             >
-                <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center' }}>
+                <Typography
+                    variant="body1"
+                    sx={{ textAlign: 'center', color: (theme) => theme.vars.palette.text.secondary }}
+                >
                     You don&apos;t have any notifications enabled.
                 </Typography>
                 <Box
@@ -61,11 +63,20 @@ export function NotificationsTabs() {
                         flexWrap: 'wrap',
                     }}
                 >
-                    <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                    <Typography
+                        variant="body2"
+                        sx={{ textAlign: 'center', color: (theme) => theme.vars.palette.text.secondary }}
+                    >
                         Enable notifications for courses using the
                     </Typography>
-                    <NotificationAddOutlined fontSize="small" sx={{ color: 'text.secondary' }} />
-                    <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                    <NotificationAddOutlined
+                        fontSize="small"
+                        sx={{ color: (theme) => theme.vars.palette.text.secondary }}
+                    />
+                    <Typography
+                        variant="body2"
+                        sx={{ textAlign: 'center', color: (theme) => theme.vars.palette.text.secondary }}
+                    >
                         icon to get notified about status changes.
                     </Typography>
                 </Box>
@@ -83,7 +94,10 @@ export function NotificationsTabs() {
                 elevation={0}
                 variant="outlined"
                 square
-                sx={{ bgcolor: theme.palette.background.elevated, borderColor: 'divider' }}
+                sx={(theme) => ({
+                    bgcolor: theme.vars.palette.background.elevated,
+                    borderColor: theme.vars.palette.divider,
+                })}
             >
                 <Tabs
                     value={displayTab}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/LoadingMessage.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/LoadingMessage.tsx
@@ -1,9 +1,9 @@
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Box } from '@mui/material';
 import Image from 'next/image';
 
 export function LoadingMessage() {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     return (
         <Box sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/NoResults.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/NoResults.tsx
@@ -1,6 +1,6 @@
 import { PlannerCourseLinkBanner } from '$components/RightPane/CoursePane/CourseRenderPane/PlannerCourseLinkBanner';
 import type { CourseSearchParams } from '$components/RightPane/CoursePane/SearchParams/types';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Box } from '@mui/material';
 import Image from 'next/image';
 
@@ -9,7 +9,7 @@ interface NoResultsProps {
 }
 
 export function NoResults({ formData }: NoResultsProps) {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     return (
         <Box

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/RecruitmentBanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/RecruitmentBanner.tsx
@@ -41,7 +41,7 @@ export function RecruitmentBanner({ deptValue }: RecruitmentBannerProps) {
                     severity="info"
                     style={{
                         color: 'unset',
-                        backgroundColor: theme.palette.background.paper,
+                        backgroundColor: theme.vars.palette.background.paper,
                         boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
                     }}
                     action={

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CreateRoadmapLinkItem.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/CreateRoadmapLinkItem.tsx
@@ -1,6 +1,6 @@
-import { LIGHT_BLUE, PLANNER_LINK } from '$src/globals';
-import { useThemeStore } from '$stores/SettingsStore';
+import { PLANNER_LINK } from '$src/globals';
 import { Link, MenuItem } from '@mui/material';
+import NextLink from 'next/link';
 
 interface CreateRoadmapLinkItemProps {
     verticalPadding?: number | string;
@@ -8,20 +8,17 @@ interface CreateRoadmapLinkItemProps {
 }
 
 export const CreateRoadmapLinkItem = ({ verticalPadding, value }: CreateRoadmapLinkItemProps) => {
-    const isDark = useThemeStore((state) => state.isDark);
-
     return (
         <MenuItem value={value} sx={{ padding: 0 }}>
             <Link
+                component={NextLink}
                 href={PLANNER_LINK}
-                target="_blank"
                 sx={{
                     padding: 2,
                     paddingTop: verticalPadding,
                     paddingBottom: verticalPadding,
                     width: '100%',
                     height: '100%',
-                    ...(isDark && { color: LIGHT_BLUE }),
                 }}
             >
                 Create a roadmap!

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/Footer.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/Footer.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@mui/material';
 
 export const Footer = () => {
     return (
-        <Stack direction="row" justifyContent="center" sx={{ color: 'text.secondary' }}>
+        <Stack direction="row" justifyContent="center" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
             <ProjectsButton />
             <GitHubButton />
             <FeedbackButton />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox.tsx
@@ -1,4 +1,4 @@
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Box, type BoxProps, useTheme } from '@mui/material';
 import { grey } from '@mui/material/colors';
 
@@ -8,9 +8,9 @@ interface CustomInputBoxProps {
 }
 
 export const CustomInputBox = ({ children, boxProps }: CustomInputBoxProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const theme = useTheme();
-    const secondaryColor = theme.palette.secondary.main;
+    const secondaryColor = theme.vars.palette.secondary.main;
     return (
         <Box
             {...boxProps}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel.tsx
@@ -1,5 +1,5 @@
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { mergeSx } from '$lib/helpers';
-import { useThemeStore } from '$stores/SettingsStore';
 import { InputLabel, type SxProps, type Theme } from '@mui/material';
 import { grey } from '@mui/material/colors';
 
@@ -11,14 +11,14 @@ interface CustomInputLabelProps {
 }
 
 export const CustomInputLabel = ({ label, id, isAligned, sx }: CustomInputLabelProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     return (
         <InputLabel
             htmlFor={id}
             shrink={false}
             sx={mergeSx(
-                {
+                (theme) => ({
                     display: 'flex',
                     alignItems: 'center',
                     height: '100%',
@@ -28,7 +28,7 @@ export const CustomInputLabel = ({ label, id, isAligned, sx }: CustomInputLabelP
                     whiteSpace: 'nowrap',
                     border: '1px solid',
                     // Adjusted borderColor to better match the background of CustomInputBox.
-                    // The default theme.palette.divider values are:
+                    // The default theme.vars.palette.divider values are:
                     // - Light mode: rgba(0, 0, 0, 0.12)
                     // - Dark mode: rgba(255, 255, 255, 0.12)
                     //
@@ -43,8 +43,8 @@ export const CustomInputLabel = ({ label, id, isAligned, sx }: CustomInputLabelP
                     userSelect: 'none',
                     borderTopLeftRadius: '4px',
                     borderBottomLeftRadius: '4px',
-                    color: isDark ? 'white' : 'text.secondary',
-                },
+                    color: isDark ? 'white' : theme.vars.palette.text.secondary,
+                }),
                 sx
             )}
         >

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
@@ -13,14 +13,14 @@ import { StartTimeField } from '$components/RightPane/CoursePane/SearchForm/Manu
 import { UnitsField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/UnitsField';
 import { hasAdvancedParams } from '$components/RightPane/CoursePane/SearchParams/helpers';
 import { readAdvancedSearchParams } from '$components/RightPane/CoursePane/SearchParams/loaders';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { Box, Button, Collapse, Typography } from '@mui/material';
 import { useState } from 'react';
 
 export function AdvancedSearch() {
     const [expanded, setExpanded] = useState(() => hasAdvancedParams(readAdvancedSearchParams()));
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const handleExpand = () => setExpanded((value) => !value);
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchFormModeToggle.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchFormModeToggle.tsx
@@ -6,9 +6,9 @@ import {
 } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { readCourseSearchParams } from '$components/RightPane/CoursePane/SearchParams/loaders';
 import type { CourseSearchMode } from '$components/RightPane/CoursePane/SearchParams/types';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { LIGHT_BLUE } from '$src/globals';
 import { useSavedSearchStore } from '$stores/SavedSearchStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { alpha, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -16,7 +16,7 @@ export function SearchFormModeToggle() {
     const { manualSearchEnabled, setSearchMode } = useCourseSearchMode();
     const { resetForm, setFields } = useCourseSearchForm();
     const { clearView } = useCourseSearchView();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const { savedManualSearch, saveManualSearch } = useSavedSearchStore(
         useShallow((store) => ({
             savedManualSearch: store.savedManualSearch,

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBarPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBarPopover.tsx
@@ -55,7 +55,10 @@ export function CourseInfoBarPopover({
                     }}
                 />
                 <CardContent sx={{ maxWidth: 500, pt: 0 }}>
-                    <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center' }}>
+                    <Typography
+                        variant="body1"
+                        sx={{ textAlign: 'center', color: (theme) => theme.vars.palette.text.secondary }}
+                    >
                         No description available.
                     </Typography>
                 </CardContent>
@@ -86,7 +89,7 @@ export function CourseInfoBarPopover({
                             textAlign: 'center',
                         }}
                     >
-                        <Typography variant="body1" color="text.secondary">
+                        <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                             No description available.
                         </Typography>
                     </Box>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/PrereqTree.tsx
@@ -24,8 +24,8 @@ const Node: FC<NodeProps> = (props) => {
             <div
                 className={'course'}
                 style={{
-                    backgroundColor: theme.palette.background.paper,
-                    color: theme.palette.text.primary,
+                    backgroundColor: theme.vars.palette.background.paper,
+                    color: theme.vars.palette.text.primary,
                 }}
             >
                 {props.label}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/CourseCodeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/CourseCodeCell.tsx
@@ -1,7 +1,7 @@
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Chip, type SxProps, type TableCellProps, Tooltip } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { useState } from 'react';
@@ -12,7 +12,7 @@ interface CourseCodeCellProps extends TableCellProps {
 }
 
 export const CourseCodeCell = ({ sectionCode, sx, ...rest }: CourseCodeCellProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const [isHovered, setIsHovered] = useState(false);
 
     const postHog = usePostHog();

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/EnrollmentCell.tsx
@@ -2,7 +2,7 @@ import { TableBodyCellContainer } from '$components/RightPane/SectionTable/Secti
 import { EnrollmentHistoryPopover } from '$components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { useTimeFormatStore } from '$stores/SettingsStore';
-import { Box, ButtonBase, Popover, Tooltip, Typography, useTheme } from '@mui/material';
+import { Box, ButtonBase, Popover, Tooltip, Typography } from '@mui/material';
 import type { AACourseWithTerm, AASection } from '@packages/antalmanac-types';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -14,8 +14,6 @@ interface EnrollmentCellProps {
 export const EnrollmentCell = ({ section, course }: EnrollmentCellProps) => {
     const isMobile = useIsMobile();
     const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
-    const theme = useTheme();
-    const secondaryColor = theme.palette.secondary.main;
 
     const formattedTime = useMemo(() => {
         if (!section.updatedAt) {
@@ -56,7 +54,7 @@ export const EnrollmentCell = ({ section, course }: EnrollmentCellProps) => {
                 sx={{
                     fontFamily: 'inherit',
                     fontSize: 'unset',
-                    color: secondaryColor,
+                    color: (theme) => theme.vars.palette.secondary.main,
                     fontWeight: 700,
                 }}
                 onClick={handleClick}
@@ -64,7 +62,7 @@ export const EnrollmentCell = ({ section, course }: EnrollmentCellProps) => {
                 {section.numCurrentlyEnrolled.totalEnrolled} / {maxCapacity}
             </ButtonBase>
         ),
-        [handleClick, section.numCurrentlyEnrolled.totalEnrolled, maxCapacity, secondaryColor]
+        [handleClick, section.numCurrentlyEnrolled.totalEnrolled, maxCapacity]
     );
 
     return (

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -2,7 +2,7 @@ import { TableBodyCellContainer } from '$components/RightPane/SectionTable/Secti
 import { GradesPopover } from '$components/RightPane/SectionTable/SectionTablePopover/GradesPopover';
 import { useIsMobile } from '$hooks/useIsMobile';
 import { trpcReact } from '$lib/api/trpc';
-import { ButtonBase, Popover, useTheme } from '@mui/material';
+import { ButtonBase, Popover } from '@mui/material';
 import type { AACourseWithTerm, AASection } from '@packages/antalmanac-types';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -15,7 +15,6 @@ export const GpaCell = ({ section, course }: GpaCellProps) => {
     const { deptCode, courseNumber } = course;
     const { instructors } = section;
     const isMobile = useIsMobile();
-    const theme = useTheme();
     const [anchorEl, setAnchorEl] = useState<Element>();
 
     const namedInstructors = useMemo(() => instructors.filter((i) => i !== 'STAFF'), [instructors]);
@@ -54,7 +53,7 @@ export const GpaCell = ({ section, course }: GpaCellProps) => {
                 sx={{
                     fontFamily: 'inherit',
                     fontSize: 'unset',
-                    color: theme.palette.secondary.main,
+                    color: (theme) => theme.vars.palette.secondary.main,
                     fontWeight: 700,
                 }}
                 onClick={handleClick}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
@@ -1,7 +1,6 @@
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
-import { Box, Typography, type SxProps } from '@mui/material';
+import { Box, Link, Typography, type SxProps } from '@mui/material';
 import type { AASection } from '@packages/antalmanac-types';
-import Link from 'next/link';
 
 interface InstructorsCellProps {
     section: Pick<AASection, 'instructors'>;
@@ -12,7 +11,7 @@ export const InstructorsCell = ({ section, sx }: InstructorsCellProps) => {
     const { instructors } = section;
     const links = instructors.map((profName, index) => {
         if (profName === 'STAFF') {
-            return <Box key={profName + index}>{profName}</Box>; // The key should be fine as we're not changing ['STAFF, 'STAFF']
+            return <Box key={profName + index}>{profName}</Box>;
         }
 
         const lastName = profName.substring(0, profName.indexOf(','));

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
@@ -1,7 +1,7 @@
 import { EXCLUDE_RESTRICTION_CODES_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { Box, Popover, Tooltip, Typography, useTheme } from '@mui/material';
+import { Box, Link, Popover, Tooltip, Typography } from '@mui/material';
 import type { AASection } from '@packages/antalmanac-types';
 import { Fragment, useCallback, useMemo, useState } from 'react';
 
@@ -16,8 +16,6 @@ const RESTRICTION_CODE_LABELS = Object.fromEntries(
 export const RestrictionsCell = ({ section }: RestrictionsCellProps) => {
     const { restrictions } = section;
     const isMobile = useIsMobile();
-    const theme = useTheme();
-    const secondaryColor = theme.palette.secondary.main;
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
     const parsedRestrictions = useMemo(
@@ -50,8 +48,7 @@ export const RestrictionsCell = ({ section }: RestrictionsCellProps) => {
             }}
         >
             <Typography>{parsedRestrictions}</Typography>
-            <Typography
-                component="a"
+            <Link
                 href="https://www.reg.uci.edu/enrollment/restrict_codes.html"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -61,7 +58,7 @@ export const RestrictionsCell = ({ section }: RestrictionsCellProps) => {
                 }}
             >
                 University Requirements
-            </Typography>
+            </Link>
         </Box>
     );
 
@@ -81,7 +78,7 @@ export const RestrictionsCell = ({ section }: RestrictionsCellProps) => {
                                 background: 'none',
                                 border: 0,
                                 textDecoration: 'underline',
-                                color: secondaryColor,
+                                color: (theme) => theme.vars.palette.secondary.main,
                             }}
                         >
                             {restrictions}
@@ -98,15 +95,14 @@ export const RestrictionsCell = ({ section }: RestrictionsCellProps) => {
                     </>
                 ) : (
                     <Tooltip title={restrictionDescriptions}>
-                        <Typography
-                            variant="inherit"
-                            component="a"
+                        <Link
                             href="https://www.reg.uci.edu/enrollment/restrict_codes.html"
                             target="_blank"
                             rel="noopener noreferrer"
+                            sx={{ color: 'inherit', font: 'inherit' }}
                         >
                             {restrictions}
-                        </Typography>
+                        </Link>
                     </Tooltip>
                 )}
             </Box>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SectionCodeCell.tsx
@@ -1,7 +1,7 @@
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { type AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Chip, Tooltip } from '@mui/material';
 import type { AASection } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
@@ -14,7 +14,7 @@ interface SectionCodeCellProps {
 
 export const SectionCodeCell = ({ section, analyticsCategory }: SectionCodeCellProps) => {
     const { sectionCode } = section;
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const [isHovered, setIsHovered] = useState(false);
 
     const postHog = usePostHog();

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/StatusCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/StatusCell.tsx
@@ -5,13 +5,13 @@ import { type WebsocSectionStatus } from '@packages/anteater-api/types';
 
 const SECTION_STATUS_COLORS: Partial<Record<WebsocSectionStatus, SxProps<Theme>>> = {
     OPEN: {
-        color: (theme) => theme.palette.enrollmentStatus.open,
+        color: (theme) => theme.vars.palette.enrollmentStatus.open,
     },
     Waitl: {
-        color: (theme) => theme.palette.enrollmentStatus.waitlist,
+        color: (theme) => theme.vars.palette.enrollmentStatus.waitlist,
     },
     FULL: {
-        color: (theme) => theme.palette.enrollmentStatus.full,
+        color: (theme) => theme.vars.palette.enrollmentStatus.full,
     },
 };
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/SyllabusCell.tsx
@@ -1,4 +1,5 @@
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
+import { Link } from '@mui/material';
 import type { AASection } from '@packages/antalmanac-types';
 
 interface SyllabusCellProps {
@@ -13,9 +14,9 @@ export const SyllabusCell = ({ section }: SyllabusCellProps) => {
 
     return (
         <TableBodyCellContainer>
-            <a href={webURL} target="_blank" rel="noopener noreferrer">
+            <Link href={webURL} target="_blank" rel="noopener noreferrer">
                 Link
-            </a>
+            </Link>
         </TableBodyCellContainer>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -1,12 +1,13 @@
 import { SectionTableBodyRowCell } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowCells';
 import { SectionTableBodyRowColorStrip } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { type AnalyticsCategory } from '$lib/analytics/analytics';
 import AppStore from '$stores/AppStore';
 import { useColumnStore } from '$stores/ColumnStore';
 import { useHoveredStore } from '$stores/HoveredStore';
 import { scheduleSectionKey } from '$stores/scheduleHelpers';
-import { usePreviewStore, useThemeStore } from '$stores/SettingsStore';
-import { TableRow, useTheme } from '@mui/material';
+import { usePreviewStore } from '$stores/SettingsStore';
+import { TableRow } from '@mui/material';
 import { type AASection, type AACourseWithTerm } from '@packages/antalmanac-types';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -22,8 +23,7 @@ interface SectionTableBodyRowProps {
 export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
     const { section, course, allowHighlight, scheduleNames, scheduleConflict, analyticsCategory } = props;
 
-    const theme = useTheme();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const activeColumns = useColumnStore((store) => store.activeColumns);
     const previewMode = usePreviewStore((store) => store.previewMode);
     const setHoveredEvent = useHoveredStore((store) => store.setHoveredEvent);
@@ -92,7 +92,7 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
              */
             sx={{
                 '&:nth-of-type(odd)': {
-                    backgroundColor: theme.palette.action.hover,
+                    backgroundColor: (theme) => theme.vars.palette.action.hover,
                 },
             }}
             style={computedRowStyle}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
@@ -1,4 +1,5 @@
 import { changeCourseColor } from '$actions/AppStoreActions';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useIsMobile } from '$hooks/useIsMobile';
 import {
     courseColorKey,
@@ -10,7 +11,6 @@ import {
 import AppStore from '$stores/AppStore';
 import { colorPickerPresetColors } from '$stores/scheduleHelpers';
 import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Box, Popover, type PopoverProps, type SxProps, TableCell, Tooltip } from '@mui/material';
 import { type AASection, type AATerm } from '@packages/antalmanac-types';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -64,7 +64,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
     // Read the single resolved source of truth so the strip always matches the calendar
     // (which reads the same map via useSectionThemeAssignments).
     const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
-    const isDark = useThemeStore((s) => s.isDark);
+    const isDark = useIsDarkMode();
 
     const palette = useMemo(() => getPalette(activeSectionColor, isDark), [activeSectionColor, isDark]);
     const assignments = activeSectionColor === 'custom' ? EMPTY_ASSIGNMENTS : activeAssignments;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
@@ -147,7 +147,7 @@ export function EnrollmentHistoryPopover({
                             px: 1,
                         }}
                     >
-                        <Typography variant="body1" color="text.secondary">
+                        <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                             No past enrollment data found for this course
                         </Typography>
                     </Box>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
@@ -17,17 +17,17 @@ interface EnrollmentHistoryPopoverChartProps {
 
 export function EnrollmentHistoryPopoverChart({ days }: EnrollmentHistoryPopoverChartProps) {
     const theme = useTheme();
-    const chartColors = theme.palette.enrollmentStatus;
+    const chartColors = theme.vars.palette.enrollmentStatus;
 
     return (
         <ResponsiveContainer>
             <LineChart data={days} style={{ cursor: 'pointer' }}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                <RechartsTooltip contentStyle={{ backgroundColor: theme.palette.background.paper }} />
+                <RechartsTooltip contentStyle={{ backgroundColor: theme.vars.palette.background.paper }} />
                 <Legend wrapperStyle={{ left: 0, width: '100%' }} />
 
-                <XAxis dataKey="date" tick={{ fontSize: 12, fill: theme.palette.text.primary }} />
-                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} width={35} />
+                <XAxis dataKey="date" tick={{ fontSize: 12, fill: theme.vars.palette.text.primary }} />
+                <YAxis tick={{ fontSize: 12, fill: theme.vars.palette.text.primary }} width={35} />
 
                 <Line
                     type="monotone"

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
@@ -153,7 +153,7 @@ export function GradesPopover(props: GradesPopoverProps) {
                             px: 1,
                         }}
                     >
-                        <Typography variant="body1" color="text.secondary">
+                        <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                             {view === 'instructor'
                                 ? "This instructor doesn't have a specific GPA for this course."
                                 : 'No data available.'}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
@@ -10,21 +10,23 @@ interface GradesPopoverChartProps {
 
 export function GradesPopoverChart({ grades }: GradesPopoverChartProps) {
     const theme = useTheme();
-    const secondaryColor = theme.palette.secondary.main;
+    const accentColor = theme.vars.palette.secondary.main;
+    const textColor = theme.vars.palette.text.primary;
+    const paperColor = theme.vars.palette.background.paper;
 
     return (
         <ResponsiveContainer>
             <BarChart data={grades} style={{ cursor: 'pointer' }}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                <XAxis dataKey="name" tick={{ fontSize: 12, fill: theme.palette.text.primary }} height={20} />
-                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} unit="%" width={35} />
+                <XAxis dataKey="name" tick={{ fontSize: 12, fill: textColor }} height={20} />
+                <YAxis tick={{ fontSize: 12, fill: textColor }} unit="%" width={35} />
                 <RechartsTooltip
                     contentStyle={{
-                        backgroundColor: theme.palette.background.paper,
+                        backgroundColor: paperColor,
                         border: 0,
                     }}
-                    labelStyle={{ color: secondaryColor }}
-                    itemStyle={{ color: secondaryColor }}
+                    labelStyle={{ color: accentColor }}
+                    itemStyle={{ color: accentColor }}
                     labelFormatter={(gradeLabel) => `Grade ${gradeLabel}`}
                     formatter={(value) => {
                         const n = typeof value === 'number' ? value : Number(value);
@@ -32,7 +34,7 @@ export function GradesPopoverChart({ grades }: GradesPopoverChartProps) {
                         return [`${pct}%`];
                     }}
                 />
-                <Bar dataKey="all" fill={theme.palette.primary.main} />
+                <Bar dataKey="all" fill={accentColor} />
             </BarChart>
         </ResponsiveContainer>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
@@ -68,14 +68,14 @@ export function PastSyllabiPopover(props: PastSyllabiPopoverProps) {
                 {loading ? (
                     <Skeleton variant="rectangular" animation="wave" height="150px" width="100%" />
                 ) : syllabi.length === 0 ? (
-                    <Typography variant="body1" color="text.secondary">
+                    <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.secondary }}>
                         No syllabi found for this course.
                     </Typography>
                 ) : (
                     <List disablePadding sx={{ maxHeight: height, overflow: 'auto' }}>
                         {Object.entries(syllabiByTerm).map(([term, entries]) => (
                             <ListSubheader key={term} disableGutters disableSticky>
-                                <Typography variant="body1" color="text.primary">
+                                <Typography variant="body1" sx={{ color: (theme) => theme.vars.palette.text.primary }}>
                                     {term}
                                 </Typography>
                                 {entries.map((entry) => (

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
@@ -1,9 +1,9 @@
 import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
 import { AddedCoursesRoot } from '$components/RightPane/AddedCourses/AddedCoursesRoot';
 import { CoursePaneRoot } from '$components/RightPane/CoursePane/CoursePaneRoot';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useActiveTab } from '$lib/tabs/hooks';
 import { unreachableCase } from '$lib/utils';
-import { useThemeStore } from '$stores/SettingsStore';
 import Image from 'next/image';
 import { lazy, Suspense } from 'react';
 
@@ -11,7 +11,7 @@ const UCIMap = lazy(() => import('$components/Map/Map').then((m) => ({ default: 
 
 export function ScheduleManagementContent() {
     const activeTab = useActiveTab();
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     switch (activeTab) {
         case 'calendar':

--- a/apps/antalmanac/src/components/buttons/AboutButton.tsx
+++ b/apps/antalmanac/src/components/buttons/AboutButton.tsx
@@ -1,13 +1,11 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { DONATION_LINK, LIGHT_BLUE } from '$src/globals';
-import { useThemeStore } from '$stores/SettingsStore';
+import { DONATION_LINK } from '$src/globals';
 import { Info } from '@mui/icons-material';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Link } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useState } from 'react';
 
 export const AboutButton = () => {
-    const isDark = useThemeStore((store) => store.isDark);
     const [open, setOpen] = useState(false);
     const postHog = usePostHog();
 
@@ -30,7 +28,7 @@ export const AboutButton = () => {
             </Button>
             <Dialog open={open} onClose={handleClose}>
                 <DialogTitle>About</DialogTitle>
-                <DialogContent sx={isDark ? { '& a, & a:hover, & a:visited': { color: LIGHT_BLUE } } : undefined}>
+                <DialogContent>
                     <DialogContentText>
                         AntAlmanac is a schedule planning tool for UCI students.
                         <br />

--- a/apps/antalmanac/src/components/buttons/MapLink.tsx
+++ b/apps/antalmanac/src/components/buttons/MapLink.tsx
@@ -1,4 +1,5 @@
-import Link from 'next/link';
+import { Link } from '@mui/material';
+import NextLink from 'next/link';
 
 interface MapLinkProps {
     buildingId: number;
@@ -7,12 +8,7 @@ interface MapLinkProps {
 
 export const MapLink = ({ buildingId, room }: MapLinkProps) => {
     return (
-        <Link
-            href={`/map?location=${buildingId}`}
-            style={{
-                textDecoration: 'none',
-            }}
-        >
+        <Link component={NextLink} href={`/map?location=${buildingId}`} underline="hover">
             {room}
         </Link>
     );

--- a/apps/antalmanac/src/components/buttons/Screenshot.tsx
+++ b/apps/antalmanac/src/components/buttons/Screenshot.tsx
@@ -1,5 +1,5 @@
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Panorama } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
 import { saveAs } from 'file-saver';
@@ -10,7 +10,7 @@ interface ScreenshotButtonProps {
 }
 
 export function ScreenshotButton({ onScreenshot }: ScreenshotButtonProps) {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
     const postHog = usePostHog();
 
     const handleClick = () => {

--- a/apps/antalmanac/src/components/buttons/SignInButtons/AppleSignInButton.tsx
+++ b/apps/antalmanac/src/components/buttons/SignInButtons/AppleSignInButton.tsx
@@ -1,6 +1,6 @@
 import { SignInButton } from '$components/buttons/SignInButtons/SignInButton';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Provider } from '$lib/auth/authTypes';
-import { useThemeStore } from '$stores/SettingsStore';
 import { Apple as AppleIcon } from '@mui/icons-material';
 
 interface AppleSignInButtonProps {
@@ -20,7 +20,7 @@ interface AppleSignInButtonProps {
  * Light mode → black style: #000000 bg, #FFFFFF text, #1A1A1A on hover.
  */
 export const AppleSignInButton = ({ fullWidth }: AppleSignInButtonProps) => {
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     return (
         <SignInButton

--- a/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
+++ b/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
@@ -1,5 +1,5 @@
 import { SignInButtons } from '$components/buttons/SignInButtons/SignInButtons';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { Stack, Dialog, DialogTitle, DialogContent, Alert } from '@mui/material';
 
 interface SignInDialogProps {
@@ -10,7 +10,7 @@ interface SignInDialogProps {
 
 export function SignInDialog(props: SignInDialogProps) {
     const { onClose, open } = props;
-    const isDark = useThemeStore((store) => store.isDark);
+    const isDark = useIsDarkMode();
 
     const handleClose = () => {
         onClose();

--- a/apps/antalmanac/src/components/drag-and-drop/DragHandle.tsx
+++ b/apps/antalmanac/src/components/drag-and-drop/DragHandle.tsx
@@ -31,7 +31,7 @@ export function DragHandle({ disabled = false, sx, iconSx }: DragHandleProps) {
                     borderRadius: 1,
                     touchAction: 'none',
                     '&:hover': {
-                        backgroundColor: disabled ? 'transparent' : theme.palette.action.hover,
+                        backgroundColor: disabled ? 'transparent' : theme.vars.palette.action.hover,
                     },
                     '&:focus-visible': {
                         boxShadow: disabled ? 'none' : '0 0 0 2px #4c9ffe',
@@ -43,7 +43,7 @@ export function DragHandle({ disabled = false, sx, iconSx }: DragHandleProps) {
             <DragIndicatorIcon
                 sx={mergeSx(
                     {
-                        color: disabled ? theme.palette.action.disabled : theme.palette.action.active,
+                        color: disabled ? theme.vars.palette.action.disabled : theme.vars.palette.action.active,
                     },
                     iconSx
                 )}

--- a/apps/antalmanac/src/hooks/useIsDarkMode.ts
+++ b/apps/antalmanac/src/hooks/useIsDarkMode.ts
@@ -1,0 +1,32 @@
+import { useColorScheme } from '@mui/material/styles';
+
+export function getIsDarkMode(): boolean {
+    if (typeof document === 'undefined') {
+        return false;
+    }
+
+    return document.documentElement.classList.contains('dark');
+}
+
+export function useIsDarkMode(): boolean {
+    const { mode, systemMode, colorScheme } = useColorScheme();
+
+    if (colorScheme === 'dark') {
+        return true;
+    }
+    if (colorScheme === 'light') {
+        return false;
+    }
+
+    if (mode === 'dark') {
+        return true;
+    }
+    if (mode === 'light') {
+        return false;
+    }
+    if (mode === 'system' && systemMode) {
+        return systemMode === 'dark';
+    }
+
+    return getIsDarkMode();
+}

--- a/apps/antalmanac/src/hooks/useSectionThemeAssignments.ts
+++ b/apps/antalmanac/src/hooks/useSectionThemeAssignments.ts
@@ -1,6 +1,6 @@
+import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { getPalette, type SectionColorSetting, type ThemeAssignmentMap } from '$lib/sectionThemes';
 import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import { useMemo } from 'react';
 
 export interface SectionThemeContext {
@@ -21,7 +21,7 @@ export interface SectionThemeContext {
 export function useSectionThemeAssignments(): SectionThemeContext {
     const setting = useSectionThemeStore(selectActiveSectionColor);
     const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
-    const isDark = useThemeStore((s) => s.isDark);
+    const isDark = useIsDarkMode();
 
     return useMemo(() => {
         const palette = getPalette(setting, isDark);

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -4,6 +4,8 @@ enum LocalStorageKeys {
     patchNotesKey = 'latestPatchSeen',
     recruitmentDismissalTime = 'recruitmentDismissalTime',
     tourHasRun = 'tourHasRun',
+    /** @deprecated Theme preference is now managed by MUI via modeStorageKey="theme". */
+    theme = 'theme',
     sectionColor = 'sectionColor',
     sectionColorAssignments = 'sectionColorAssignments',
     show24HourTime = 'show24HourTime',
@@ -13,14 +15,11 @@ enum LocalStorageKeys {
     columnToggles = 'columnToggles',
     wasLoggedIn = 'wasLoggedIn',
     dataCache = 'dataCache',
+    importedUser = 'importedUser',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
     addedCoursesSkeletonBlueprint = 'addedCoursesSkeletonBlueprint',
 
-    /** @deprecated theme is now managed by MUI and should not be written to directly */
-    theme = 'theme',
-    /** @deprecated Guest import confirmation now uses a snackbar in AuthInitializer. */
-    importedUser = 'importedUser',
     /** @deprecated No longer used. Low impact feature. */
     recentlySearched = 'recentlySearched',
     /** @deprecated Removed for being a net negative on UX and confusing schedule persistence behavior */
@@ -37,183 +36,176 @@ enum LocalStorageKeys {
 
 const LSK = LocalStorageKeys;
 
-function getLocalStorage(): Storage | null {
-    return globalThis.window?.localStorage ?? null;
-}
-
 export function setLocalStorageImportedUser(value: string) {
-    getLocalStorage()?.setItem(LSK.importedUser, value);
+    window.localStorage.setItem(LSK.importedUser, value);
 }
 
 export function getLocalStorageImportedUser() {
-    return getLocalStorage()?.getItem(LSK.importedUser) ?? null;
+    return window.localStorage.getItem(LSK.importedUser);
 }
 
 export function removeLocalStorageImportedUser() {
-    getLocalStorage()?.removeItem(LSK.importedUser);
+    window.localStorage.removeItem(LSK.importedUser);
 }
 
 export function setLocalStorageDataCache(value: string) {
-    getLocalStorage()?.setItem(LSK.dataCache, value);
+    window.localStorage.setItem(LSK.dataCache, value);
 }
 
 export function getLocalStorageDataCache() {
-    return getLocalStorage()?.getItem(LSK.dataCache) ?? null;
+    return window.localStorage.getItem(LSK.dataCache);
 }
 
 export function removeLocalStorageDataCache() {
-    getLocalStorage()?.removeItem(LSK.dataCache);
+    window.localStorage.removeItem(LSK.dataCache);
 }
 
 export function setLocalStorageUserId(value: string) {
-    getLocalStorage()?.setItem(LSK.userId, value);
+    window.localStorage.setItem(LSK.userId, value);
 }
 
 export function getLocalStorageUserId() {
-    return getLocalStorage()?.getItem(LSK.userId) ?? null;
+    return window.localStorage.getItem(LSK.userId);
 }
 
 export function removeLocalStorageUserId() {
-    getLocalStorage()?.removeItem(LSK.userId);
+    window.localStorage.removeItem(LSK.userId);
 }
 
 export function getWasLoggedIn(): boolean {
-    return getLocalStorage()?.getItem(LSK.wasLoggedIn) === 'true';
+    return window.localStorage.getItem(LSK.wasLoggedIn) === 'true';
 }
 
 export function setWasLoggedIn(value: boolean) {
-    const storage = getLocalStorage();
-    if (!storage) return;
-
     if (value) {
-        storage.setItem(LSK.wasLoggedIn, 'true');
+        window.localStorage.setItem(LSK.wasLoggedIn, 'true');
     } else {
-        storage.removeItem(LSK.wasLoggedIn);
+        window.localStorage.removeItem(LSK.wasLoggedIn);
     }
 }
 
 // Helper functions for patchNotesKey
 export function setLocalStoragePatchNotesKey(value: string) {
-    getLocalStorage()?.setItem(LSK.patchNotesKey, value);
+    window.localStorage.setItem(LSK.patchNotesKey, value);
 }
 
 export function getLocalStoragePatchNotesKey() {
-    return getLocalStorage()?.getItem(LSK.patchNotesKey) ?? null;
+    return window.localStorage.getItem(LSK.patchNotesKey);
 }
 
 // Helper functions for recruitmentDismissalTime
 export function setLocalStorageRecruitmentDismissalTime(value: string) {
-    getLocalStorage()?.setItem(LSK.recruitmentDismissalTime, value);
+    window.localStorage.setItem(LSK.recruitmentDismissalTime, value);
 }
 
 export function getLocalStorageRecruitmentDismissalTime() {
-    return getLocalStorage()?.getItem(LSK.recruitmentDismissalTime) ?? null;
+    return window.localStorage.getItem(LSK.recruitmentDismissalTime);
 }
 
 // Helper functions for tourHasRun
 export function setLocalStorageTourHasRun(value: string) {
-    getLocalStorage()?.setItem(LSK.tourHasRun, value);
+    window.localStorage.setItem(LSK.tourHasRun, value);
 }
 
 export function getLocalStorageTourHasRun() {
-    return getLocalStorage()?.getItem(LSK.tourHasRun) ?? null;
+    return window.localStorage.getItem(LSK.tourHasRun);
 }
 
 // Helper functions for sectionColor
 export function setLocalStorageSectionColor(value: string) {
-    getLocalStorage()?.setItem(LSK.sectionColor, value);
+    window.localStorage.setItem(LSK.sectionColor, value);
 }
 
 export function getLocalStorageSectionColor() {
-    return getLocalStorage()?.getItem(LSK.sectionColor) ?? null;
+    return window.localStorage.getItem(LSK.sectionColor);
 }
 
 // Helper functions for sectionColorAssignments
 export function setLocalStorageSectionColorAssignments(value: string) {
-    getLocalStorage()?.setItem(LSK.sectionColorAssignments, value);
+    window.localStorage.setItem(LSK.sectionColorAssignments, value);
 }
 
 export function getLocalStorageSectionColorAssignments() {
-    return getLocalStorage()?.getItem(LSK.sectionColorAssignments) ?? null;
+    return window.localStorage.getItem(LSK.sectionColorAssignments);
 }
 
 // Helper functions for show24HourTime
 export function setLocalStorageShow24HourTime(value: string) {
-    getLocalStorage()?.setItem(LSK.show24HourTime, value);
+    window.localStorage.setItem(LSK.show24HourTime, value);
 }
 
 export function getLocalStorageShow24HourTime() {
-    return getLocalStorage()?.getItem(LSK.show24HourTime) ?? null;
+    return window.localStorage.getItem(LSK.show24HourTime);
 }
 
 // Helper functions for previewMode
 export function setLocalStoragePreviewMode(value: string) {
-    getLocalStorage()?.setItem(LSK.previewMode, value);
+    window.localStorage.setItem(LSK.previewMode, value);
 }
 
 export function getLocalStoragePreviewMode() {
-    return getLocalStorage()?.getItem(LSK.previewMode) ?? null;
+    return window.localStorage.getItem(LSK.previewMode);
 }
 
 // Helper functions for autoSave
 export function setLocalStorageAutoSave(value: string) {
-    getLocalStorage()?.setItem(LSK.autoSave, value);
+    window.localStorage.setItem(LSK.autoSave, value);
 }
 
 export function getLocalStorageAutoSave() {
-    return getLocalStorage()?.getItem(LSK.autoSave) ?? null;
+    return window.localStorage.getItem(LSK.autoSave);
 }
 
 // Helper functions for devMode
 export function setLocalStorageDevMode(value: string) {
-    getLocalStorage()?.setItem(LSK.devMode, value);
+    localStorage.setItem(LocalStorageKeys.devMode, value);
 }
 
 export function getLocalStorageDevMode() {
-    return getLocalStorage()?.getItem(LSK.devMode) ?? null;
+    return localStorage.getItem(LocalStorageKeys.devMode);
 }
 
 // Helper functions for columnToggles
 export function setLocalStorageColumnToggles(value: string) {
-    getLocalStorage()?.setItem(LSK.columnToggles, value);
+    window.localStorage.setItem(LSK.columnToggles, value);
 }
 
 export function getLocalStorageColumnToggles() {
-    return getLocalStorage()?.getItem(LSK.columnToggles) ?? null;
+    return window.localStorage.getItem(LSK.columnToggles);
 }
 
 export function setLocalStorageTempSaveData(value: string) {
-    getLocalStorage()?.setItem(LSK.tempSaveData, value);
+    window.localStorage.setItem(LSK.tempSaveData, value);
 }
 
 export function getLocalStorageTempSaveData() {
-    return getLocalStorage()?.getItem(LSK.tempSaveData) ?? null;
+    return window.localStorage.getItem(LSK.tempSaveData);
 }
 
 export function removeLocalStorageTempSaveData() {
-    getLocalStorage()?.removeItem(LSK.tempSaveData);
+    window.localStorage.removeItem(LSK.tempSaveData);
 }
 
 export function setLocalStorageSkeletonBlueprint(value: string) {
-    getLocalStorage()?.setItem(LSK.skeletonBlueprint, value);
+    window.localStorage.setItem(LSK.skeletonBlueprint, value);
 }
 
 export function getLocalStorageSkeletonBlueprint() {
-    return getLocalStorage()?.getItem(LSK.skeletonBlueprint) ?? null;
+    return window.localStorage.getItem(LSK.skeletonBlueprint);
 }
 
 export function removeLocalStorageSkeletonBlueprint() {
-    getLocalStorage()?.removeItem(LSK.skeletonBlueprint);
+    window.localStorage.removeItem(LSK.skeletonBlueprint);
 }
 
 export function setLocalStorageAddedCoursesSkeletonBlueprint(value: string) {
-    getLocalStorage()?.setItem(LSK.addedCoursesSkeletonBlueprint, value);
+    window.localStorage.setItem(LSK.addedCoursesSkeletonBlueprint, value);
 }
 
 export function getLocalStorageAddedCoursesSkeletonBlueprint() {
-    return getLocalStorage()?.getItem(LSK.addedCoursesSkeletonBlueprint) ?? null;
+    return window.localStorage.getItem(LSK.addedCoursesSkeletonBlueprint);
 }
 
 export function removeLocalStorageAddedCoursesSkeletonBlueprint() {
-    getLocalStorage()?.removeItem(LSK.addedCoursesSkeletonBlueprint);
+    window.localStorage.removeItem(LSK.addedCoursesSkeletonBlueprint);
 }

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -4,7 +4,6 @@ enum LocalStorageKeys {
     patchNotesKey = 'latestPatchSeen',
     recruitmentDismissalTime = 'recruitmentDismissalTime',
     tourHasRun = 'tourHasRun',
-    theme = 'theme',
     sectionColor = 'sectionColor',
     sectionColorAssignments = 'sectionColorAssignments',
     show24HourTime = 'show24HourTime',
@@ -14,11 +13,14 @@ enum LocalStorageKeys {
     columnToggles = 'columnToggles',
     wasLoggedIn = 'wasLoggedIn',
     dataCache = 'dataCache',
-    importedUser = 'importedUser',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
     addedCoursesSkeletonBlueprint = 'addedCoursesSkeletonBlueprint',
 
+    /** @deprecated theme is now managed by MUI and should not be written to directly */
+    theme = 'theme',
+    /** @deprecated Guest import confirmation now uses a snackbar in AuthInitializer. */
+    importedUser = 'importedUser',
     /** @deprecated No longer used. Low impact feature. */
     recentlySearched = 'recentlySearched',
     /** @deprecated Removed for being a net negative on UX and confusing schedule persistence behavior */
@@ -35,185 +37,183 @@ enum LocalStorageKeys {
 
 const LSK = LocalStorageKeys;
 
+function getLocalStorage(): Storage | null {
+    return globalThis.window?.localStorage ?? null;
+}
+
 export function setLocalStorageImportedUser(value: string) {
-    window.localStorage.setItem(LSK.importedUser, value);
+    getLocalStorage()?.setItem(LSK.importedUser, value);
 }
 
 export function getLocalStorageImportedUser() {
-    return window.localStorage.getItem(LSK.importedUser);
+    return getLocalStorage()?.getItem(LSK.importedUser) ?? null;
 }
 
 export function removeLocalStorageImportedUser() {
-    window.localStorage.removeItem(LSK.importedUser);
+    getLocalStorage()?.removeItem(LSK.importedUser);
 }
 
 export function setLocalStorageDataCache(value: string) {
-    window.localStorage.setItem(LSK.dataCache, value);
+    getLocalStorage()?.setItem(LSK.dataCache, value);
 }
 
 export function getLocalStorageDataCache() {
-    return window.localStorage.getItem(LSK.dataCache);
+    return getLocalStorage()?.getItem(LSK.dataCache) ?? null;
 }
 
 export function removeLocalStorageDataCache() {
-    window.localStorage.removeItem(LSK.dataCache);
+    getLocalStorage()?.removeItem(LSK.dataCache);
 }
 
 export function setLocalStorageUserId(value: string) {
-    window.localStorage.setItem(LSK.userId, value);
+    getLocalStorage()?.setItem(LSK.userId, value);
 }
 
 export function getLocalStorageUserId() {
-    return window.localStorage.getItem(LSK.userId);
+    return getLocalStorage()?.getItem(LSK.userId) ?? null;
 }
 
 export function removeLocalStorageUserId() {
-    window.localStorage.removeItem(LSK.userId);
+    getLocalStorage()?.removeItem(LSK.userId);
 }
 
 export function getWasLoggedIn(): boolean {
-    return window.localStorage.getItem(LSK.wasLoggedIn) === 'true';
+    return getLocalStorage()?.getItem(LSK.wasLoggedIn) === 'true';
 }
 
 export function setWasLoggedIn(value: boolean) {
+    const storage = getLocalStorage();
+    if (!storage) return;
+
     if (value) {
-        window.localStorage.setItem(LSK.wasLoggedIn, 'true');
+        storage.setItem(LSK.wasLoggedIn, 'true');
     } else {
-        window.localStorage.removeItem(LSK.wasLoggedIn);
+        storage.removeItem(LSK.wasLoggedIn);
     }
 }
 
 // Helper functions for patchNotesKey
 export function setLocalStoragePatchNotesKey(value: string) {
-    window.localStorage.setItem(LSK.patchNotesKey, value);
+    getLocalStorage()?.setItem(LSK.patchNotesKey, value);
 }
 
 export function getLocalStoragePatchNotesKey() {
-    return window.localStorage.getItem(LSK.patchNotesKey);
+    return getLocalStorage()?.getItem(LSK.patchNotesKey) ?? null;
 }
 
 // Helper functions for recruitmentDismissalTime
 export function setLocalStorageRecruitmentDismissalTime(value: string) {
-    window.localStorage.setItem(LSK.recruitmentDismissalTime, value);
+    getLocalStorage()?.setItem(LSK.recruitmentDismissalTime, value);
 }
 
 export function getLocalStorageRecruitmentDismissalTime() {
-    return window.localStorage.getItem(LSK.recruitmentDismissalTime);
+    return getLocalStorage()?.getItem(LSK.recruitmentDismissalTime) ?? null;
 }
 
 // Helper functions for tourHasRun
 export function setLocalStorageTourHasRun(value: string) {
-    window.localStorage.setItem(LSK.tourHasRun, value);
+    getLocalStorage()?.setItem(LSK.tourHasRun, value);
 }
 
 export function getLocalStorageTourHasRun() {
-    return window.localStorage.getItem(LSK.tourHasRun);
-}
-
-// Helper functions for theme
-export function setLocalStorageTheme(value: string) {
-    window.localStorage.setItem(LSK.theme, value);
-}
-
-export function getLocalStorageTheme() {
-    return window.localStorage.getItem(LSK.theme);
+    return getLocalStorage()?.getItem(LSK.tourHasRun) ?? null;
 }
 
 // Helper functions for sectionColor
 export function setLocalStorageSectionColor(value: string) {
-    window.localStorage.setItem(LSK.sectionColor, value);
+    getLocalStorage()?.setItem(LSK.sectionColor, value);
 }
 
 export function getLocalStorageSectionColor() {
-    return window.localStorage.getItem(LSK.sectionColor);
+    return getLocalStorage()?.getItem(LSK.sectionColor) ?? null;
 }
 
 // Helper functions for sectionColorAssignments
 export function setLocalStorageSectionColorAssignments(value: string) {
-    window.localStorage.setItem(LSK.sectionColorAssignments, value);
+    getLocalStorage()?.setItem(LSK.sectionColorAssignments, value);
 }
 
 export function getLocalStorageSectionColorAssignments() {
-    return window.localStorage.getItem(LSK.sectionColorAssignments);
+    return getLocalStorage()?.getItem(LSK.sectionColorAssignments) ?? null;
 }
 
 // Helper functions for show24HourTime
 export function setLocalStorageShow24HourTime(value: string) {
-    window.localStorage.setItem(LSK.show24HourTime, value);
+    getLocalStorage()?.setItem(LSK.show24HourTime, value);
 }
 
 export function getLocalStorageShow24HourTime() {
-    return window.localStorage.getItem(LSK.show24HourTime);
+    return getLocalStorage()?.getItem(LSK.show24HourTime) ?? null;
 }
 
 // Helper functions for previewMode
 export function setLocalStoragePreviewMode(value: string) {
-    window.localStorage.setItem(LSK.previewMode, value);
+    getLocalStorage()?.setItem(LSK.previewMode, value);
 }
 
 export function getLocalStoragePreviewMode() {
-    return window.localStorage.getItem(LSK.previewMode);
+    return getLocalStorage()?.getItem(LSK.previewMode) ?? null;
 }
 
 // Helper functions for autoSave
 export function setLocalStorageAutoSave(value: string) {
-    window.localStorage.setItem(LSK.autoSave, value);
+    getLocalStorage()?.setItem(LSK.autoSave, value);
 }
 
 export function getLocalStorageAutoSave() {
-    return window.localStorage.getItem(LSK.autoSave);
+    return getLocalStorage()?.getItem(LSK.autoSave) ?? null;
 }
 
 // Helper functions for devMode
 export function setLocalStorageDevMode(value: string) {
-    localStorage.setItem(LocalStorageKeys.devMode, value);
+    getLocalStorage()?.setItem(LSK.devMode, value);
 }
 
 export function getLocalStorageDevMode() {
-    return localStorage.getItem(LocalStorageKeys.devMode);
+    return getLocalStorage()?.getItem(LSK.devMode) ?? null;
 }
 
 // Helper functions for columnToggles
 export function setLocalStorageColumnToggles(value: string) {
-    window.localStorage.setItem(LSK.columnToggles, value);
+    getLocalStorage()?.setItem(LSK.columnToggles, value);
 }
 
 export function getLocalStorageColumnToggles() {
-    return window.localStorage.getItem(LSK.columnToggles);
+    return getLocalStorage()?.getItem(LSK.columnToggles) ?? null;
 }
 
 export function setLocalStorageTempSaveData(value: string) {
-    window.localStorage.setItem(LSK.tempSaveData, value);
+    getLocalStorage()?.setItem(LSK.tempSaveData, value);
 }
 
 export function getLocalStorageTempSaveData() {
-    return window.localStorage.getItem(LSK.tempSaveData);
+    return getLocalStorage()?.getItem(LSK.tempSaveData) ?? null;
 }
 
 export function removeLocalStorageTempSaveData() {
-    window.localStorage.removeItem(LSK.tempSaveData);
+    getLocalStorage()?.removeItem(LSK.tempSaveData);
 }
 
 export function setLocalStorageSkeletonBlueprint(value: string) {
-    window.localStorage.setItem(LSK.skeletonBlueprint, value);
+    getLocalStorage()?.setItem(LSK.skeletonBlueprint, value);
 }
 
 export function getLocalStorageSkeletonBlueprint() {
-    return window.localStorage.getItem(LSK.skeletonBlueprint);
+    return getLocalStorage()?.getItem(LSK.skeletonBlueprint) ?? null;
 }
 
 export function removeLocalStorageSkeletonBlueprint() {
-    window.localStorage.removeItem(LSK.skeletonBlueprint);
+    getLocalStorage()?.removeItem(LSK.skeletonBlueprint);
 }
 
 export function setLocalStorageAddedCoursesSkeletonBlueprint(value: string) {
-    window.localStorage.setItem(LSK.addedCoursesSkeletonBlueprint, value);
+    getLocalStorage()?.setItem(LSK.addedCoursesSkeletonBlueprint, value);
 }
 
 export function getLocalStorageAddedCoursesSkeletonBlueprint() {
-    return window.localStorage.getItem(LSK.addedCoursesSkeletonBlueprint);
+    return getLocalStorage()?.getItem(LSK.addedCoursesSkeletonBlueprint) ?? null;
 }
 
 export function removeLocalStorageAddedCoursesSkeletonBlueprint() {
-    window.localStorage.removeItem(LSK.addedCoursesSkeletonBlueprint);
+    getLocalStorage()?.removeItem(LSK.addedCoursesSkeletonBlueprint);
 }

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -4,8 +4,6 @@ enum LocalStorageKeys {
     patchNotesKey = 'latestPatchSeen',
     recruitmentDismissalTime = 'recruitmentDismissalTime',
     tourHasRun = 'tourHasRun',
-    /** @deprecated Theme preference is now managed by MUI via modeStorageKey="theme". */
-    theme = 'theme',
     sectionColor = 'sectionColor',
     sectionColorAssignments = 'sectionColorAssignments',
     show24HourTime = 'show24HourTime',
@@ -20,6 +18,8 @@ enum LocalStorageKeys {
     skeletonBlueprint = 'skeletonBlueprint',
     addedCoursesSkeletonBlueprint = 'addedCoursesSkeletonBlueprint',
 
+    /** @deprecated Theme preference is now managed by MUI via modeStorageKey="theme". */
+    theme = 'theme',
     /** @deprecated No longer used. Low impact feature. */
     recentlySearched = 'recentlySearched',
     /** @deprecated Removed for being a net negative on UX and confusing schedule persistence behavior */

--- a/apps/antalmanac/src/stores/SectionThemeStore.ts
+++ b/apps/antalmanac/src/stores/SectionThemeStore.ts
@@ -1,3 +1,4 @@
+import { getIsDarkMode } from '$hooks/useIsDarkMode';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import {
     getLocalStorageSectionColor,
@@ -14,7 +15,6 @@ import {
     type ThemeAssignmentMap,
 } from '$lib/sectionThemes';
 import AppStore from '$stores/AppStore';
-import { useThemeStore } from '$stores/SettingsStore';
 import type { PostHog } from 'posthog-js/react';
 import { create } from 'zustand';
 
@@ -51,7 +51,6 @@ interface SectionThemeStore {
 
 function readStoredSectionColor(): SectionColorSetting {
     const raw = getLocalStorageSectionColor();
-    // Default users to 'custom' so their hand-picked colors are preserved.
     return isSectionColorSetting(raw) ? raw : 'custom';
 }
 
@@ -139,7 +138,7 @@ export const useSectionThemeStore = create<SectionThemeStore>((set, get) => {
 
             const courses = AppStore.schedule.getCurrentCourses();
             const customEventIds = AppStore.schedule.getCurrentCustomEvents().map((event) => event.customEventID);
-            const palette = getPalette(sectionColor, useThemeStore.getState().isDark);
+            const palette = getPalette(sectionColor, getIsDarkMode());
 
             const existing = assignments[sectionColor] ?? {};
             const { map } = computeAssignments(existing, courses, customEventIds, palette);

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -16,12 +16,14 @@ interface TimeFormatStore {
 }
 
 export const useTimeFormatStore = create<TimeFormatStore>((set) => {
-    const isMilitaryTime = getLocalStorageShow24HourTime() == 'true';
+    const isMilitaryTime = typeof Storage !== 'undefined' && getLocalStorageShow24HourTime() == 'true';
 
     return {
         isMilitaryTime,
         setTimeFormat: (isMilitaryTime) => {
-            setLocalStorageShow24HourTime(isMilitaryTime.toString());
+            if (typeof Storage !== 'undefined') {
+                setLocalStorageShow24HourTime(isMilitaryTime.toString());
+            }
             set({ isMilitaryTime });
         },
     };
@@ -32,12 +34,15 @@ interface PreviewStore {
 }
 
 export const usePreviewStore = create<PreviewStore>((set) => {
-    const previewMode = getLocalStoragePreviewMode() == 'true';
+    const previewMode = typeof Storage !== 'undefined' && getLocalStoragePreviewMode() == 'true';
 
     return {
         previewMode: previewMode,
         setPreviewMode: (previewMode) => {
-            setLocalStoragePreviewMode(previewMode.toString());
+            if (typeof Storage !== 'undefined') {
+                setLocalStoragePreviewMode(previewMode.toString());
+            }
+
             set({ previewMode: previewMode });
         },
     };
@@ -49,12 +54,14 @@ interface AutoSaveStore {
 }
 
 export const useAutoSaveStore = create<AutoSaveStore>((set) => {
-    const autoSave = getLocalStorageAutoSave() == 'true';
+    const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() == 'true';
 
     return {
         autoSave,
         setAutoSave: (autoSave) => {
-            setLocalStorageAutoSave(autoSave.toString());
+            if (typeof Storage !== 'undefined') {
+                setLocalStorageAutoSave(autoSave.toString());
+            }
             set({ autoSave });
         },
     };
@@ -66,13 +73,16 @@ interface DevModeStore {
 }
 
 export const useDevModeStore = create<DevModeStore>((set) => {
-    const stored = getLocalStorageDevMode();
-    const devMode = stored === 'true';
+    const stored = typeof Storage !== 'undefined' ? getLocalStorageDevMode() : null;
+    const isLocalDev = process.env.NODE_ENV === 'development';
+    const devMode = stored === null ? isLocalDev : stored === 'true';
 
     return {
         devMode,
         setDevMode: (devMode: boolean) => {
-            setLocalStorageDevMode(devMode.toString());
+            if (typeof Storage !== 'undefined') {
+                setLocalStorageDevMode(devMode.toString());
+            }
             set({ devMode });
         },
     };

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -1,77 +1,14 @@
-import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import {
     getLocalStorageAutoSave,
     getLocalStorageDevMode,
     getLocalStoragePreviewMode,
     getLocalStorageShow24HourTime,
-    getLocalStorageTheme,
     setLocalStorageAutoSave,
     setLocalStorageDevMode,
     setLocalStoragePreviewMode,
     setLocalStorageShow24HourTime,
-    setLocalStorageTheme,
 } from '$lib/localStorage';
-import { PostHog } from 'posthog-js/react';
 import { create } from 'zustand';
-
-type ThemeSetting = 'light' | 'dark' | 'system';
-
-interface ThemeStore {
-    /**
-     * The 'raw' theme, based on the user's selected setting
-     */
-    themeSetting: ThemeSetting;
-    /**
-     * The 'derived' theme, based on user settings and device preferences
-     */
-    isDark: boolean;
-
-    setAppTheme: (themeSetting: ThemeSetting, postHog?: PostHog) => void;
-    syncSystemTheme: (isDark: boolean) => void;
-}
-
-function themeShouldBeDark(themeSetting: ThemeSetting) {
-    if (typeof window === 'undefined') {
-        return themeSetting === 'dark';
-    }
-
-    if (themeSetting == 'system') return window.matchMedia('(prefers-color-scheme: dark)').matches;
-    return themeSetting == 'dark';
-}
-
-export const useThemeStore = create<ThemeStore>((set, get) => {
-    const storedThemeSetting: ThemeSetting = ((typeof Storage !== 'undefined' ? getLocalStorageTheme() : null) ??
-        'system') as ThemeSetting;
-    const isDark = themeShouldBeDark(storedThemeSetting);
-
-    return {
-        themeSetting: storedThemeSetting,
-        isDark: isDark,
-
-        setAppTheme: (themeSetting, postHog) => {
-            setLocalStorageTheme(themeSetting);
-
-            const isDark = themeShouldBeDark(themeSetting);
-
-            set({ themeSetting, isDark });
-
-            logAnalytics(postHog, {
-                category: analyticsEnum.nav,
-                action: analyticsEnum.nav.actions.CHANGE_THEME,
-                customProps: {
-                    themeSetting,
-                },
-            });
-        },
-
-        syncSystemTheme: (isDark) => {
-            if (get().themeSetting !== 'system') {
-                return;
-            }
-            set({ isDark });
-        },
-    };
-});
 
 interface TimeFormatStore {
     isMilitaryTime: boolean;
@@ -79,14 +16,12 @@ interface TimeFormatStore {
 }
 
 export const useTimeFormatStore = create<TimeFormatStore>((set) => {
-    const isMilitaryTime = typeof Storage !== 'undefined' && getLocalStorageShow24HourTime() == 'true';
+    const isMilitaryTime = getLocalStorageShow24HourTime() == 'true';
 
     return {
         isMilitaryTime,
         setTimeFormat: (isMilitaryTime) => {
-            if (typeof Storage !== 'undefined') {
-                setLocalStorageShow24HourTime(isMilitaryTime.toString());
-            }
+            setLocalStorageShow24HourTime(isMilitaryTime.toString());
             set({ isMilitaryTime });
         },
     };
@@ -97,15 +32,12 @@ interface PreviewStore {
 }
 
 export const usePreviewStore = create<PreviewStore>((set) => {
-    const previewMode = typeof Storage !== 'undefined' && getLocalStoragePreviewMode() == 'true';
+    const previewMode = getLocalStoragePreviewMode() == 'true';
 
     return {
         previewMode: previewMode,
         setPreviewMode: (previewMode) => {
-            if (typeof Storage !== 'undefined') {
-                setLocalStoragePreviewMode(previewMode.toString());
-            }
-
+            setLocalStoragePreviewMode(previewMode.toString());
             set({ previewMode: previewMode });
         },
     };
@@ -117,14 +49,12 @@ interface AutoSaveStore {
 }
 
 export const useAutoSaveStore = create<AutoSaveStore>((set) => {
-    const autoSave = typeof Storage !== 'undefined' && getLocalStorageAutoSave() == 'true';
+    const autoSave = getLocalStorageAutoSave() == 'true';
 
     return {
         autoSave,
         setAutoSave: (autoSave) => {
-            if (typeof Storage !== 'undefined') {
-                setLocalStorageAutoSave(autoSave.toString());
-            }
+            setLocalStorageAutoSave(autoSave.toString());
             set({ autoSave });
         },
     };
@@ -136,16 +66,13 @@ interface DevModeStore {
 }
 
 export const useDevModeStore = create<DevModeStore>((set) => {
-    const stored = typeof Storage !== 'undefined' ? getLocalStorageDevMode() : null;
-    const isLocalDev = process.env.NODE_ENV === 'development';
-    const devMode = stored === null ? isLocalDev : stored === 'true';
+    const stored = getLocalStorageDevMode();
+    const devMode = stored === 'true';
 
     return {
         devMode,
         setDevMode: (devMode: boolean) => {
-            if (typeof Storage !== 'undefined') {
-                setLocalStorageDevMode(devMode.toString());
-            }
+            setLocalStorageDevMode(devMode.toString());
             set({ devMode });
         },
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts the MUI theme migration from #1936 into a standalone PR. SSR header work (layout move, UA hints, TermAutocomplete, etc.) is intentionally **not** included.

**Core changes:**
- `AppThemeProvider` uses MUI `colorSchemes` + `cssVariables` with `colorSchemeSelector: 'class'`
- `InitColorSchemeScript` in root layout (`modeStorageKey="theme"`, `defaultMode="system"`)
- Removed `useThemeStore`; `ThemeSelector` uses MUI `useColorScheme` / `setMode`
- Added `useIsDarkMode` for cases that still need a boolean (section palettes, image assets, alert variants)
- ~60 components updated to `theme.vars.palette.*` and `theme.applyStyles('dark', …)`
- `MuiAppBar.defaultProps.enableColorOnDark` so the header stays blue in dark mode
- `localStorage`: removed `get/setLocalStorageTheme` only (MUI owns the `theme` key)

## Test Plan

- [ ] Toggle light / system / dark in Settings — persists across reload
- [ ] No theme flash on hard refresh
- [ ] AppBar stays blue in light and dark mode
- [ ] Section color themes correct in both modes
- [ ] Import dialog, keyboard shortcuts modal, settings popover look right in dark mode
- [ ] Dialog links use correct colors without manual `isDark` overrides
- [ ] `pnpm lint` passes

## Follow-ups

1. **Use `isDarkMode` less** — many call sites can move to `theme.applyStyles('dark', …)` or `theme.vars` instead of a boolean (`SettingsMenu`, `AppSwitcher`, `headerStyles`, `KeyboardShortcutsModal`, row highlights, etc.). Keep the hook only where a boolean is unavoidable (image `src`, `Alert` variant, hex palette resolution).

2. **Refactor `useIsDarkMode`** — simplify to `useColorScheme()` only (drop DOM `classList` fallback); consider `getAssignmentPalette()` for section-theme slot assignment so the Zustand store never needs mode at all.

3. **Other ideas**
   - Extract shared `SettingsSegmentControl` for `ThemeSelector` / `TimeSelector` duplicated segment UI
   - Typed theme token helper (explicit palette refs without magic strings *or* verbose `(theme) => theme.vars…` everywhere)
   - Audit `MuiPaper` surfaces after removing the blanket dark override
   - `optimizePackageImports` for MUI tree-shaking (~10–20 kB gzip, noted in #1936)
   - Revisit whether mechanical `theme.vars` rewrites in ~19 files could stay as palette shorthand if a typed helper isn't worth it yet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dd77d73-c99a-491d-a3f2-45b2b99c1f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dd77d73-c99a-491d-a3f2-45b2b99c1f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

