### PR TITLE
refactor: unify section key format — delete courseColorKey, use scheduleSectionKey

### DIFF
--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,9 +1,9 @@
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
 import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { type AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
-import { courseColorKey, customEventColorKey, getPalette, resolveAssignment } from '$lib/sectionThemes';
+import { customEventColorKey, getPalette, resolveAssignment } from '$lib/sectionThemes';
 import AppStore from '$stores/AppStore';
-import { colorPickerPresetColors } from '$stores/scheduleHelpers';
+import { colorPickerPresetColors, scheduleSectionKey } from '$stores/scheduleHelpers';
 import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, type PopoverProps, Tooltip } from '@mui/material';
@@ -53,7 +53,7 @@ export const ColorPicker = memo(function ColorPicker({
             isCustomEvent && customEventID != null
                 ? customEventColorKey(customEventID)
                 : sectionCode != null && term != null
-                  ? courseColorKey(term, sectionCode)
+                  ? scheduleSectionKey(term, sectionCode)
                   : null;
         const value = key != null ? activeAssignments[key] : undefined;
         return value != null ? resolveAssignment(value, getPalette(activeSectionColor, isDark)) : null;
@@ -73,7 +73,7 @@ export const ColorPicker = memo(function ColorPicker({
     useEffect(() => {
         let colorPickerId;
         if (isCustomEvent && customEventID) colorPickerId = customEventID.toString();
-        else if (sectionCode && term) colorPickerId = courseColorKey(term, sectionCode);
+        else if (sectionCode && term) colorPickerId = scheduleSectionKey(term, sectionCode);
         else throw new Error("Colorpicker custom component wasn't supplied a custom event id or a section code.");
         AppStore.registerColorPicker(colorPickerId, updateColor);
 
@@ -110,7 +110,7 @@ export const ColorPicker = memo(function ColorPicker({
                 isCustomEvent && customEventID
                     ? customEventColorKey(customEventID)
                     : sectionCode != null && term != null
-                      ? courseColorKey(term, sectionCode)
+                      ? scheduleSectionKey(term, sectionCode)
                       : null;
             if (key != null) setManualColor(sectionColor, key, newColor.hex);
             return;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
@@ -1,15 +1,9 @@
 import { changeCourseColor } from '$actions/AppStoreActions';
 import { useIsDarkMode } from '$hooks/useIsDarkMode';
 import { useIsMobile } from '$hooks/useIsMobile';
-import {
-    courseColorKey,
-    getPalette,
-    resolveAssignment,
-    type SectionColorSetting,
-    type ThemeAssignmentMap,
-} from '$lib/sectionThemes';
+import { getPalette, resolveAssignment, type SectionColorSetting, type ThemeAssignmentMap } from '$lib/sectionThemes';
 import AppStore from '$stores/AppStore';
-import { colorPickerPresetColors } from '$stores/scheduleHelpers';
+import { colorPickerPresetColors, scheduleSectionKey } from '$stores/scheduleHelpers';
 import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
 import { Box, Popover, type PopoverProps, type SxProps, TableCell, Tooltip } from '@mui/material';
 import { type AASection, type AATerm } from '@packages/antalmanac-types';
@@ -44,7 +38,7 @@ function getDisplayColor(
     if (setting === 'custom') {
         return scheduledSection.color;
     }
-    const value = assignments[courseColorKey(term, section.sectionCode)];
+    const value = assignments[scheduleSectionKey(term, section.sectionCode)];
     return value != null ? resolveAssignment(value, palette) : scheduledSection.color;
 }
 
@@ -95,7 +89,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
             // On a preset theme, store an override layered on the theme; on custom, edit
             // the section's stored color directly.
             if (sectionColor !== 'custom') {
-                setManualColor(sectionColor, courseColorKey(term, section.sectionCode), newColor.hex);
+                setManualColor(sectionColor, scheduleSectionKey(term, section.sectionCode), newColor.hex);
             } else {
                 changeCourseColor(section.sectionCode, term, newColor.hex);
             }
@@ -125,7 +119,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
         if (!visible) {
             return;
         }
-        const pickerId = courseColorKey(term, section.sectionCode);
+        const pickerId = scheduleSectionKey(term, section.sectionCode);
         AppStore.registerColorPicker(pickerId, updateColorFromPicker);
         return () => {
             AppStore.unregisterColorPicker(pickerId, updateColorFromPicker);

--- a/apps/antalmanac/src/lib/sectionThemes/index.ts
+++ b/apps/antalmanac/src/lib/sectionThemes/index.ts
@@ -1,6 +1,6 @@
 import { isCustomEvent, isSkeletonEvent, type CalendarEvent } from '$components/Calendar/types';
-import { scheduleOfferingKey } from '$stores/scheduleHelpers';
-import type { AACourseWithTerm, AASection, AATerm } from '@packages/antalmanac-types';
+import { scheduleOfferingKey, scheduleSectionKey } from '$stores/scheduleHelpers';
+import type { AACourseWithTerm, AASection } from '@packages/antalmanac-types';
 
 import { SECTION_THEMES, type SectionTheme, type SectionThemeId } from './themes';
 
@@ -71,16 +71,8 @@ export function resolveAssignment(value: string, palette: readonly (readonly str
     return palette[slot.family]?.[slot.variant] ?? palette[slot.family]?.[0] ?? palette[0][0];
 }
 
-// TODO: consolidate with scheduleSectionKey once theme assignment keys are migrated off `term|sectionCode`.
-export function courseColorKey(term: AATerm | string, sectionCode: string): string {
-    // Use the term's stable short name (e.g. "2024 Fall"); stringifying the AATerm object
-    // would collapse every term to "[object Object]" and collide on shared section codes.
-    const termId = typeof term === 'string' ? term : term.shortName;
-    return `${termId}|${sectionCode}`;
-}
-
 export function customEventColorKey(customEventID: unknown): string {
-    return `custom|${String(customEventID)}`;
+    return `custom::${String(customEventID)}`;
 }
 
 /**
@@ -148,7 +140,7 @@ export function computeAssignments(
     const courseKeys: string[] = [];
     for (const course of courses) {
         for (const section of course.sections) {
-            courseKeys.push(courseColorKey(course.term, section.sectionCode));
+            courseKeys.push(scheduleSectionKey(course.term, section.sectionCode));
         }
     }
     const customKeys = customEventIds.map(customEventColorKey);
@@ -162,7 +154,7 @@ export function computeAssignments(
     for (const course of courses) {
         const offeringKey = scheduleOfferingKey(course);
         for (const section of course.sections) {
-            const value = next[courseColorKey(course.term, section.sectionCode)];
+            const value = next[scheduleSectionKey(course.term, section.sectionCode)];
             const slot = value != null ? parseSlot(value) : null;
             if (slot) {
                 assigned.push({
@@ -179,7 +171,7 @@ export function computeAssignments(
     for (const course of courses) {
         const offeringKey = scheduleOfferingKey(course);
         for (const section of course.sections) {
-            const key = courseColorKey(course.term, section.sectionCode);
+            const key = scheduleSectionKey(course.term, section.sectionCode);
             if (next[key] != null) continue;
             const slot = pickCourseSlot(offeringKey, section, assigned, palette);
             next[key] = encodeSlot(slot);
@@ -232,7 +224,7 @@ export function applyThemeToCalendarEvents<E extends CalendarEvent>(
         if (isSkeletonEvent(event)) return event;
         const key = isCustomEvent(event)
             ? customEventColorKey(event.customEventID)
-            : courseColorKey(event.term, event.sectionCode);
+            : scheduleSectionKey(event.term, event.sectionCode);
         const value = assignments[key];
         return value != null ? { ...event, color: resolveAssignment(value, palette) } : event;
     });

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -17,10 +17,10 @@ import actionTypesStore, {
     type AddScheduleAction,
     type ReorderAddedCoursesAction,
 } from '$actions/ActionTypesStore';
-import { courseColorKey } from '$lib/sectionThemes';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { useHiddenCoursesStore } from '$stores/HiddenCoursesStore';
 import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
+import { scheduleSectionKey } from '$stores/scheduleHelpers';
 import { Schedules } from '$stores/Schedules';
 import type {
     AACourseWithTerm,
@@ -436,7 +436,7 @@ class AppStore extends EventEmitter {
             newColor: newColor,
         };
         actionTypesStore.autoSaveSchedule(action);
-        this.colorPickers[courseColorKey(term, sectionCode)]?.emit('colorChange', newColor);
+        this.colorPickers[scheduleSectionKey(term, sectionCode)]?.emit('colorChange', newColor);
         this.emit('colorChange', false);
     }
 

--- a/apps/antalmanac/src/stores/SectionThemeStore.ts
+++ b/apps/antalmanac/src/stores/SectionThemeStore.ts
@@ -54,13 +54,39 @@ function readStoredSectionColor(): SectionColorSetting {
     return isSectionColorSetting(raw) ? raw : 'custom';
 }
 
+/**
+ * Migrate persisted assignment keys from the old `term|sectionCode` format
+ * to the canonical `term::sectionCode` format used by `scheduleSectionKey`.
+ */
+function migrateAssignmentKeys(map: ThemeAssignmentMap): ThemeAssignmentMap {
+    const migrated: ThemeAssignmentMap = {};
+    for (const [key, value] of Object.entries(map)) {
+        migrated[key.includes('|') ? key.replace('|', '::') : key] = value;
+    }
+    return migrated;
+}
+
 function readStoredAssignments(): AssignmentsByTheme {
     if (typeof window === 'undefined') return {};
     const raw = getLocalStorageSectionColorAssignments();
     if (!raw) return {};
     try {
         const parsed = JSON.parse(raw);
-        return parsed && typeof parsed === 'object' ? (parsed as AssignmentsByTheme) : {};
+        if (!parsed || typeof parsed !== 'object') return {};
+        const assignments = parsed as AssignmentsByTheme;
+        const migrated: AssignmentsByTheme = {};
+        let didMigrate = false;
+        for (const [themeId, themeMap] of Object.entries(assignments)) {
+            if (!themeMap) continue;
+            const needsMigration = Object.keys(themeMap).some((k) => k.includes('|'));
+            const migratedMap = needsMigration ? migrateAssignmentKeys(themeMap) : themeMap;
+            migrated[themeId as SectionThemeId] = migratedMap;
+            if (needsMigration) didMigrate = true;
+        }
+        if (didMigrate) {
+            persistAssignments(migrated);
+        }
+        return migrated;
     } catch {
         return {};
     }
@@ -144,7 +170,7 @@ export const useSectionThemeStore = create<SectionThemeStore>((set, get) => {
             const existing = assignments[sectionColor] ?? {};
             const { map } = computeAssignments(existing, courses, customEventIds, palette);
 
-            // Merge rather than replace: assignment keys are global (term|sectionCode), and
+            // Merge rather than replace: assignment keys are global (term::sectionCode), and
             // computeAssignments only returns the *current* schedule's keys. Replacing would
             // drop assignments/overrides belonging to other schedules, losing them on switch.
             const hasNew = Object.keys(map).some((key) => existing[key] !== map[key]);


### PR DESCRIPTION
## Summary

Consolidates the two section key functions (`courseColorKey` using `|` separator and `scheduleSectionKey` using `::`) into one. Deletes `courseColorKey` and replaces all usages with `scheduleSectionKey` from `scheduleHelpers.ts`.

```diff
// Before: two functions, two formats
courseColorKey(term, sectionCode)    → "2024 Fall|00100"   // sectionThemes
scheduleSectionKey(term, sectionCode) → "2024 Fall::00100" // scheduleHelpers

// After: one function, one format
scheduleSectionKey(term, sectionCode) → "2024 Fall::00100" // everywhere
```

Also updates `customEventColorKey` separator from `|` to `::` for consistency: `custom|eventId` → `custom::eventId`.

### Migration

Existing theme assignments are persisted in localStorage with `|`-separated keys. A migration shim in `SectionThemeStore.readStoredAssignments()` converts old keys on first load and re-persists, so users don't lose their per-section color overrides.

### Files changed

- **`sectionThemes/index.ts`**: Deleted `courseColorKey`, removed `AATerm` import (no longer needed). Replaced all internal usages with `scheduleSectionKey`. Updated `customEventColorKey` separator.
- **`SectionThemeStore.ts`**: Added `migrateAssignmentKeys` shim for `|` → `::` migration on load.
- **`AppStore.ts`**: Replaced `courseColorKey` import/usage with `scheduleSectionKey`.
- **`ColorPicker.tsx`**: Same replacement.
- **`SectionTableBodyRowColorStrip.tsx`**: Same replacement.

## Test Plan

- `vitest run tests/scheduleHelpers.test.ts tests/calendarize-helpers.test.ts` — 12/12 pass
- `oxlint` clean (0 warnings, 0 errors)

## Issues

Follow-up to #1945 (resolves the TODO at the old line 74 of `sectionThemes/index.ts`)

Link to Devin session: https://app.devin.ai/sessions/a41ea2e605db40e78ed4f4818e411a9f
Requested by: @KevinWu098

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

