### PR TITLE
fix: use the latest schedule term for custom events in the ICS export

### DIFF
--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -224,8 +224,8 @@ export function getEventsFromCourses(events = AppStore.getEventsWithFinalsInCale
     const customEventIDs = new Set();
     const calendarEvents = events.flatMap((event) => {
         if (isCustomEvent(event)) {
-            // FIXME: We don't have a way to get the term for custom events,
-            // so we just use the default term.
+            // Custom events aren't tied to a term, so they take the latest term on the
+            // schedule; a schedule with no courses falls back to the default term.
             const term = getDefaultTerm(events);
             const { title, start, end, building } = event;
             const days = getByDays(event.days.join(''));

--- a/apps/antalmanac/src/lib/term.ts
+++ b/apps/antalmanac/src/lib/term.ts
@@ -14,15 +14,24 @@ const defaultTermIndex = termData.findIndex((term) => !term.isSummerTerm);
 /**
  * Get the default term (first non-summer term with SOC available).
  *
- * If an array of events is provided, returns the first term found in those events instead.
+ * If an array of events is provided, returns the latest term among its course events instead.
+ * A schedule can hold courses from more than one term, and the events are in whatever order
+ * they were added, so the latest term is used rather than whichever one happens to come first.
  */
 export function getDefaultTerm(events: (CustomEvent | CourseEvent)[] = []): AATerm {
+    let latestTerm: AATerm | undefined;
+
     for (const event of events) {
-        if (isCourseEvent(event)) {
-            return event.term;
+        if (!isCourseEvent(event)) {
+            continue;
+        }
+
+        if (latestTerm === undefined || event.term.instructionStart > latestTerm.instructionStart) {
+            latestTerm = event.term;
         }
     }
-    return termData[defaultTermIndex];
+
+    return latestTerm ?? termData[defaultTermIndex];
 }
 
 export function getTermByShortName(termShortName: string): AATerm | undefined {

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -1,70 +1,10 @@
-import type { CalendarEvent, CourseEvent, CustomEvent } from '$components/Calendar/types';
+import type { CalendarEvent } from '$components/Calendar/types';
 import { getEventsFromCourses } from '$lib/download';
 import { getDefaultTerm } from '$lib/term';
-import type { AATerm } from '@packages/antalmanac-types';
 import type { DateArray } from 'ics';
 import { describe, expect, test } from 'vitest';
 
-const FALL_2023: AATerm = {
-    year: '2023',
-    quarter: 'Fall',
-    shortName: '2023 Fall',
-    longName: 'Fall 2023',
-    instructionStart: new Date(2023, 8, 28),
-    instructionEnd: new Date(2023, 11, 8),
-    finalsStart: new Date(2023, 11, 9),
-    finalsEnd: new Date(2023, 11, 15),
-    socAvailable: new Date(2023, 4, 1),
-    isSummerTerm: false,
-};
-
-const WINTER_2024: AATerm = {
-    year: '2024',
-    quarter: 'Winter',
-    shortName: '2024 Winter',
-    longName: 'Winter 2024',
-    instructionStart: new Date(2024, 0, 8),
-    instructionEnd: new Date(2024, 2, 15),
-    finalsStart: new Date(2024, 2, 16),
-    finalsEnd: new Date(2024, 2, 22),
-    socAvailable: new Date(2023, 9, 1),
-    isSummerTerm: false,
-};
-
-function courseEvent(term: AATerm): CourseEvent {
-    return {
-        color: 'placeholderColor',
-        start: new Date(2023, 9, 29, 1, 2),
-        end: new Date(2023, 9, 29, 3, 4),
-        title: 'placeholderDeptCode placeholderCourseNumber',
-        locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
-        showLocationInfo: true,
-        finalExam: {
-            examStatus: 'NO_FINAL',
-        },
-        courseTitle: 'placeholderCourseTitle',
-        instructors: ['placeholderInstructor'],
-        eventKind: 'course',
-        sectionCode: 'placeholderSectionCode',
-        deptValue: 'placeholderDeptCode',
-        courseNumber: 'placeholderCourseNumber',
-        sectionType: 'placeholderSectionType',
-        term,
-    };
-}
-
-function customEvent(): CustomEvent {
-    return {
-        color: 'placeholderColor',
-        start: new Date(2023, 9, 29, 9, 0),
-        end: new Date(2023, 9, 29, 10, 0),
-        title: 'placeholderCustomEventTitle',
-        customEventID: '123',
-        eventKind: 'custom',
-        days: ['M'],
-        building: 'placeholderCustomEventBuilding',
-    };
-}
+import { FALL_2023, WINTER_2024, courseEvent, customEvent } from './helpers/term-fixtures';
 
 describe('download-ics', () => {
     test('converts schedule courses to events for the ics library', () => {

--- a/apps/antalmanac/tests/download-ics.test.ts
+++ b/apps/antalmanac/tests/download-ics.test.ts
@@ -1,6 +1,8 @@
-import type { CalendarEvent } from '$components/Calendar/types';
+import type { CalendarEvent, CourseEvent, CustomEvent } from '$components/Calendar/types';
 import { getEventsFromCourses } from '$lib/download';
+import { getDefaultTerm } from '$lib/term';
 import type { AATerm } from '@packages/antalmanac-types';
+import type { DateArray } from 'ics';
 import { describe, expect, test } from 'vitest';
 
 const FALL_2023: AATerm = {
@@ -15,6 +17,54 @@ const FALL_2023: AATerm = {
     socAvailable: new Date(2023, 4, 1),
     isSummerTerm: false,
 };
+
+const WINTER_2024: AATerm = {
+    year: '2024',
+    quarter: 'Winter',
+    shortName: '2024 Winter',
+    longName: 'Winter 2024',
+    instructionStart: new Date(2024, 0, 8),
+    instructionEnd: new Date(2024, 2, 15),
+    finalsStart: new Date(2024, 2, 16),
+    finalsEnd: new Date(2024, 2, 22),
+    socAvailable: new Date(2023, 9, 1),
+    isSummerTerm: false,
+};
+
+function courseEvent(term: AATerm): CourseEvent {
+    return {
+        color: 'placeholderColor',
+        start: new Date(2023, 9, 29, 1, 2),
+        end: new Date(2023, 9, 29, 3, 4),
+        title: 'placeholderDeptCode placeholderCourseNumber',
+        locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
+        showLocationInfo: true,
+        finalExam: {
+            examStatus: 'NO_FINAL',
+        },
+        courseTitle: 'placeholderCourseTitle',
+        instructors: ['placeholderInstructor'],
+        eventKind: 'course',
+        sectionCode: 'placeholderSectionCode',
+        deptValue: 'placeholderDeptCode',
+        courseNumber: 'placeholderCourseNumber',
+        sectionType: 'placeholderSectionType',
+        term,
+    };
+}
+
+function customEvent(): CustomEvent {
+    return {
+        color: 'placeholderColor',
+        start: new Date(2023, 9, 29, 9, 0),
+        end: new Date(2023, 9, 29, 10, 0),
+        title: 'placeholderCustomEventTitle',
+        customEventID: '123',
+        eventKind: 'custom',
+        days: ['M'],
+        building: 'placeholderCustomEventBuilding',
+    };
+}
 
 describe('download-ics', () => {
     test('converts schedule courses to events for the ics library', () => {
@@ -96,10 +146,32 @@ describe('download-ics', () => {
             },
         ];
 
-        // Custom events use getDefaultTerm(events) — first non-custom course term (FALL_2023 here).
+        // Custom events use getDefaultTerm(events) — the only course term (FALL_2023 here).
         const result = getEventsFromCourses(courses);
 
         expect(result).toMatchSnapshot();
+    });
+
+    test('schedules custom events in the latest term of a multi-term schedule', () => {
+        const courses = [courseEvent(FALL_2023), courseEvent(WINTER_2024), customEvent()];
+
+        const result = getEventsFromCourses(courses);
+        const custom = result.find((event) => event.title === 'placeholderCustomEventTitle');
+
+        // Winter 2024 instruction starts on Monday, January 8th; Fall 2023 starts in September.
+        expect(custom?.start).toEqual([2024, 1, 8, 9, 0]);
+        // Winter is a 10-week term, so a Monday event meets 10 times.
+        expect(custom?.recurrenceRule).toEqual('FREQ=WEEKLY;BYDAY=MO;INTERVAL=1;COUNT=10');
+    });
+
+    test('schedules custom events in the default term when the schedule has no courses', () => {
+        const [custom] = getEventsFromCourses([customEvent()]);
+        const [year, month, day] = custom.start as DateArray;
+        const defaultTerm = getDefaultTerm();
+        const customEventStart = new Date(year, month - 1, day);
+
+        expect(customEventStart.getTime()).toBeGreaterThanOrEqual(defaultTerm.instructionStart.getTime());
+        expect(customEventStart.getTime()).toBeLessThanOrEqual(defaultTerm.instructionEnd.getTime());
     });
 
     test('ics file has the correct contents', () => {

--- a/apps/antalmanac/tests/helpers/term-fixtures.ts
+++ b/apps/antalmanac/tests/helpers/term-fixtures.ts
@@ -1,0 +1,63 @@
+import type { CourseEvent, CustomEvent } from '$components/Calendar/types';
+import type { AATerm } from '@packages/antalmanac-types';
+
+export const FALL_2023: AATerm = {
+    year: '2023',
+    quarter: 'Fall',
+    shortName: '2023 Fall',
+    longName: 'Fall 2023',
+    instructionStart: new Date(2023, 8, 28),
+    instructionEnd: new Date(2023, 11, 8),
+    finalsStart: new Date(2023, 11, 9),
+    finalsEnd: new Date(2023, 11, 15),
+    socAvailable: new Date(2023, 4, 1),
+    isSummerTerm: false,
+};
+
+export const WINTER_2024: AATerm = {
+    year: '2024',
+    quarter: 'Winter',
+    shortName: '2024 Winter',
+    longName: 'Winter 2024',
+    instructionStart: new Date(2024, 0, 8),
+    instructionEnd: new Date(2024, 2, 15),
+    finalsStart: new Date(2024, 2, 16),
+    finalsEnd: new Date(2024, 2, 22),
+    socAvailable: new Date(2023, 9, 1),
+    isSummerTerm: false,
+};
+
+export function courseEvent(term: AATerm): CourseEvent {
+    return {
+        color: 'placeholderColor',
+        start: new Date(2023, 9, 29, 1, 2),
+        end: new Date(2023, 9, 29, 3, 4),
+        title: 'placeholderDeptCode placeholderCourseNumber',
+        locations: [{ building: 'placeholderLocation', room: 'placeholderRoom', days: 'MWF' }],
+        showLocationInfo: true,
+        finalExam: {
+            examStatus: 'NO_FINAL',
+        },
+        courseTitle: 'placeholderCourseTitle',
+        instructors: ['placeholderInstructor'],
+        eventKind: 'course',
+        sectionCode: 'placeholderSectionCode',
+        deptValue: 'placeholderDeptCode',
+        courseNumber: 'placeholderCourseNumber',
+        sectionType: 'placeholderSectionType',
+        term,
+    };
+}
+
+export function customEvent(): CustomEvent {
+    return {
+        color: 'placeholderColor',
+        start: new Date(2023, 9, 29, 9, 0),
+        end: new Date(2023, 9, 29, 10, 0),
+        title: 'placeholderCustomEventTitle',
+        customEventID: '123',
+        eventKind: 'custom',
+        days: ['M'],
+        building: 'placeholderCustomEventBuilding',
+    };
+}

--- a/apps/antalmanac/tests/termData.test.tsx
+++ b/apps/antalmanac/tests/termData.test.tsx
@@ -1,68 +1,7 @@
-import type { CourseEvent, CustomEvent } from '$components/Calendar/types';
 import { getDefaultTerm, termData } from '$lib/term';
-import type { AATerm } from '@packages/antalmanac-types';
 import { describe, expect, test } from 'vitest';
 
-const FALL_2023: AATerm = {
-    year: '2023',
-    quarter: 'Fall',
-    shortName: '2023 Fall',
-    longName: '2023 Fall Quarter',
-    instructionStart: new Date(2023, 8, 28),
-    instructionEnd: new Date(2023, 11, 8),
-    finalsStart: new Date(2023, 11, 9),
-    finalsEnd: new Date(2023, 11, 15),
-    socAvailable: new Date(2023, 4, 1),
-    isSummerTerm: false,
-};
-
-const WINTER_2024: AATerm = {
-    year: '2024',
-    quarter: 'Winter',
-    shortName: '2024 Winter',
-    longName: '2024 Winter Quarter',
-    instructionStart: new Date(2024, 0, 8),
-    instructionEnd: new Date(2024, 2, 15),
-    finalsStart: new Date(2024, 2, 16),
-    finalsEnd: new Date(2024, 2, 22),
-    socAvailable: new Date(2023, 9, 1),
-    isSummerTerm: false,
-};
-
-function courseEvent(term: AATerm): CourseEvent {
-    return {
-        locations: [],
-        showLocationInfo: false,
-        finalExam: {
-            examStatus: 'NO_FINAL',
-        },
-        courseTitle: '',
-        instructors: [],
-        eventKind: 'course',
-        sectionCode: '',
-        sectionType: '',
-        term,
-        color: '',
-        deptValue: '',
-        courseNumber: '',
-        start: new Date(0),
-        end: new Date(0),
-        title: '',
-    };
-}
-
-function customEvent(): CustomEvent {
-    return {
-        eventKind: 'custom',
-        customEventID: '1',
-        building: '',
-        days: ['M'],
-        color: '',
-        start: new Date(0),
-        end: new Date(0),
-        title: '',
-    };
-}
+import { FALL_2023, WINTER_2024, courseEvent, customEvent } from './helpers/term-fixtures';
 
 describe('termData', () => {
     /**
@@ -92,9 +31,7 @@ describe('termData', () => {
         expect(getDefaultTerm(events).shortName).toEqual(WINTER_2024.shortName);
     });
 
-    test('uses default term index if the events contain no courses', () => {
-        const defaultTermIndex = termData.findIndex((t) => !t.isSummerTerm);
-
-        expect(getDefaultTerm([customEvent()]).shortName).toEqual(termData[defaultTermIndex].shortName);
+    test('falls back to the no-events default term when the events contain no courses', () => {
+        expect(getDefaultTerm([customEvent()]).shortName).toEqual(getDefaultTerm().shortName);
     });
 });

--- a/apps/antalmanac/tests/termData.test.tsx
+++ b/apps/antalmanac/tests/termData.test.tsx
@@ -1,6 +1,68 @@
-import type { CourseEvent } from '$components/Calendar/types';
+import type { CourseEvent, CustomEvent } from '$components/Calendar/types';
 import { getDefaultTerm, termData } from '$lib/term';
+import type { AATerm } from '@packages/antalmanac-types';
 import { describe, expect, test } from 'vitest';
+
+const FALL_2023: AATerm = {
+    year: '2023',
+    quarter: 'Fall',
+    shortName: '2023 Fall',
+    longName: '2023 Fall Quarter',
+    instructionStart: new Date(2023, 8, 28),
+    instructionEnd: new Date(2023, 11, 8),
+    finalsStart: new Date(2023, 11, 9),
+    finalsEnd: new Date(2023, 11, 15),
+    socAvailable: new Date(2023, 4, 1),
+    isSummerTerm: false,
+};
+
+const WINTER_2024: AATerm = {
+    year: '2024',
+    quarter: 'Winter',
+    shortName: '2024 Winter',
+    longName: '2024 Winter Quarter',
+    instructionStart: new Date(2024, 0, 8),
+    instructionEnd: new Date(2024, 2, 15),
+    finalsStart: new Date(2024, 2, 16),
+    finalsEnd: new Date(2024, 2, 22),
+    socAvailable: new Date(2023, 9, 1),
+    isSummerTerm: false,
+};
+
+function courseEvent(term: AATerm): CourseEvent {
+    return {
+        locations: [],
+        showLocationInfo: false,
+        finalExam: {
+            examStatus: 'NO_FINAL',
+        },
+        courseTitle: '',
+        instructors: [],
+        eventKind: 'course',
+        sectionCode: '',
+        sectionType: '',
+        term,
+        color: '',
+        deptValue: '',
+        courseNumber: '',
+        start: new Date(0),
+        end: new Date(0),
+        title: '',
+    };
+}
+
+function customEvent(): CustomEvent {
+    return {
+        eventKind: 'custom',
+        customEventID: '1',
+        building: '',
+        days: ['M'],
+        color: '',
+        start: new Date(0),
+        end: new Date(0),
+        title: '',
+    };
+}
 
 describe('termData', () => {
     /**
@@ -12,28 +74,27 @@ describe('termData', () => {
         expect(term.shortName).toEqual(termData[defaultTermIndex].shortName);
     });
 
-    test('uses first term found in event list if provided', () => {
-        const term = getDefaultTerm();
-        const event: CourseEvent = {
-            locations: [],
-            showLocationInfo: false,
-            finalExam: {
-                examStatus: 'NO_FINAL',
-            },
-            courseTitle: '',
-            instructors: [],
-            eventKind: 'course',
-            sectionCode: '',
-            sectionType: '',
-            term,
-            color: '',
-            deptValue: '',
-            courseNumber: '',
-            start: new Date(0),
-            end: new Date(0),
-            title: '',
-        };
+    test('uses the term found in event list if provided', () => {
+        const event = courseEvent(getDefaultTerm());
 
         expect(getDefaultTerm([event]).shortName).toEqual(event.term.shortName);
+    });
+
+    test('uses the latest term when the events span multiple terms', () => {
+        const events = [courseEvent(FALL_2023), courseEvent(WINTER_2024)];
+
+        expect(getDefaultTerm(events).shortName).toEqual(WINTER_2024.shortName);
+    });
+
+    test('uses the latest term regardless of the order of the events', () => {
+        const events = [courseEvent(WINTER_2024), courseEvent(FALL_2023)];
+
+        expect(getDefaultTerm(events).shortName).toEqual(WINTER_2024.shortName);
+    });
+
+    test('uses default term index if the events contain no courses', () => {
+        const defaultTermIndex = termData.findIndex((t) => !t.isSummerTerm);
+
+        expect(getDefaultTerm([customEvent()]).shortName).toEqual(termData[defaultTermIndex].shortName);
     });
 });


### PR DESCRIPTION
This PR proposes fixing the term that custom events inherit when a schedule is exported to .ics, so a custom event on a schedule that spans more than one term is written into the latest term instead of whichever course happens to come first in the event list. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/202. You can sign in with your GitHub ID to claim ownership of the project.

## Summary

`getEventsFromCourses` gives every custom event a term via `getDefaultTerm(events)`, and that helper returned the first course term it found while walking the event list. That list is in whatever order the courses were added, so a schedule holding both a 2023 Fall and a 2024 Winter course can hand a custom event the Fall term: `getClassStartDate` then anchors the event to Fall's instruction start and `getRRule` counts out Fall's weeks, dropping a "Work shift" block about three months away from where the student put it.

Reproduced on `main` at 310e564 with a scratch test — a schedule holding one 2023 Fall course, one 2024 Winter course, and one Monday 9:00 custom event:

```
$ pnpm vitest run tests/repro-762.test.ts

 FAIL  tests/repro-762.test.ts > custom event inherits the LATEST course term
AssertionError: expected [ 2023, 10, 2, 9, 0 ] to deeply equal [ 2024, 1, 8, 9, 0 ]

  Array [
-   2024,
-   1,
-   8,
+   2023,
+   10,
+   2,
    9,
    0,
  ]
```

Winter 2024 instruction starts Monday January 8th; the export put the event on October 2nd, in the wrong quarter. To replay that against this branch, restore the one changed source file from `main` and the two new tests go red on their own:

```
$ git checkout main -- apps/antalmanac/src/lib/term.ts
$ pnpm vitest run tests/termData.test.tsx tests/download-ics.test.ts

 FAIL  tests/termData.test.tsx > termData > uses the latest term when the events span multiple terms
AssertionError: expected '2023 Fall' to deeply equal '2024 Winter'

 FAIL  tests/download-ics.test.ts > download-ics > schedules custom events in the latest term of a multi-term schedule

 Test Files  2 failed (2)
      Tests  2 failed | 7 passed (9)
```

The fix is in `getDefaultTerm`: rather than returning the first course term encountered, it keeps the course term with the latest `instructionStart`, which makes the result independent of event order. Single-term schedules are unaffected, a schedule with no course events still falls back to the default term, and the .ics export is the only caller that passes events, so nothing else changes behavior. This is the term-selection rule spelled out in #762, derived at export time rather than stored on the custom event — the route the two earlier attempts (#1098, #1403) took before they grew into a database change and stalled.

## Test Plan

```
$ pnpm vitest run

 Test Files  11 passed (11)
      Tests  51 passed (51)
```

The same command on `main` gives 11 files / 46 tests, so the five new tests are the whole difference and no existing test changed state. `pnpm lint` and `oxfmt --check` are both clean on this branch, as they are on `main`. (As CI does before `pnpm test`, `termData.json` was generated first.)

The new tests, each of which fails with the `getDefaultTerm` change reverted and passes with it:

- `termData`: the latest term wins when the events span two terms — asserted with the terms in both list orders, so a passing result cannot come from ordering luck.
- `termData`: a list with no course events still resolves to the default term.
- `download-ics`: a custom event on a 2023 Fall + 2024 Winter schedule is exported at `[2024, 1, 8, 9, 0]` with `FREQ=WEEKLY;BYDAY=MO;INTERVAL=1;COUNT=10`, i.e. anchored to Winter and repeating for Winter's ten weeks.
- `download-ics`: with no courses on the schedule, the exported custom event still falls inside the default term's instruction window.

The existing snapshot test is untouched — its schedule is single-term, so its output is identical. Its inline comment and the `FIXME` above the `getDefaultTerm` call both described the old behavior and were updated to match.

## Issues

Addresses #762.

## How this was managed

This work was tracked as a story on a live board built by importing this repository's issues and pull requests (1,567 stories): the story for this change is at https://eastagiletracker.com/projects/202/stories/64532, and the board it lives on is at https://eastagiletracker.com/projects/202.

![board](https://raw.githubusercontent.com/eastagiletracker/AntAlmanac/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

