### PR TITLE
refactor: drop cross-schedule section ref-sharing, always clone on add

### DIFF
--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -253,15 +253,15 @@ export class Schedules {
     }
 
     /**
-     * Find a section across **all** schedules.
-     * Returns the AASection reference so cross-schedule color sharing works.
+     * Find the color of a section across **all** schedules.
+     * Used to inherit color when adding an already-scheduled section to another schedule.
      */
-    private findSectionAcrossSchedules(sectionCode: string, term: AATerm): AASection | undefined {
+    private findSectionColorAcrossSchedules(sectionCode: string, term: AATerm): string | undefined {
         for (const schedule of this.schedules) {
             for (const course of schedule.courses) {
                 if (course.term.shortName !== term.shortName) continue;
                 const section = course.sections.find((s) => s.sectionCode === sectionCode);
-                if (section) return section;
+                if (section) return section.color;
             }
         }
         return undefined;
@@ -299,16 +299,19 @@ export class Schedules {
             return;
         }
 
-        // Reuse existing section reference from any schedule for cross-schedule color sharing
-        const existingSection = this.findSectionAcrossSchedules(section.sectionCode, course.term);
+        // Always clone — never share references across schedules.
+        // Inherit color from an existing copy in any schedule, or assign a new one.
+        const existingColor = this.findSectionColorAcrossSchedules(section.sectionCode, course.term);
 
-        const sectionToAdd = existingSection ?? {
+        const sectionToAdd = {
             ...section,
-            color: getColorForNewSection(
-                section,
-                course,
-                this.getAllCourses().filter((c) => c.term.shortName === course.term.shortName)
-            ),
+            color:
+                existingColor ??
+                getColorForNewSection(
+                    section,
+                    course,
+                    this.getAllCourses().filter((c) => c.term.shortName === course.term.shortName)
+                ),
         };
 
         const courses = this.schedules[scheduleIndex].courses;
@@ -346,8 +349,8 @@ export class Schedules {
 
     /**
      * Change courses that match the code and term in all schedules to new color.
-     * Iterates every schedule explicitly so color updates survive undo/redo
-     * (structuredClone severs shared references).
+     * Sections are independent clones across schedules, so this iterates every
+     * schedule explicitly to keep colors in sync.
      */
     changeCourseColor(sectionCode: string, term: AATerm, newColor: string) {
         this.addUndoState();


### PR DESCRIPTION
## Summary

Eliminates the implicit ref-sharing contract between sections across schedules. Previously, `addCourse` reused the same `AASection` object reference when a section existed in another schedule — meaning mutations on one schedule's section would silently propagate to others (until undo/redo's `structuredClone` severed the link).

Now every schedule gets its own independent section clone. Color is still inherited from existing copies, but through an explicit color lookup rather than object identity:

```diff
- private findSectionAcrossSchedules(...): AASection | undefined {
-     // returns the full object reference
+ private findSectionColorAcrossSchedules(...): string | undefined {
+     // returns only the color string
```

```diff
- const existingSection = this.findSectionAcrossSchedules(...);
- const sectionToAdd = existingSection ?? { ...section, color: getColorForNewSection(...) };
+ const existingColor = this.findSectionColorAcrossSchedules(...);
+ const sectionToAdd = { ...section, color: existingColor ?? getColorForNewSection(...) };
```

`changeCourseColor` already iterated all schedules explicitly (fixed in #1945) — that's now the *only* cross-schedule sync mechanism, not a workaround for broken refs.

**One model, no special cases:** sections are always independent clones; cross-schedule mutations always iterate explicitly.

## Test Plan

- `vitest run tests/scheduleHelpers.test.ts tests/calendarize-helpers.test.ts` — 12/12 pass
- `oxlint` clean

## Issues

Follow-up to #1945

Link to Devin session: https://app.devin.ai/sessions/a41ea2e605db40e78ed4f4818e411a9f
Requested by: @KevinWu098

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

