### PR TITLE
fix: correct enrollment change deadline boundary

### DIFF
--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -83,5 +83,7 @@ export function canTermEnrollmentChange(term: AATerm) {
         weeksUntilDropDeadline++;
     }
 
-    return new Date() <= setDay(addWeeks(term.instructionStart, weeksUntilDropDeadline), 5);
+    const dropDeadline = setDay(addWeeks(term.instructionStart, weeksUntilDropDeadline), 5);
+    dropDeadline.setHours(17, 0, 0, 0);
+    return new Date() <= dropDeadline;
 }

--- a/apps/antalmanac/tests/termHelpers.test.ts
+++ b/apps/antalmanac/tests/termHelpers.test.ts
@@ -1,0 +1,35 @@
+import { canTermEnrollmentChange } from '$lib/termHelpers';
+import type { AATerm } from '@packages/antalmanac-types';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const WINTER_2026: AATerm = {
+    year: '2026',
+    quarter: 'Winter',
+    shortName: '2026 Winter',
+    longName: 'Winter 2026',
+    instructionStart: new Date(2026, 0, 5),
+    instructionEnd: new Date(2026, 2, 13),
+    finalsStart: new Date(2026, 2, 14),
+    finalsEnd: new Date(2026, 2, 20),
+    socAvailable: new Date(2025, 10, 1),
+    isSummerTerm: false,
+};
+
+describe('canTermEnrollmentChange', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test.each([
+        ['Thursday at 11:59 p.m.', new Date(2026, 0, 15, 23, 59), true],
+        ['Friday at 4:59:59.999 p.m.', new Date(2026, 0, 16, 16, 59, 59, 999), true],
+        ['Friday at exactly 5:00 p.m.', new Date(2026, 0, 16, 17), true],
+        ['Friday at 5:00:00.001 p.m.', new Date(2026, 0, 16, 17, 0, 0, 1), false],
+        ['Saturday at midnight', new Date(2026, 0, 17), false],
+    ])('returns %s at %s', (_description, currentTime, expected) => {
+        vi.useFakeTimers();
+        vi.setSystemTime(currentTime);
+
+        expect(canTermEnrollmentChange(WINTER_2026)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Summary

- Correct the enrollment-change deadline from the beginning of Friday to Friday at 5:00 p.m.
- Preserve the existing full-term, short-term, and Week 0 calculations.
- Add focused boundary tests for times before, exactly at, and after the deadline.

## Root cause

The calculated deadline inherited midnight from `instructionStart`, causing enrollment changes and related functionality to become unavailable at the beginning of deadline Friday.

## Testing

- `pnpm exec vitest run tests/termHelpers.test.ts` — 5 tests passed
- `pnpm lint` — passed
- Full `pnpm test --run` could not complete locally because generating `termData.json` requires an unavailable `ANTEATER_API_KEY`; the new `termHelpers` tests pass independently

Closes #1818

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

