### PR TITLE
perf: dynamic-import ics, replace file-saver with native saveAs (-24 KB gzip deferred)

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -46,7 +46,6 @@
         "date-fns": "^3.6.0",
         "drizzle-orm": "^0.45.2",
         "events": "^3.3.0",
-        "file-saver": "^2.0.5",
         "fuzzysort": "3.1.0",
         "html2canvas": "^1.4.1",
         "ics": "^3.8.1",
@@ -71,7 +70,6 @@
     },
     "devDependencies": {
         "@testing-library/react": "^14.0.0",
-        "@types/file-saver": "^2.0.5",
         "@types/leaflet": "^1.9.14",
         "@types/leaflet-routing-machine": "^3.2.4",
         "@types/leaflet.locatecontrol": "^0.74.1",

--- a/apps/antalmanac/src/components/buttons/Screenshot.tsx
+++ b/apps/antalmanac/src/components/buttons/Screenshot.tsx
@@ -1,8 +1,8 @@
 import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { saveAs } from '$lib/utils';
 import { Panorama } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
-import { saveAs } from 'file-saver';
 import { usePostHog } from 'posthog-js/react';
 
 interface ScreenshotButtonProps {

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -1,13 +1,12 @@
 import { isCustomEvent, type FinalExam } from '$components/Calendar/types';
 import buildingCatalogue from '$lib/locations/buildingCatalogue';
 import { getDefaultTerm } from '$lib/term';
-import { notNull } from '$lib/utils';
+import { notNull, saveAs } from '$lib/utils';
 import AppStore from '$stores/AppStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import type { AATerm } from '@packages/antalmanac-types';
 import type { HourMinute, Quarter } from '@packages/anteater-api/types';
-import { saveAs } from 'file-saver';
-import { createEvents, type EventAttributes } from 'ics';
+import type { EventAttributes } from 'ics';
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'] as const;
 
@@ -308,8 +307,10 @@ export function getEventsFromCourses(events = AppStore.getEventsWithFinalsInCale
     return calendarEvents;
 }
 
-export function exportCalendar() {
+export async function exportCalendar() {
     const events = getEventsFromCourses();
+
+    const { createEvents } = await import('ics');
 
     // Convert the events into a vcalendar.
     // Callback function triggers a download of the .ics file

--- a/apps/antalmanac/src/lib/utils.ts
+++ b/apps/antalmanac/src/lib/utils.ts
@@ -62,3 +62,17 @@ export function moveArrayElements(
 export function unreachableCase(value: never): never {
     throw new Error(`Unreachable code reached: ${value}`);
 }
+
+/**
+ * Save a Blob or data URI to disk as a file download.
+ */
+export function saveAs(data: Blob | string, filename: string) {
+    const href = typeof data === 'string' ? data : URL.createObjectURL(data);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = filename;
+    a.click();
+    if (typeof data !== 'string') {
+        URL.revokeObjectURL(href);
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       events:
         specifier: ^3.3.0
         version: 3.3.0
-      file-saver:
-        specifier: ^2.0.5
-        version: 2.0.5
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -259,9 +256,6 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.3.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/file-saver':
-        specifier: ^2.0.5
-        version: 2.0.7
       '@types/leaflet':
         specifier: ^1.9.14
         version: 1.9.14
@@ -2481,9 +2475,6 @@ packages:
   '@types/date-arithmetic@4.1.1':
     resolution: {integrity: sha512-o9ILUTMSRiOC73o7h30mgLpuDwOJWqMHZfnEIwNQlfZsGY6Kw2gK5Gz6nXAjNt9zm3Qpr12pM4FDqssfdtBzGA==}
 
-  '@types/file-saver@2.0.7':
-    resolution: {integrity: sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==}
-
   '@types/geojson@7946.0.10':
     resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==}
 
@@ -3379,9 +3370,6 @@ packages:
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
-
-  file-saver@2.0.5:
-    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -7140,8 +7128,6 @@ snapshots:
 
   '@types/date-arithmetic@4.1.1': {}
 
-  '@types/file-saver@2.0.7': {}
-
   '@types/geojson@7946.0.10': {}
 
   '@types/leaflet-routing-machine@3.2.8':
@@ -8022,8 +8008,6 @@ snapshots:
       strnum: 2.1.2
 
   fflate@0.4.8: {}
-
-  file-saver@2.0.5: {}
 
   fill-range@7.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

`ics` (66 KB min / 21 KB gzip) and `file-saver` (8 KB min / 3 KB gzip) were both eagerly imported at module level but only used on explicit user actions (Download Calendar, Screenshot). This PR:

1. **Dynamic-imports `ics`** inside `exportCalendar()` — the chunk only loads when the user clicks Download Calendar. Same pattern as `html2canvas` in `Screenshot.tsx`.

2. **Replaces `file-saver` with a native `saveAs` utility** in `lib/utils.ts`:
```ts
export function saveAs(data: Blob | string, filename: string) {
    const href = typeof data === 'string' ? data : URL.createObjectURL(data);
    const a = document.createElement('a');
    a.href = href;
    a.download = filename;
    a.click();
    if (typeof data !== 'string') {
        URL.revokeObjectURL(href);
    }
}
```
This uses the `<a download>` attribute supported in all modern browsers — `file-saver` is essentially a polyfill for this.

3. **Removes `file-saver` and `@types/file-saver`** from dependencies entirely.

Net result: ~24 KB gzip deferred off the critical path + one fewer dependency.

## Test Plan

- Download Calendar button should produce a `.ics` file as before
- Screenshot button should produce a `.png` file as before
- Both features now lazy-load their heavy deps on first use

## Issues

Follows up on #1940 (react-color replacement) — continues the pattern of deferring action-only dependencies off the critical path.

## Future Followup

- `@reactour/tour` (~9 KB gz) wraps entire app but only fires for first-time users — could be conditionally loaded
- PostHog slim bundle (`posthog-js/dist/module.slim`) would save ~24 KB gz permanent
- `react-lazyload` is unmaintained — replaceable with native `IntersectionObserver`

Link to Devin session: https://app.devin.ai/sessions/5e142a4c56a043ea9003ad17c4c2c241
Requested by: @KevinWu098

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

