### PR TITLE
fix(db): make 0020 migration transaction-safe for fresh databases

### DIFF
--- a/packages/db/migrations/0020_better_auth.sql
+++ b/packages/db/migrations/0020_better_auth.sql
@@ -20,4 +20,4 @@ ALTER TABLE "sessions" ADD COLUMN "ip_address" text;--> statement-breakpoint
 ALTER TABLE "sessions" ADD COLUMN "user_agent" text;--> statement-breakpoint
 ALTER TABLE "users" ADD COLUMN "email_verified" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 CREATE INDEX "session_userId_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
-UPDATE accounts SET provider_id = 'icssc' WHERE account_type = 'OIDC' OR account_type = 'GOOGLE' OR account_type = 'APPLE';
+UPDATE accounts SET provider_id = 'icssc' WHERE account_type::text IN ('OIDC', 'GOOGLE', 'APPLE');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Running `pnpm db:migrate` against a fresh database fails with PostgreSQL error `55P04` (`New enum values must be committed before they can be used`), which blocks the documented local dev setup.

`drizzle-kit migrate` applies all pending migrations inside a single transaction. Migration `0016_sparkling_mauler.sql` adds the enum value `'APPLE'` (`ALTER TYPE "public"."account_type" ADD VALUE 'APPLE'`), and `0020_better_auth.sql` then references that value in an `UPDATE ... WHERE account_type = 'APPLE'`. PostgreSQL forbids using a newly added enum value in the same transaction that added it, so the whole batch rolls back and no tables are created.

This change compares `account_type::text` instead of the enum literal, so the newly added value is not referenced before commit. It is semantically identical (matches the same rows) and has no effect on already-migrated databases, since drizzle only applies migrations newer than the last-applied one and does not re-run `0020`.

Before:
```sql
UPDATE accounts SET provider_id = 'icssc' WHERE account_type = 'OIDC' OR account_type = 'GOOGLE' OR account_type = 'APPLE';
```
After:
```sql
UPDATE accounts SET provider_id = 'icssc' WHERE account_type::text IN ('OIDC', 'GOOGLE', 'APPLE');
```

## Test Plan

- Created a fresh PostgreSQL 16 database and ran `pnpm db:migrate`.
  - Before: failed with `55P04` and created zero tables (single-transaction rollback).
  - After: `migrations applied successfully!`; all 11 tables present (`accounts`, `schedules`, `users`, `verifications`, `friendships`, etc.).
- `pnpm lint` — 0 warnings, 0 errors.
- `pnpm exec vitest run` — 49/49 tests pass.
- Brought the full app up locally against the migrated DB and verified end-to-end: course search autocomplete, live section fetch from the Anteater API, adding a course to the calendar, and a DB-backed tRPC query (`schedule.getGuest`) reaching PostgreSQL.

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-353c419b-6a43-432c-ab0d-871f3a1f8af5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-353c419b-6a43-432c-ab0d-871f3a1f8af5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

