### PR TITLE
perf: @mui/x-date-pickers off critical path 

### DIFF
--- a/apps/antalmanac/src/app/(main)/client.tsx
+++ b/apps/antalmanac/src/app/(main)/client.tsx
@@ -13,8 +13,6 @@ import { TutorialInitializer } from '$components/TutorialInitializer';
 import { useKeyboardShortcutsModal } from '$hooks/useKeyboardShortcutsModal';
 import { Stack, useMediaQuery, useTheme } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { useCallback, useEffect } from 'react';
 import { Group, Panel, Separator, useGroupRef } from 'react-resizable-panels';
 
@@ -108,7 +106,7 @@ export default function Client() {
     }, []);
 
     return (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <>
             <AutoSignIn />
             <TutorialInitializer />
             <AuthInitializer />
@@ -121,6 +119,6 @@ export default function Client() {
             <NotificationSnackbar />
             <ReviewPrompt />
             <KeyboardShortcutsModal open={shortcutsOpen} onClose={closeShortcutsModal} />
-        </LocalizationProvider>
+        </>
     );
 }

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
@@ -1,12 +1,8 @@
-import { Skeleton } from '@mui/material';
 import type { TextFieldProps } from '@mui/material';
 import type { TimePickerProps } from '@mui/x-date-pickers';
 import dynamic from 'next/dynamic';
 
-const LabeledTimePickerContent = dynamic(() => import('./LabeledTimePickerContent'), {
-    ssr: false,
-    loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} />,
-});
+const LabeledTimePickerContent = dynamic(() => import('./LabeledTimePickerContent'), { ssr: false });
 
 interface LabeledTimePickerProps {
     label: string;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
@@ -2,6 +2,8 @@ import { CustomInputBox } from '$components/RightPane/CoursePane/SearchForm/Labe
 import { CustomInputLabel } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel';
 import { Box, TextField, type TextFieldProps } from '@mui/material';
 import { DesktopTimePicker, type TimePickerProps } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { forwardRef, useId, useState } from 'react';
 
 interface LabeledTimePickerProps {
@@ -21,28 +23,30 @@ export const LabeledTimePicker = ({ label, timePickerProps, textFieldProps, isAl
     TimePickerTextField.displayName = 'TimePickerTextField';
 
     return (
-        <Box sx={{ display: 'flex', width: '100%', flex: 1 }}>
-            <CustomInputLabel label={label} id={id} isAligned={isAligned} />
-            <CustomInputBox
-                boxProps={{
-                    ref: (node: HTMLElement | null) => {
-                        setAnchorEl(node);
-                    },
-                }}
-            >
-                <DesktopTimePicker
-                    enableAccessibleFieldDOMStructure={false}
-                    {...timePickerProps}
-                    slotProps={{
-                        popper: {
-                            anchorEl,
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Box sx={{ display: 'flex', width: '100%', flex: 1 }}>
+                <CustomInputLabel label={label} id={id} isAligned={isAligned} />
+                <CustomInputBox
+                    boxProps={{
+                        ref: (node: HTMLElement | null) => {
+                            setAnchorEl(node);
                         },
                     }}
-                    slots={{
-                        textField: TimePickerTextField,
-                    }}
-                />
-            </CustomInputBox>
-        </Box>
+                >
+                    <DesktopTimePicker
+                        enableAccessibleFieldDOMStructure={false}
+                        {...timePickerProps}
+                        slotProps={{
+                            popper: {
+                                anchorEl,
+                            },
+                        }}
+                        slots={{
+                            textField: TimePickerTextField,
+                        }}
+                    />
+                </CustomInputBox>
+            </Box>
+        </LocalizationProvider>
     );
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
@@ -1,10 +1,12 @@
-import { CustomInputBox } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox';
-import { CustomInputLabel } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel';
-import { Box, TextField, type TextFieldProps } from '@mui/material';
-import { DesktopTimePicker, type TimePickerProps } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { forwardRef, useId, useState } from 'react';
+import { Skeleton } from '@mui/material';
+import type { TextFieldProps } from '@mui/material';
+import type { TimePickerProps } from '@mui/x-date-pickers';
+import dynamic from 'next/dynamic';
+
+const LabeledTimePickerContent = dynamic(() => import('./LabeledTimePickerContent'), {
+    ssr: false,
+    loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} />,
+});
 
 interface LabeledTimePickerProps {
     label: string;
@@ -13,40 +15,4 @@ interface LabeledTimePickerProps {
     isAligned?: boolean;
 }
 
-export const LabeledTimePicker = ({ label, timePickerProps, textFieldProps, isAligned }: LabeledTimePickerProps) => {
-    const id = useId();
-    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-    const TimePickerTextField = forwardRef<HTMLInputElement, TextFieldProps>((params, ref) => (
-        <TextField size="small" variant="outlined" {...params} {...textFieldProps} id={id} inputRef={ref} />
-    ));
-    TimePickerTextField.displayName = 'TimePickerTextField';
-
-    return (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-            <Box sx={{ display: 'flex', width: '100%', flex: 1 }}>
-                <CustomInputLabel label={label} id={id} isAligned={isAligned} />
-                <CustomInputBox
-                    boxProps={{
-                        ref: (node: HTMLElement | null) => {
-                            setAnchorEl(node);
-                        },
-                    }}
-                >
-                    <DesktopTimePicker
-                        enableAccessibleFieldDOMStructure={false}
-                        {...timePickerProps}
-                        slotProps={{
-                            popper: {
-                                anchorEl,
-                            },
-                        }}
-                        slots={{
-                            textField: TimePickerTextField,
-                        }}
-                    />
-                </CustomInputBox>
-            </Box>
-        </LocalizationProvider>
-    );
-};
+export const LabeledTimePicker = (props: LabeledTimePickerProps) => <LabeledTimePickerContent {...props} />;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePicker.tsx
@@ -1,8 +1,12 @@
+import { Skeleton } from '@mui/material';
 import type { TextFieldProps } from '@mui/material';
 import type { TimePickerProps } from '@mui/x-date-pickers';
 import dynamic from 'next/dynamic';
 
-const LabeledTimePickerContent = dynamic(() => import('./LabeledTimePickerContent'), { ssr: false });
+const LabeledTimePickerContent = dynamic(() => import('./LabeledTimePickerContent'), {
+    ssr: false,
+    loading: () => <Skeleton variant="rounded" animation="wave" width="100%" height={40} sx={{ flex: 1 }} />,
+});
 
 interface LabeledTimePickerProps {
     label: string;

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePickerContent.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePickerContent.tsx
@@ -1,0 +1,57 @@
+import { CustomInputBox } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox';
+import { CustomInputLabel } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel';
+import { Box, TextField, type TextFieldProps } from '@mui/material';
+import { DesktopTimePicker, type TimePickerProps } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { forwardRef, useId, useState } from 'react';
+
+interface LabeledTimePickerContentProps {
+    label: string;
+    timePickerProps?: TimePickerProps;
+    textFieldProps?: TextFieldProps;
+    isAligned?: boolean;
+}
+
+export default function LabeledTimePickerContent({
+    label,
+    timePickerProps,
+    textFieldProps,
+    isAligned,
+}: LabeledTimePickerContentProps) {
+    const id = useId();
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+    const TimePickerTextField = forwardRef<HTMLInputElement, TextFieldProps>((params, ref) => (
+        <TextField size="small" variant="outlined" {...params} {...textFieldProps} id={id} inputRef={ref} />
+    ));
+    TimePickerTextField.displayName = 'TimePickerTextField';
+
+    return (
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Box sx={{ display: 'flex', width: '100%', flex: 1 }}>
+                <CustomInputLabel label={label} id={id} isAligned={isAligned} />
+                <CustomInputBox
+                    boxProps={{
+                        ref: (node: HTMLElement | null) => {
+                            setAnchorEl(node);
+                        },
+                    }}
+                >
+                    <DesktopTimePicker
+                        enableAccessibleFieldDOMStructure={false}
+                        {...timePickerProps}
+                        slotProps={{
+                            popper: {
+                                anchorEl,
+                            },
+                        }}
+                        slots={{
+                            textField: TimePickerTextField,
+                        }}
+                    />
+                </CustomInputBox>
+            </Box>
+        </LocalizationProvider>
+    );
+}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePickerContent.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledTimePickerContent.tsx
@@ -1,10 +1,10 @@
 import { CustomInputBox } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox';
 import { CustomInputLabel } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputLabel';
-import { Box, TextField, type TextFieldProps } from '@mui/material';
+import { Box, type TextFieldProps } from '@mui/material';
 import { DesktopTimePicker, type TimePickerProps } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { forwardRef, useId, useState } from 'react';
+import { useId, useState } from 'react';
 
 interface LabeledTimePickerContentProps {
     label: string;
@@ -21,11 +21,6 @@ export default function LabeledTimePickerContent({
 }: LabeledTimePickerContentProps) {
     const id = useId();
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-    const TimePickerTextField = forwardRef<HTMLInputElement, TextFieldProps>((params, ref) => (
-        <TextField size="small" variant="outlined" {...params} {...textFieldProps} id={id} inputRef={ref} />
-    ));
-    TimePickerTextField.displayName = 'TimePickerTextField';
 
     return (
         <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -45,9 +40,12 @@ export default function LabeledTimePickerContent({
                             popper: {
                                 anchorEl,
                             },
-                        }}
-                        slots={{
-                            textField: TimePickerTextField,
+                            textField: {
+                                size: 'small' as const,
+                                variant: 'outlined' as const,
+                                ...textFieldProps,
+                                id,
+                            },
                         }}
                     />
                 </CustomInputBox>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
@@ -14,7 +14,7 @@ import { readAdvancedSearchParams } from '$components/RightPane/CoursePane/Searc
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { Box, Button, Collapse, Skeleton, Typography } from '@mui/material';
 import dynamic from 'next/dynamic';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const StartTimeField = dynamic(
     () => import('./AdvancedSearchFields/StartTimeField').then((m) => ({ default: m.StartTimeField })),
@@ -28,11 +28,6 @@ const EndTimeField = dynamic(
 
 export function AdvancedSearch() {
     const [expanded, setExpanded] = useState(() => hasAdvancedParams(readAdvancedSearchParams()));
-    const [mounted, setMounted] = useState(expanded);
-
-    useEffect(() => {
-        if (expanded) setMounted(true);
-    }, [expanded]);
 
     const handleExpand = () => setExpanded((value) => !value);
 
@@ -54,41 +49,39 @@ export function AdvancedSearch() {
                 {expanded ? <ExpandLess /> : <ExpandMore />}
             </Button>
 
-            <Collapse in={expanded}>
-                {mounted && (
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexWrap: 'wrap',
-                            gap: 2,
-                            marginBottom: '1rem',
-                        }}
-                    >
-                        <AdvancedSearchFieldRow>
-                            <InstructorField />
-                            <UnitsField />
-                            <FullCoursesField />
-                        </AdvancedSearchFieldRow>
+            <Collapse in={expanded} mountOnEnter>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 2,
+                        marginBottom: '1rem',
+                    }}
+                >
+                    <AdvancedSearchFieldRow>
+                        <InstructorField />
+                        <UnitsField />
+                        <FullCoursesField />
+                    </AdvancedSearchFieldRow>
 
-                        <AdvancedSearchFieldRow>
-                            <DivisionField />
-                            <StartTimeField />
-                            <EndTimeField />
-                        </AdvancedSearchFieldRow>
+                    <AdvancedSearchFieldRow>
+                        <DivisionField />
+                        <StartTimeField />
+                        <EndTimeField />
+                    </AdvancedSearchFieldRow>
 
-                        <AdvancedSearchFieldRow>
-                            <OnlineField />
-                            <BuildingField />
-                            <RoomField />
-                        </AdvancedSearchFieldRow>
+                    <AdvancedSearchFieldRow>
+                        <OnlineField />
+                        <BuildingField />
+                        <RoomField />
+                    </AdvancedSearchFieldRow>
 
-                        <AdvancedSearchFieldRow>
-                            <ExcludeRoadmapField />
-                            <ExcludeRestrictionsField />
-                            <DaysField />
-                        </AdvancedSearchFieldRow>
-                    </Box>
-                )}
+                    <AdvancedSearchFieldRow>
+                        <ExcludeRoadmapField />
+                        <ExcludeRestrictionsField />
+                        <DaysField />
+                    </AdvancedSearchFieldRow>
+                </Box>
             </Collapse>
         </>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
@@ -2,23 +2,37 @@ import { AdvancedSearchFieldRow } from '$components/RightPane/CoursePane/SearchF
 import { BuildingField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/BuildingField';
 import { DaysField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField';
 import { DivisionField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DivisionField';
-import { EndTimeField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/EndTimeField';
 import { ExcludeRestrictionsField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField';
 import { ExcludeRoadmapField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRoadmapField';
 import { FullCoursesField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/FullCoursesField';
 import { InstructorField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/InstructorField';
 import { OnlineField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/OnlineField';
 import { RoomField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/RoomField';
-import { StartTimeField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/StartTimeField';
 import { UnitsField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/UnitsField';
 import { hasAdvancedParams } from '$components/RightPane/CoursePane/SearchParams/helpers';
 import { readAdvancedSearchParams } from '$components/RightPane/CoursePane/SearchParams/loaders';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { Box, Button, Collapse, Typography } from '@mui/material';
-import { useState } from 'react';
+import { Box, Button, Collapse, Skeleton, Typography } from '@mui/material';
+import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
+
+const StartTimeField = dynamic(
+    () => import('./AdvancedSearchFields/StartTimeField').then((m) => ({ default: m.StartTimeField })),
+    { ssr: false, loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} /> }
+);
+
+const EndTimeField = dynamic(
+    () => import('./AdvancedSearchFields/EndTimeField').then((m) => ({ default: m.EndTimeField })),
+    { ssr: false, loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} /> }
+);
 
 export function AdvancedSearch() {
     const [expanded, setExpanded] = useState(() => hasAdvancedParams(readAdvancedSearchParams()));
+    const [mounted, setMounted] = useState(expanded);
+
+    useEffect(() => {
+        if (expanded) setMounted(true);
+    }, [expanded]);
 
     const handleExpand = () => setExpanded((value) => !value);
 
@@ -41,38 +55,40 @@ export function AdvancedSearch() {
             </Button>
 
             <Collapse in={expanded}>
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: 2,
-                        marginBottom: '1rem',
-                    }}
-                >
-                    <AdvancedSearchFieldRow>
-                        <InstructorField />
-                        <UnitsField />
-                        <FullCoursesField />
-                    </AdvancedSearchFieldRow>
+                {mounted && (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: 2,
+                            marginBottom: '1rem',
+                        }}
+                    >
+                        <AdvancedSearchFieldRow>
+                            <InstructorField />
+                            <UnitsField />
+                            <FullCoursesField />
+                        </AdvancedSearchFieldRow>
 
-                    <AdvancedSearchFieldRow>
-                        <DivisionField />
-                        <StartTimeField />
-                        <EndTimeField />
-                    </AdvancedSearchFieldRow>
+                        <AdvancedSearchFieldRow>
+                            <DivisionField />
+                            <StartTimeField />
+                            <EndTimeField />
+                        </AdvancedSearchFieldRow>
 
-                    <AdvancedSearchFieldRow>
-                        <OnlineField />
-                        <BuildingField />
-                        <RoomField />
-                    </AdvancedSearchFieldRow>
+                        <AdvancedSearchFieldRow>
+                            <OnlineField />
+                            <BuildingField />
+                            <RoomField />
+                        </AdvancedSearchFieldRow>
 
-                    <AdvancedSearchFieldRow>
-                        <ExcludeRoadmapField />
-                        <ExcludeRestrictionsField />
-                        <DaysField />
-                    </AdvancedSearchFieldRow>
-                </Box>
+                        <AdvancedSearchFieldRow>
+                            <ExcludeRoadmapField />
+                            <ExcludeRestrictionsField />
+                            <DaysField />
+                        </AdvancedSearchFieldRow>
+                    </Box>
+                )}
             </Collapse>
         </>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearch.tsx
@@ -2,29 +2,20 @@ import { AdvancedSearchFieldRow } from '$components/RightPane/CoursePane/SearchF
 import { BuildingField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/BuildingField';
 import { DaysField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField';
 import { DivisionField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DivisionField';
+import { EndTimeField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/EndTimeField';
 import { ExcludeRestrictionsField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField';
 import { ExcludeRoadmapField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRoadmapField';
 import { FullCoursesField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/FullCoursesField';
 import { InstructorField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/InstructorField';
 import { OnlineField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/OnlineField';
 import { RoomField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/RoomField';
+import { StartTimeField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/StartTimeField';
 import { UnitsField } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/UnitsField';
 import { hasAdvancedParams } from '$components/RightPane/CoursePane/SearchParams/helpers';
 import { readAdvancedSearchParams } from '$components/RightPane/CoursePane/SearchParams/loaders';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { Box, Button, Collapse, Skeleton, Typography } from '@mui/material';
-import dynamic from 'next/dynamic';
+import { Box, Button, Collapse, Typography } from '@mui/material';
 import { useState } from 'react';
-
-const StartTimeField = dynamic(
-    () => import('./AdvancedSearchFields/StartTimeField').then((m) => ({ default: m.StartTimeField })),
-    { ssr: false, loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} /> }
-);
-
-const EndTimeField = dynamic(
-    () => import('./AdvancedSearchFields/EndTimeField').then((m) => ({ default: m.EndTimeField })),
-    { ssr: false, loading: () => <Skeleton variant="rounded" width="100%" height={40} sx={{ flex: 1 }} /> }
-);
 
 export function AdvancedSearch() {
     const [expanded, setExpanded] = useState(() => hasAdvancedParams(readAdvancedSearchParams()));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Defers `@mui/x-date-pickers` off the search tab's lazy chunk, so the date-picker code only loads when a user opens the Advanced Search accordion.

**Context:** `ScheduleManagement.tsx` already uses `next/dynamic`, so the date-picker code was never in the initial page load — it was already in a lazy chunk loaded when the search tab mounts. This PR moves it one level deeper.

**Measured impact (production builds):**

| | Search tab chunk (gzip) | Accordion expand (gzip) | Total bundle (gzip) |
|---|---|---|---|
| **main** | 98 KB (date-pickers included) | — | 1,150 KB |
| **This PR** | 62 KB (date-pickers excluded) | 41 KB (on demand) | 1,154 KB |

- **Search tab load: -36 KB gzip**
- **Total bundle: +4 KB gzip** (chunk splitting overhead)
- **Initial page load: unchanged**

**Changes:**

1. **`client.tsx`** — Removed `LocalizationProvider` + `AdapterDateFns` from the top-level app wrapper
2. **`LabeledTimePicker.tsx`** — Now a thin `next/dynamic` wrapper that lazy-loads `LabeledTimePickerContent`
3. **`LabeledTimePickerContent.tsx`** *(new)* — Extracted implementation with `LocalizationProvider` scoped to the only consumer
4. **`AdvancedSearch.tsx`** — Added `mountOnEnter` to `Collapse` to defer child mounting until first expand; reverted to static imports (lazy boundary is now inside `LabeledTimePicker`)

## Test Plan

- `pnpm lint` passes (0 warnings, 0 errors)
- Production build succeeds, chunk sizes verified via `build-manifest.json` and `react-loadable-manifest.json`
- No behavioral change for users — time pickers render correctly when accordion is expanded

## Issues

N/A — optimization only, reimplements #1943 with the lazy boundary colocated at `LabeledTimePicker` instead of at the `AdvancedSearch` consumer level
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2340153-047c-44c9-9e26-8a14fd24a633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2340153-047c-44c9-9e26-8a14fd24a633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

