### PR TITLE
perf(ci): skip redundant termData generation and remove it from lint

### DIFF
--- a/.github/actions/cache-generated-data/action.yml
+++ b/.github/actions/cache-generated-data/action.yml
@@ -10,6 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore termData cache
+      id: cache-restore
       uses: actions/cache/restore@v5
       with:
         path: apps/antalmanac/src/generated
@@ -19,12 +20,14 @@ runs:
           termData-cache-main-
 
     - name: Generate termData
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       run: pnpm --filter antalmanac get-data
       shell: bash
       env:
         ANTEATER_API_KEY: ${{ inputs.api-key }}
 
     - name: Save termData cache
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
         path: apps/antalmanac/src/generated

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,5 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Generate termData
-              uses: ./.github/actions/cache-generated-data
-              with:
-                api-key: ${{ secrets.ANTEATER_API_KEY }}
-
             - name: Lint
               run: pnpm lint


### PR DESCRIPTION
## Summary

Two CI optimizations that remove redundant work:

**1. Skip `get-data` when termData cache hits** (`.github/actions/cache-generated-data/action.yml`)

```yaml
# Added id + conditional to existing steps
- name: Restore termData cache
  id: cache-restore
  ...

- name: Generate termData
  if: steps.cache-restore.outputs.cache-hit != 'true'  # NEW
  ...

- name: Save termData cache
  if: steps.cache-restore.outputs.cache-hit != 'true'  # NEW
  ...
```

Previously the action always re-ran `pnpm --filter antalmanac get-data` (~15-20s) and re-saved the cache even when the restore was a cache hit. Now both steps are skipped when the cache already contains the generated files.

**2. Remove `Generate termData` from lint workflow** (`.github/workflows/lint.yml`)

`oxlint --deny-warnings` is a pure linter — it doesn't resolve TS path aliases (`$generated/*`) or import modules. Verified locally that lint passes with no generated files present. Removing this step saves ~20s (cache restore + potential regeneration) from every lint run.

**Combined savings:** ~20s on lint, ~15-20s on deploy-staging/deploy-production/deploy-staging-shared (when cache hits, which is the common case for incremental deploys).

## Test Plan

- Verified locally: `pnpm lint` passes after deleting all generated files (except the git-tracked `departments.json` and `deployed_terms.json`)
- CI lint job on this PR should pass without the `Generate termData` step
- Deploy-staging should skip `get-data` on cache hit and still deploy successfully

## Issues

Follow-up to #1948

Link to Devin session: https://app.devin.ai/sessions/b139e2621e8947b9bed66665b1d5554c
Requested by: @KevinWu098

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

