### PR TITLE
feat: add weighted review prompt selection by review count

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds/reviews.ts
+++ b/apps/antalmanac/src/backend/lib/rds/reviews.ts
@@ -1,6 +1,6 @@
 import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import { type NewInstructorReview, instructorReviews, reviewDismissals } from '@packages/db/src/schema';
-import { eq, max } from 'drizzle-orm';
+import { count, eq, inArray, max } from 'drizzle-orm';
 
 export async function insertInstructorReview(
     db: DatabaseOrTransaction,
@@ -38,6 +38,22 @@ export async function getReviewedCombos(db: DatabaseOrTransaction, userId: strin
         })
         .from(instructorReviews)
         .where(eq(instructorReviews.userId, userId));
+}
+
+export async function getReviewCounts(db: DatabaseOrTransaction, courseIds: string[]) {
+    if (courseIds.length === 0) {
+        return [];
+    }
+
+    return db
+        .select({
+            professorId: instructorReviews.professorId,
+            courseId: instructorReviews.courseId,
+            reviewCount: count(),
+        })
+        .from(instructorReviews)
+        .where(inArray(instructorReviews.courseId, courseIds))
+        .groupBy(instructorReviews.courseId, instructorReviews.professorId);
 }
 
 export async function insertReviewDismissal(

--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -7,6 +7,7 @@ import {
     insertReviewDismissal,
 } from '$backend/lib/rds/reviews';
 import { protectedProcedure, router } from '$backend/trpc';
+import { REVIEW_COUNT_BATCH_SIZE } from '$lib/reviewPrompt';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -86,7 +87,7 @@ const reviewRouter = router({
      * Review counts per (professorId, courseId) across all users
      */
     getReviewCounts: protectedProcedure
-        .input(z.object({ courseIds: z.array(z.string()).min(1).max(200) }))
+        .input(z.object({ courseIds: z.array(z.string()).min(1).max(REVIEW_COUNT_BATCH_SIZE) }))
         .query(async ({ input }) => {
             return getReviewCounts(db, input.courseIds);
         }),

--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -1,5 +1,6 @@
 import {
     getDismissedCombos,
+    getReviewCounts,
     getReviewPromptLastInteractionAt,
     getReviewedCombos,
     insertInstructorReview,
@@ -80,6 +81,15 @@ const reviewRouter = router({
     getDismissedCombos: protectedProcedure.query(async ({ ctx }) => {
         return getDismissedCombos(db, ctx.userId);
     }),
+
+    /**
+     * Review counts per (professorId, courseId) across all users
+     */
+    getReviewCounts: protectedProcedure
+        .input(z.object({ courseIds: z.array(z.string()).min(1).max(200) }))
+        .query(async ({ input }) => {
+            return getReviewCounts(db, input.courseIds);
+        }),
 
     /**
      * Latest time the user dismissed a review prompt or submitted a quick review.

--- a/apps/antalmanac/src/lib/reviewPrompt.ts
+++ b/apps/antalmanac/src/lib/reviewPrompt.ts
@@ -1,0 +1,13 @@
+export const REVIEW_COUNT_BATCH_SIZE = 200;
+
+export function chunk<T>(items: T[], size: number): T[][] {
+    if (size < 1) {
+        throw new Error(`chunk size must be >= 1, got ${size}`);
+    }
+
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) {
+        chunks.push(items.slice(i, i + size));
+    }
+    return chunks;
+}

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -43,6 +43,22 @@ const PAST_TERMS_WINDOW = 4;
 /** Min time between review prompts after the user last dismissed, skipped, or submitted. */
 const REVIEW_PROMPT_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
 
+export function reviewSelectionWeight(reviewCount: number): number {
+    return 1 / (reviewCount + 1);
+}
+
+/** Key for looking a candidate up in the review count map. */
+function reviewCountKey(courseId: string, professorId: string): string {
+    return `${courseId}::${professorId}`;
+}
+
+export function weightedOrder<T>(items: T[], weightOf: (item: T) => number): T[] {
+    return items
+        .map((item) => ({ item, key: Math.random() ** (1 / weightOf(item)) }))
+        .sort((a, b) => b.key - a.key)
+        .map(({ item }) => item);
+}
+
 type ReviewPromptState = {
     candidate: ReviewCandidate | null;
     eligibleCandidates: ReviewCandidate[];
@@ -178,13 +194,20 @@ export const useReviewPromptStore = create(
 
                 if (eligible.length === 0) return;
 
-                const shuffled = [...eligible];
-                for (let i = shuffled.length - 1; i > 0; i--) {
-                    const j = Math.floor(Math.random() * (i + 1));
-                    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-                }
-                const first = shuffled[0];
-                toStep('enrollment-confirm', { ...RESET_STATE, candidate: first, eligibleCandidates: shuffled });
+                let reviewCounts = new Map<string, number>();
+                try {
+                    const rows = await trpc.review.getReviewCounts.query({
+                        courseIds: [...new Set(eligible.map((c) => c.courseId))],
+                    });
+                    reviewCounts = new Map(rows.map((r) => [reviewCountKey(r.courseId, r.professorId), r.reviewCount]));
+                } catch {}
+
+                const candidateReviewCount = (candidate: ReviewCandidate) =>
+                    reviewCounts.get(reviewCountKey(candidate.courseId, candidate.professorId)) ?? 0;
+
+                const ordered = weightedOrder(eligible, (c) => reviewSelectionWeight(candidateReviewCount(c)));
+                const first = ordered[0];
+                toStep('enrollment-confirm', { ...RESET_STATE, candidate: first, eligibleCandidates: ordered });
                 logAnalytics(postHog, {
                     category: analyticsEnum.review,
                     action: analyticsEnum.review.actions.PROMPT_SHOWN,
@@ -193,6 +216,7 @@ export const useReviewPromptStore = create(
                         courseTitle: first.courseTitle,
                         professorId: first.professorId,
                         term: first.term.shortName,
+                        reviewCount: candidateReviewCount(first),
                     },
                 });
             },

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -1,5 +1,6 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { trpc } from '$lib/api/trpc';
+import { REVIEW_COUNT_BATCH_SIZE, chunk } from '$lib/reviewPrompt';
 import { termData } from '$lib/term';
 import { postHog } from '$providers/AppPostHogProvider';
 import AppStore from '$stores/AppStore';
@@ -54,7 +55,7 @@ function reviewCountKey(courseId: string, professorId: string): string {
 
 export function weightedOrder<T>(items: T[], weightOf: (item: T) => number): T[] {
     return items
-        .map((item) => ({ item, key: Math.random() ** (1 / weightOf(item)) }))
+        .map((item) => ({ item, key: Math.log(Math.random()) / weightOf(item) }))
         .sort((a, b) => b.key - a.key)
         .map(({ item }) => item);
 }
@@ -195,12 +196,26 @@ export const useReviewPromptStore = create(
                 if (eligible.length === 0) return;
 
                 let reviewCounts = new Map<string, number>();
+                let reviewCountsLoaded = true;
                 try {
-                    const rows = await trpc.review.getReviewCounts.query({
-                        courseIds: [...new Set(eligible.map((c) => c.courseId))],
-                    });
-                    reviewCounts = new Map(rows.map((r) => [reviewCountKey(r.courseId, r.professorId), r.reviewCount]));
-                } catch {}
+                    const batches = chunk([...new Set(eligible.map((c) => c.courseId))], REVIEW_COUNT_BATCH_SIZE);
+                    const results = await Promise.all(
+                        batches.map((courseIds) => trpc.review.getReviewCounts.query({ courseIds }))
+                    );
+
+                    reviewCounts = new Map(
+                        results.flat().map((r) => [reviewCountKey(r.courseId, r.professorId), r.reviewCount])
+                    );
+                } catch (error) {
+                    // Non-fatal by design: counts only bias the ordering, so a failure degrades
+                    // to uniform selection rather than suppressing the prompt entirely. But it
+                    // is reported rather than swallowed — an empty map makes every candidate
+                    // report reviewCount 0, which is indistinguishable from genuinely equal
+                    // counts and would otherwise silently pollute the PROMPT_SHOWN analytics
+                    // used to validate the weighting.
+                    reviewCountsLoaded = false;
+                    console.warn('[ReviewPrompt] Failed to load review counts; selection is unweighted', error);
+                }
 
                 const candidateReviewCount = (candidate: ReviewCandidate) =>
                     reviewCounts.get(reviewCountKey(candidate.courseId, candidate.professorId)) ?? 0;
@@ -217,6 +232,9 @@ export const useReviewPromptStore = create(
                         professorId: first.professorId,
                         term: first.term.shortName,
                         reviewCount: candidateReviewCount(first),
+                        // False means `reviewCount` above is a fallback zero, not a real count.
+                        // Filter these out before analyzing the selection distribution.
+                        reviewCountsLoaded,
                     },
                 });
             },

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -45,7 +45,7 @@ const PAST_TERMS_WINDOW = 4;
 const REVIEW_PROMPT_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function reviewSelectionWeight(reviewCount: number): number {
-    return 1 / (reviewCount + 1);
+    return 1 / (1 + Math.log(reviewCount + 1));
 }
 
 /** Key for looking a candidate up in the review count map. */

--- a/apps/antalmanac/tests/review-prompt-weighting.test.ts
+++ b/apps/antalmanac/tests/review-prompt-weighting.test.ts
@@ -1,3 +1,4 @@
+import { REVIEW_COUNT_BATCH_SIZE, chunk } from '$lib/reviewPrompt';
 import { reviewSelectionWeight, weightedOrder } from '$stores/ReviewPromptStore';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
@@ -26,6 +27,49 @@ describe('reviewSelectionWeight', () => {
         for (let i = 1; i < weights.length; i++) {
             expect(weights[i]).toBeLessThan(weights[i - 1]);
         }
+    });
+});
+
+describe('chunk', () => {
+    test('splits into chunks of at most size', () => {
+        expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns a single chunk when input fits exactly', () => {
+        const items = Array.from({ length: REVIEW_COUNT_BATCH_SIZE }, (_, i) => i);
+        const chunks = chunk(items, REVIEW_COUNT_BATCH_SIZE);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]).toHaveLength(REVIEW_COUNT_BATCH_SIZE);
+    });
+
+    test('splits at one past the batch size — the case that previously failed validation', () => {
+        const items = Array.from({ length: REVIEW_COUNT_BATCH_SIZE + 1 }, (_, i) => i);
+        const chunks = chunk(items, REVIEW_COUNT_BATCH_SIZE);
+
+        expect(chunks).toHaveLength(2);
+        expect(chunks[0]).toHaveLength(REVIEW_COUNT_BATCH_SIZE);
+        expect(chunks[1]).toHaveLength(1);
+
+        expect(chunks.every((c) => c.length <= REVIEW_COUNT_BATCH_SIZE)).toBe(true);
+    });
+
+    test('preserves all items in order across chunks', () => {
+        const items = Array.from({ length: 457 }, (_, i) => i);
+        const chunks = chunk(items, REVIEW_COUNT_BATCH_SIZE);
+
+        expect(chunks).toHaveLength(3);
+        expect(chunks.flat()).toEqual(items);
+        expect(chunks.every((c) => c.length >= 1 && c.length <= REVIEW_COUNT_BATCH_SIZE)).toBe(true);
+    });
+
+    test('returns no chunks for empty input, so no request is made', () => {
+        expect(chunk([], REVIEW_COUNT_BATCH_SIZE)).toEqual([]);
+    });
+
+    test('rejects a non-positive size rather than looping forever', () => {
+        expect(() => chunk([1, 2, 3], 0)).toThrow();
+        expect(() => chunk([1, 2, 3], -1)).toThrow();
     });
 });
 
@@ -95,6 +139,41 @@ describe('weightedOrder', () => {
         }
 
         expect(seenFirst).toEqual(new Set(['unreviewed', 'reviewed']));
+    });
+
+    test('stays random at review counts that underflow a naive u**(1/w) key', () => {
+        const TRIALS = 6_000;
+        const HEAVY = 5_000;
+        const items = ['a', 'b', 'c'];
+        const firstCounts = new Map(items.map((item) => [item, 0]));
+
+        for (let i = 0; i < TRIALS; i++) {
+            const first = weightedOrder(items, () => reviewSelectionWeight(HEAVY))[0];
+            firstCounts.set(first, (firstCounts.get(first) ?? 0) + 1);
+        }
+
+        for (const item of items) {
+            const share = (firstCounts.get(item) ?? 0) / TRIALS;
+            expect(share).toBeGreaterThan(0.25);
+            expect(share).toBeLessThan(0.42);
+        }
+    });
+
+    test('still favors an unreviewed candidate over a heavily reviewed one', () => {
+        const TRIALS = 2_000;
+        const items = [
+            { name: 'unreviewed', count: 0 },
+            { name: 'heavy', count: 5_000 },
+        ];
+
+        let unreviewedFirst = 0;
+        for (let i = 0; i < TRIALS; i++) {
+            if (weightedOrder(items, (item) => reviewSelectionWeight(item.count))[0].name === 'unreviewed') {
+                unreviewedFirst++;
+            }
+        }
+
+        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.99);
     });
 
     test('approximates uniform selection when all weights are equal', () => {

--- a/apps/antalmanac/tests/review-prompt-weighting.test.ts
+++ b/apps/antalmanac/tests/review-prompt-weighting.test.ts
@@ -1,0 +1,114 @@
+import { reviewSelectionWeight, weightedOrder } from '$stores/ReviewPromptStore';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('reviewSelectionWeight', () => {
+    test('is inverse-linear in the review count', () => {
+        expect(reviewSelectionWeight(0)).toBe(1);
+        expect(reviewSelectionWeight(1)).toBe(0.5);
+        expect(reviewSelectionWeight(3)).toBe(0.25);
+        expect(reviewSelectionWeight(9)).toBeCloseTo(0.1);
+    });
+
+    test('stays positive and finite for large counts', () => {
+        for (const count of [0, 1, 50, 10_000]) {
+            const weight = reviewSelectionWeight(count);
+            expect(weight).toBeGreaterThan(0);
+            expect(Number.isFinite(weight)).toBe(true);
+        }
+    });
+
+    test('is monotonically decreasing', () => {
+        const weights = [0, 1, 2, 5, 20].map(reviewSelectionWeight);
+        for (let i = 1; i < weights.length; i++) {
+            expect(weights[i]).toBeLessThan(weights[i - 1]);
+        }
+    });
+});
+
+describe('weightedOrder', () => {
+    test('returns a permutation of the input', () => {
+        const items = ['a', 'b', 'c', 'd', 'e'];
+        const ordered = weightedOrder(items, () => 1);
+
+        expect(ordered).toHaveLength(items.length);
+        expect([...ordered].sort()).toEqual([...items].sort());
+    });
+
+    test('handles empty and single-element input', () => {
+        expect(weightedOrder([], () => 1)).toEqual([]);
+        expect(weightedOrder(['only'], () => 1)).toEqual(['only']);
+    });
+
+    test('does not mutate the input array', () => {
+        const items = ['a', 'b', 'c'];
+        weightedOrder(items, (item) => (item === 'c' ? 10 : 1));
+
+        expect(items).toEqual(['a', 'b', 'c']);
+    });
+
+    test('orders by weight for scripted random draws', () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const items = [
+            { name: 'reviewed-a-lot', count: 99 },
+            { name: 'unreviewed', count: 0 },
+            { name: 'reviewed-once', count: 1 },
+        ];
+        const ordered = weightedOrder(items, (item) => reviewSelectionWeight(item.count));
+
+        expect(ordered.map((item) => item.name)).toEqual(['unreviewed', 'reviewed-once', 'reviewed-a-lot']);
+    });
+
+    test('favors the under-reviewed candidate across many trials', () => {
+        const TRIALS = 10_000;
+        const items = [
+            { name: 'unreviewed', count: 0 }, // weight 1
+            { name: 'reviewed', count: 9 }, // weight 0.1
+        ];
+
+        let unreviewedFirst = 0;
+        for (let i = 0; i < TRIALS; i++) {
+            const ordered = weightedOrder(items, (item) => reviewSelectionWeight(item.count));
+            if (ordered[0].name === 'unreviewed') {
+                unreviewedFirst++;
+            }
+        }
+
+        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.87);
+        expect(unreviewedFirst / TRIALS).toBeLessThan(0.94);
+    });
+
+    test('still reaches heavily-reviewed candidates sometimes', () => {
+        const TRIALS = 2_000;
+        const items = [
+            { name: 'unreviewed', count: 0 },
+            { name: 'reviewed', count: 9 },
+        ];
+
+        const seenFirst = new Set<string>();
+        for (let i = 0; i < TRIALS; i++) {
+            seenFirst.add(weightedOrder(items, (item) => reviewSelectionWeight(item.count))[0].name);
+        }
+
+        expect(seenFirst).toEqual(new Set(['unreviewed', 'reviewed']));
+    });
+
+    test('approximates uniform selection when all weights are equal', () => {
+        const TRIALS = 12_000;
+        const items = ['a', 'b', 'c'];
+        const firstCounts = new Map(items.map((item) => [item, 0]));
+
+        for (let i = 0; i < TRIALS; i++) {
+            const first = weightedOrder(items, () => 1)[0];
+            firstCounts.set(first, (firstCounts.get(first) ?? 0) + 1);
+        }
+
+        for (const item of items) {
+            expect((firstCounts.get(item) ?? 0) / TRIALS).toBeCloseTo(1 / 3, 1);
+        }
+    });
+});

--- a/apps/antalmanac/tests/review-prompt-weighting.test.ts
+++ b/apps/antalmanac/tests/review-prompt-weighting.test.ts
@@ -7,11 +7,11 @@ afterEach(() => {
 });
 
 describe('reviewSelectionWeight', () => {
-    test('is inverse-linear in the review count', () => {
+    test('is inverse-logarithmic in the review count', () => {
         expect(reviewSelectionWeight(0)).toBe(1);
-        expect(reviewSelectionWeight(1)).toBe(0.5);
-        expect(reviewSelectionWeight(3)).toBe(0.25);
-        expect(reviewSelectionWeight(9)).toBeCloseTo(0.1);
+        expect(reviewSelectionWeight(1)).toBeCloseTo(0.5906161, 6);
+        expect(reviewSelectionWeight(3)).toBeCloseTo(0.4190598, 6);
+        expect(reviewSelectionWeight(9)).toBeCloseTo(0.3027931, 6);
     });
 
     test('stays positive and finite for large counts', () => {
@@ -111,7 +111,7 @@ describe('weightedOrder', () => {
         const TRIALS = 10_000;
         const items = [
             { name: 'unreviewed', count: 0 }, // weight 1
-            { name: 'reviewed', count: 9 }, // weight 0.1
+            { name: 'reviewed', count: 9 }, // weight ≈ 0.3028
         ];
 
         let unreviewedFirst = 0;
@@ -122,8 +122,9 @@ describe('weightedOrder', () => {
             }
         }
 
-        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.87);
-        expect(unreviewedFirst / TRIALS).toBeLessThan(0.94);
+        // Exponential-race selection gives P(first) = w / Σw = 1 / (1 + 0.3028) ≈ 0.7676.
+        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.75);
+        expect(unreviewedFirst / TRIALS).toBeLessThan(0.79);
     });
 
     test('still reaches heavily-reviewed candidates sometimes', () => {
@@ -141,24 +142,6 @@ describe('weightedOrder', () => {
         expect(seenFirst).toEqual(new Set(['unreviewed', 'reviewed']));
     });
 
-    test('stays random at review counts that underflow a naive u**(1/w) key', () => {
-        const TRIALS = 6_000;
-        const HEAVY = 5_000;
-        const items = ['a', 'b', 'c'];
-        const firstCounts = new Map(items.map((item) => [item, 0]));
-
-        for (let i = 0; i < TRIALS; i++) {
-            const first = weightedOrder(items, () => reviewSelectionWeight(HEAVY))[0];
-            firstCounts.set(first, (firstCounts.get(first) ?? 0) + 1);
-        }
-
-        for (const item of items) {
-            const share = (firstCounts.get(item) ?? 0) / TRIALS;
-            expect(share).toBeGreaterThan(0.25);
-            expect(share).toBeLessThan(0.42);
-        }
-    });
-
     test('still favors an unreviewed candidate over a heavily reviewed one', () => {
         const TRIALS = 2_000;
         const items = [
@@ -173,7 +156,10 @@ describe('weightedOrder', () => {
             }
         }
 
-        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.99);
+        // The logarithmic formula compresses the gap far more than 1/(n+1) did: at 5000
+        // reviews the weight floor is ≈ 0.1051, not ≈ 0.0002, so P(first) ≈ 0.9049 rather
+        // than ≈ 0.9998. Still a strong preference, but no longer near-certain.
+        expect(unreviewedFirst / TRIALS).toBeGreaterThan(0.87);
     });
 
     test('approximates uniform selection when all weights are equal', () => {


### PR DESCRIPTION
## Summary
Review prompt selection previously did a uniform shuffle over eligible
candidates, so heavily-reviewed professor/course pairs surfaced for
review requests just as often as pairs with zero reviews.

This adds a `getReviewCounts` query (grouped by courseId + professorId,
filtered on the indexed courseId column) and replaces the uniform
shuffle in `initPrompt` with a weighted full-ordering permutation, using
weight = 1 / (1 + log(reviewCount + 1)). The sort key is `log(random) / weight`
rather than `random^(1/weight)`. Counts are global across all
users, not per-user.

This softens the correction significantly at low-to-mid review counts
(e.g. a 50-review pair now gets picked ~17% of the time against an
unreviewed pair, vs ~2% before) in exchange for eliminating starvation
at the high end.

Weighting the full ordering (not just the first pick) means "Review
another" stays weighted too, since `eligibleCandidates` keeps its
existing contract and `advanceToNext` needed no changes.

Counts are batched: the router caps input at
`REVIEW_COUNT_BATCH_SIZE` (200), so the store dedupes course IDs, chunks
them, and issues one query per batch in parallel (new shared module
`lib/reviewPrompt.ts` holds `chunk` and the batch size). Without this, a
user with more than 200 distinct courses would trip Zod validation and
lose weighting entirely. The batches run under one `Promise.all`, so a
single failed batch currently discards all counts, not just that
batch's.

The count fetch happens after the eligible-candidate filter, rather
than joining the existing `Promise.all` of eligibility queries, since
the cooldown early-return fires on most app loads. The fetch is wrapped
in its own try/catch that leaves the count map empty on failure, which
naturally degrades to uniform weighting rather than suppressing the
prompt entirely.

`reviewCount` and `reviewCountsLoaded` are logged on `PROMPT_SHOWN`
the flag matters because an empty map makes every candidate report
`reviewCount: 0`, indistinguishable from a genuinely-zero-review pair.
## Test Plan
- Manually verified against a seeded local DB: seeded a schedule with
  three real 2026 Spring COMPSCI Lec sections and gave the pairs distinct
  review counts. Confirmed end-to-end that `getReviewCounts` fires, that
  its `courseId::professorId` keys match the candidate keys, that the
  zero-count pair (which the `GROUP BY` returns no row for) resolves to 0
  via the `?? 0` fallback, and that the resulting weights are exactly
  `1 / (1 + ln(n+1))`. The full ordering is produced, not just the
  first pick, so `advanceToNext` inherits the weighting.
- Confirmed the fetch-placement decision: on a cooldown-suppressed load,
  `initPrompt` returns before the count query, so `getReviewCounts` never
  fires. It only appears on loads that actually surface a prompt.
- Incidentally exercised the dismissal path: dismissing wrote a
  `reviewDismissals` row, the 7-day cooldown blocked subsequent prompts,
  and the combo was excluded from `eligible` thereafter.
## Issues

Closes #1706 



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

