### PR TITLE
fix: clear auth.icssc sid cookie on iOS App Store logout

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -2,6 +2,7 @@ import analyticsEnum, { analyticsIdentifyUser, logAnalytics } from '$lib/analyti
 import { trpc } from '$lib/api/trpc';
 import { getSignInUrl } from '$lib/auth/authActions';
 import { Provider } from '$lib/auth/authTypes';
+import { getSignInAuthorizationUrlParams } from '$lib/auth/authUtils';
 import { warnMultipleTerms } from '$lib/helpers';
 import { shouldIgnoreShortcutTarget } from '$lib/keyboardShortcuts';
 import { setLocalStorageDataCache, setLocalStorageUserId } from '$lib/localStorage';
@@ -395,7 +396,10 @@ const cacheSchedule = () => {
 export const loginUser = async (provider: Provider, { silent = false, postHog }: LoginUserOptions = {}) => {
     try {
         const authUrl = await getSignInUrl(provider, {
-            authorizationUrlParams: silent ? { prompt: 'none' } : undefined,
+            authorizationUrlParams: getSignInAuthorizationUrlParams({
+                silent,
+                cookieString: document.cookie,
+            }),
             returnUrl: `${window.location.pathname}${window.location.search}${window.location.hash}`,
         });
 

--- a/apps/antalmanac/src/lib/auth/authUtils.ts
+++ b/apps/antalmanac/src/lib/auth/authUtils.ts
@@ -1,5 +1,51 @@
 import { Provider } from '$lib/auth/authTypes';
 
+/** Must match `platformCookie` in apps/ios/src/AntAlmanac/Settings.swift. */
+export const IOS_APP_STORE_PLATFORM_COOKIE = {
+    name: 'app-platform',
+    value: 'iOS App Store',
+} as const;
+
+export function hasIosAppStorePlatformCookie(cookieString: string): boolean {
+    const { name, value } = IOS_APP_STORE_PLATFORM_COOKIE;
+    const encodedValue = encodeURIComponent(value);
+    return cookieString.split(';').some((part) => {
+        const trimmed = part.trim();
+        const separator = trimmed.indexOf('=');
+        if (separator === -1) {
+            return false;
+        }
+        const cookieName = trimmed.slice(0, separator);
+        const cookieValue = trimmed.slice(separator + 1);
+        return cookieName === name && (cookieValue === value || cookieValue === encodedValue);
+    });
+}
+
+/**
+ * OIDC `prompt` for /authorize.
+ *
+ * auth.icssc.club only skips an existing `sid` session when `prompt=consent`
+ * (`prompt=login` is not in its query schema). The iOS App Store wrapper signs
+ * in via ASWebAuthenticationSession, so `sid` lives in Safari. Until that
+ * session is revoked, a leftover cookie would ignore the chosen provider
+ * (Google vs Apple). Interactive iOS sign-in therefore always sends consent.
+ */
+export function getSignInAuthorizationUrlParams({
+    silent,
+    cookieString,
+}: {
+    silent: boolean;
+    cookieString: string;
+}): { prompt: 'none' } | { prompt: 'consent' } | undefined {
+    if (silent) {
+        return { prompt: 'none' };
+    }
+    if (hasIosAppStorePlatformCookie(cookieString)) {
+        return { prompt: 'consent' };
+    }
+    return undefined;
+}
+
 export const getSafeAuthRedirectPath = (
     redirectUrl: string | null | undefined,
     requestUrl: string | null | undefined,

--- a/apps/antalmanac/tests/authUtils.test.ts
+++ b/apps/antalmanac/tests/authUtils.test.ts
@@ -29,9 +29,9 @@ describe('hasIosAppStorePlatformCookie', () => {
     });
 
     test('detects a URI-encoded cookie value among other cookies', () => {
-        expect(
-            hasIosAppStorePlatformCookie(`icssc_logged_in=1; ${name}=${encodeURIComponent(value)}; other=1`)
-        ).toBe(true);
+        expect(hasIosAppStorePlatformCookie(`icssc_logged_in=1; ${name}=${encodeURIComponent(value)}; other=1`)).toBe(
+            true
+        );
     });
 
     test('ignores a similarly named cookie with a different value', () => {

--- a/apps/antalmanac/tests/authUtils.test.ts
+++ b/apps/antalmanac/tests/authUtils.test.ts
@@ -1,4 +1,9 @@
-import { getSafeAuthRedirectPath } from '$lib/auth/authUtils';
+import {
+    IOS_APP_STORE_PLATFORM_COOKIE,
+    getSafeAuthRedirectPath,
+    getSignInAuthorizationUrlParams,
+    hasIosAppStorePlatformCookie,
+} from '$lib/auth/authUtils';
 import { describe, expect, test } from 'vitest';
 
 const VALID_URL = '/importRoadmap=1234&term=2026+Spring';
@@ -13,5 +18,44 @@ describe('getSafeAuthRedirectPath', () => {
 
     test('Returns root if URL origin is not allowed', () => {
         expect(getSafeAuthRedirectPath('https://www.google.com', ALLOWED_ORIGIN, ALLOWED_ORIGIN)).toStrictEqual('/');
+    });
+});
+
+describe('hasIosAppStorePlatformCookie', () => {
+    const { name, value } = IOS_APP_STORE_PLATFORM_COOKIE;
+
+    test('detects the native iOS platform cookie', () => {
+        expect(hasIosAppStorePlatformCookie(`${name}=${value}`)).toBe(true);
+    });
+
+    test('detects a URI-encoded cookie value among other cookies', () => {
+        expect(
+            hasIosAppStorePlatformCookie(`icssc_logged_in=1; ${name}=${encodeURIComponent(value)}; other=1`)
+        ).toBe(true);
+    });
+
+    test('ignores a similarly named cookie with a different value', () => {
+        expect(hasIosAppStorePlatformCookie(`${name}=android`)).toBe(false);
+        expect(hasIosAppStorePlatformCookie('')).toBe(false);
+    });
+});
+
+describe('getSignInAuthorizationUrlParams', () => {
+    const iosCookies = `${IOS_APP_STORE_PLATFORM_COOKIE.name}=${IOS_APP_STORE_PLATFORM_COOKIE.value}`;
+
+    test('uses prompt=none for silent SSO even in the iOS app', () => {
+        expect(getSignInAuthorizationUrlParams({ silent: true, cookieString: iosCookies })).toStrictEqual({
+            prompt: 'none',
+        });
+    });
+
+    test('uses prompt=consent for interactive iOS App Store sign-in', () => {
+        expect(getSignInAuthorizationUrlParams({ silent: false, cookieString: iosCookies })).toStrictEqual({
+            prompt: 'consent',
+        });
+    });
+
+    test('omits prompt for interactive browser sign-in', () => {
+        expect(getSignInAuthorizationUrlParams({ silent: false, cookieString: '' })).toBeUndefined();
     });
 });

--- a/apps/antalmanac/tests/ios-auth-handoff.test.ts
+++ b/apps/antalmanac/tests/ios-auth-handoff.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Mirrors `shouldHandOffOidcToASWebAuthenticationSession` and
+ * `authHandoffCallback` in apps/ios/src/AntAlmanac/Settings.swift so the
+ * Safari vs WKWebView cookie-jar contract is executable without Xcode.
+ */
+function shouldHandOffOidcToASWebAuthenticationSession(urlString: string): boolean {
+    const url = new URL(urlString);
+    if (!url.hostname.includes('auth.icssc.club')) {
+        return false;
+    }
+    if (url.pathname.startsWith('/logout')) {
+        return true;
+    }
+    if (!url.pathname.startsWith('/authorize')) {
+        return false;
+    }
+    return url.searchParams.get('prompt') !== 'none';
+}
+
+function authHandoffCallback(urlString: string): { host: string; path: string } {
+    const url = new URL(urlString);
+    const isLogout = url.pathname.startsWith('/logout');
+    const paramName = isLogout ? 'post_logout_redirect_uri' : 'redirect_uri';
+    const redirect = url.searchParams.get(paramName);
+    const redirectURI = redirect ? new URL(redirect) : null;
+    const host = redirectURI?.hostname ?? 'antalmanac.com';
+    const defaultPath = isLogout ? '/' : '/api/auth/oauth2/callback/icssc';
+    const rawPath = redirectURI?.pathname ?? defaultPath;
+    const path = rawPath === '' ? '/' : rawPath;
+    return { host, path };
+}
+
+describe('iOS ASW handoff URL contract', () => {
+    test('hands off interactive authorize and logout, not silent SSO', () => {
+        expect(
+            shouldHandOffOidcToASWebAuthenticationSession(
+                'https://auth.icssc.club/authorize?redirect_uri=https://antalmanac.com/api/auth/oauth2/callback/icssc'
+            )
+        ).toBe(true);
+        expect(
+            shouldHandOffOidcToASWebAuthenticationSession(
+                'https://auth.icssc.club/logout?post_logout_redirect_uri=https://antalmanac.com'
+            )
+        ).toBe(true);
+        expect(
+            shouldHandOffOidcToASWebAuthenticationSession(
+                'https://auth.icssc.club/authorize?prompt=none&redirect_uri=https://antalmanac.com/api/auth/oauth2/callback/icssc'
+            )
+        ).toBe(false);
+        expect(
+            shouldHandOffOidcToASWebAuthenticationSession('https://auth.icssc.club/.well-known/openid-configuration')
+        ).toBe(false);
+    });
+
+    test('logout callback uses post_logout_redirect_uri origin path', () => {
+        expect(
+            authHandoffCallback('https://auth.icssc.club/logout?post_logout_redirect_uri=https://antalmanac.com')
+        ).toStrictEqual({ host: 'antalmanac.com', path: '/' });
+        expect(
+            authHandoffCallback(
+                'https://auth.icssc.club/authorize?redirect_uri=https://antalmanac.com/api/auth/oauth2/callback/icssc'
+            )
+        ).toStrictEqual({ host: 'antalmanac.com', path: '/api/auth/oauth2/callback/icssc' });
+    });
+});

--- a/apps/ios/src/AntAlmanac/Settings.swift
+++ b/apps/ios/src/AntAlmanac/Settings.swift
@@ -14,19 +14,37 @@ let rootUrl = URL(string: "https://antalmanac.com")!
 // This should also appear in Info.plist
 let allowedOrigins: [String] = ["antalmanac.com"]
 
-// IdP host for ICSSC. Not every path on this host should use ASWebAuthenticationSession —
-// only interactive OAuth/OIDC *authorize* requests. See
-// `shouldHandOffOidcToASWebAuthenticationSession(_:)`.
+// IdP host for ICSSC. Interactive /authorize and /logout use ASWebAuthenticationSession
+// so they share Safari's cookie jar. See `shouldHandOffOidcToASWebAuthenticationSession(_:)`.
 let authOrigins: [String] = ["auth.icssc.club"]
 
-/// `true` only for URLs that must run in a real Safari context (Google OAuth, passkeys).
-/// `/logout` and other IdP pages load in the WKWebView so `post_logout_redirect_uri` works
-/// and users don't see a bogus "sign in" sheet on logout.
+struct AuthHandoffCallback {
+    let host: String
+    let path: String
+}
+
+func isOidcLogoutURL(_ url: URL) -> Bool {
+    guard let host = url.host else { return false }
+    guard authOrigins.contains(where: { host.range(of: $0) != nil }) else { return false }
+    return url.path.hasPrefix("/logout")
+}
+
+/// `true` for URLs that must run in Safari (ASWebAuthenticationSession), not WKWebView.
+///
+/// Interactive `/authorize` needs Safari for Google OAuth and passkeys.
+/// `/logout` must also run in Safari: sign-in writes the HttpOnly `sid` cookie
+/// into Safari's jar, and auth.icssc.club/logout only deletes that session when
+/// it receives the cookie. WKWebView has a separate jar, so in-app logout
+/// appears to succeed while the next ASW sign-in silently reuses the old
+/// account (icssc/AntAlmanac#1829, icssc/auth#8).
 func shouldHandOffOidcToASWebAuthenticationSession(_ url: URL) -> Bool {
     guard let host = url.host else { return false }
     guard authOrigins.contains(where: { host.range(of: $0) != nil }) else { return false }
-    // OIDC spec: authorization request hits .../authorize. (auth.icssc.club)
-    // Logout, discovery, JWKS, etc. stay in-app.
+
+    if url.path.hasPrefix("/logout") {
+        return true
+    }
+
     guard url.path.hasPrefix("/authorize") else { return false }
 
     // prompt=none is a silent-SSO probe (AutoSignIn). auth.icssc.club either
@@ -50,6 +68,24 @@ func shouldHandOffOidcToASWebAuthenticationSession(_ url: URL) -> Bool {
     }
 
     return true
+}
+
+/// HTTPS callback that should terminate ASWebAuthenticationSession.
+/// Authorize uses `redirect_uri`; logout uses `post_logout_redirect_uri`.
+func authHandoffCallback(for url: URL) -> AuthHandoffCallback {
+    let isLogout = url.path.hasPrefix("/logout")
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let paramName = isLogout ? "post_logout_redirect_uri" : "redirect_uri"
+    let redirectURI = components?.queryItems?
+        .first(where: { $0.name == paramName })?
+        .value
+        .flatMap { URL(string: $0) }
+
+    let host = redirectURI?.host ?? "antalmanac.com"
+    let defaultPath = isLogout ? "/" : "/api/auth/oauth2/callback/icssc"
+    let rawPath = redirectURI?.path ?? defaultPath
+    let path = rawPath.isEmpty ? "/" : rawPath
+    return AuthHandoffCallback(host: host, path: path)
 }
 
 let platformCookie = Cookie(name: "app-platform", value: "iOS App Store")

--- a/apps/ios/src/AntAlmanac/ViewController.swift
+++ b/apps/ios/src/AntAlmanac/ViewController.swift
@@ -264,18 +264,21 @@ extension ViewController: WKScriptMessageHandler {
 // MARK: - ASWebAuthenticationSession handoff
 //
 // When the WKWebView tries to navigate to auth.icssc.club (the ICSSC OIDC
-// issuer), we cancel the navigation and re-run the flow inside an
-// ASWebAuthenticationSession. Reasons:
+// issuer) for interactive authorize or logout, we cancel the navigation and
+// re-run the flow inside an ASWebAuthenticationSession. Reasons:
 //   1. Google rejects OAuth inside embedded webviews with `disallowed_useragent`
 //      since 2021-09-30 (Google Developers Blog).
 //   2. Passkeys / WebAuthn bound to a third-party RP ID (e.g. google.com) only
 //      work in top-level Safari context, not in a WKWebView owned by our app
 //      (passkeys.dev, Apple docs on passkey use in web browsers).
+//   3. Logout must see the HttpOnly `sid` cookie that ASW wrote into Safari.
+//      Hitting /logout in WKWebView cannot send that cookie, so the IdP
+//      session survives and the next sign-in is silent SSO.
 //
-// ASW uses the `redirect_uri` query param from auth.icssc.club/authorize (Better
-// Auth: `/api/auth/oauth2/callback/icssc`). Domain ownership is validated via
-// the `webcredentials` AASA entry; that callback path is intentionally not
-// listed under `applinks` so mobile Safari logins are not hijacked into the app.
+// ASW callback comes from `redirect_uri` (authorize) or `post_logout_redirect_uri`
+// (logout). Domain ownership is validated via the `webcredentials` AASA entry;
+// OAuth callback paths are intentionally not listed under `applinks` so mobile
+// Safari logins are not hijacked into the app.
 //
 // On callback, load the redirect URL in the WKWebView. Better Auth PKCE cookies
 // from the original sign-in request remain in the WKWebView jar.
@@ -285,30 +288,21 @@ extension ViewController: ASWebAuthenticationPresentationContextProviding {
     }
 
     func startAuthSession(url: URL, webView: WKWebView) {
-        // Derive the ASW callback from the redirect_uri embedded in the OIDC
-        // authorize URL. Each ICSSC app (AntAlmanac, peterportal-client planner)
-        // registers its own redirect_uri with auth.icssc.club and includes it as
-        // a query param on /authorize, so we can route ASW's termination to the
-        // correct Universal Link path without hard-coding per-app knowledge here.
+        // Derive the ASW callback from the OIDC URL:
+        //   - /authorize: `redirect_uri` (Better Auth `/api/auth/oauth2/callback/icssc`)
+        //   - /logout: `post_logout_redirect_uri` (usually https://antalmanac.com)
         //
+        // Each ICSSC app registers its own redirect_uri with auth.icssc.club.
         // Every registered callback must also be listed in the AASA file
         // (apps/antalmanac/src/app/apple-app-site-association/route.ts) — ASW's
-        // .https(host:path:) requires AASA verification on iOS 17.4+. If a new
-        // ICSSC app is added with its own OAuth callback on antalmanac.com,
-        // append the path there.
-        let authComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        let redirectUri = authComponents?
-            .queryItems?
-            .first(where: { $0.name == "redirect_uri" })?
-            .value
-            .flatMap { URL(string: $0) }
-
-        let callbackHost = redirectUri?.host ?? "antalmanac.com"
-        let callbackPath = redirectUri?.path ?? "/api/auth/oauth2/callback/icssc"
+        // .https(host:path:) requires AASA verification on iOS 17.4+. Logout
+        // returns to the site origin, which is covered by `webcredentials`.
+        let callbackTarget = authHandoffCallback(for: url)
+        let isLogout = isOidcLogoutURL(url)
 
         let callback: ASWebAuthenticationSession.Callback = .https(
-            host: callbackHost,
-            path: callbackPath
+            host: callbackTarget.host,
+            path: callbackTarget.path
         )
 
         let session = ASWebAuthenticationSession(
@@ -319,17 +313,28 @@ extension ViewController: ASWebAuthenticationPresentationContextProviding {
 
             if let error = error {
                 let nsError = error as NSError
-                // User-cancelled is expected; ignore silently.
+                // User-cancelled is expected for login. For logout, Better Auth
+                // already cleared the first-party session, so reload so the UI
+                // is not stuck in a signed-in state.
                 if nsError.domain == ASWebAuthenticationSessionError.errorDomain &&
                     nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                    if isLogout {
+                        webView?.load(URLRequest(url: rootUrl))
+                    }
                     return
                 }
                 print("ASWebAuthenticationSession error: \(error)")
+                if isLogout {
+                    webView?.load(URLRequest(url: rootUrl))
+                }
                 return
             }
 
             guard let callbackURL = callbackURL,
                   var components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
+                if isLogout {
+                    webView?.load(URLRequest(url: rootUrl))
+                }
                 return
             }
 
@@ -341,6 +346,8 @@ extension ViewController: ASWebAuthenticationPresentationContextProviding {
 
             if let redirectURL = components.url {
                 webView?.load(URLRequest(url: redirectURL))
+            } else if isLogout {
+                webView?.load(URLRequest(url: rootUrl))
             }
         }
         session.presentationContextProvider = self

--- a/apps/ios/src/AntAlmanac/WebView.swift
+++ b/apps/ios/src/AntAlmanac/WebView.swift
@@ -125,13 +125,14 @@ extension ViewController: WKUIDelegate, WKDownloadDelegate {
                 let handOffOidc = authOrigins.contains(where: { requestHost.range(of: $0) != nil })
                     && shouldHandOffOidcToASWebAuthenticationSession(requestUrl)
                 if handOffOidc {
-                    // Only /authorize: Google + passkeys; see Settings.swift. Logout (/logout) etc. stay in WKWebView.
+                    // Interactive /authorize (Google + passkeys) and /logout (Safari sid cookie).
+                    // See Settings.swift. prompt=none stays in WKWebView.
                     decisionHandler(.cancel)
                     self.startAuthSession(url: requestUrl, webView: webView)
                     return
                 }
 
-                // Remaining IdP URLs (e.g. /logout with post_logout_redirect_uri) load in the webview
+                // Remaining IdP URLs (discovery, JWKS) load in the webview
                 if authOrigins.contains(where: { requestHost.range(of: $0) != nil }) {
                     decisionHandler(.allow)
                     return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The iOS App Store app is a WKWebView wrapper, not a standalone PWA. Interactive sign-in is handed off to `ASWebAuthenticationSession`, so the auth.icssc.club HttpOnly `sid` cookie is stored in **Safari's** cookie jar.

Logout previously navigated to `/logout` **inside WKWebView**. That jar does not have `sid`, so `auth.icssc.club/logout` could not delete the KV session or expire the cookie. The next sign-in then reused the leftover session — including signing into Google after the user tapped Apple ([#1829](https://github.com/icssc/AntAlmanac/issues/1829), [icssc/auth#8](https://github.com/icssc/auth/issues/8)).

This change:

- Hands `/logout` to `ASWebAuthenticationSession` so `/logout` receives Safari's `sid`, deletes the IdP session, and clears the cookie. The logout Safari sheet is required until a back-channel revoke endpoint exists.
- Reloads the app if the logout sheet is cancelled, because Better Auth has already cleared the first-party session.
- Sends `prompt=consent` on **interactive** iOS App Store sign-in. auth.icssc.club only skips an existing `sid` when `prompt=consent` (`prompt=login` is not accepted). Silent SSO (`prompt=none`) is unchanged. This also covers already-shipped app binaries once the website is deployed.

## Test Plan

- [x] Unit tests: `hasIosAppStorePlatformCookie`, `getSignInAuthorizationUrlParams`, and iOS ASW handoff URL contract (`pnpm exec vitest run apps/antalmanac/tests/authUtils.test.ts apps/antalmanac/tests/ios-auth-handoff.test.ts`)
- [ ] iOS (device or simulator with the native app): sign in with Google, sign out, sign in with Apple — should prompt for Apple rather than silently restoring Google
- [ ] Same flow Google → sign out → Google should prompt again instead of auto-SSO
- [ ] Cancelling the logout Safari sheet still leaves the user signed out of AntAlmanac
- [ ] Browser (non-iOS-app) sign-in/sign-out is unchanged (no `prompt=consent` unless the `app-platform` cookie is present)
- [ ] Silent AutoSignIn (`prompt=none`) still stays in WKWebView and does not pop a Safari sheet

## Issues

Closes #1829

## Future Followup

A back-channel revoke endpoint ([icssc/auth#8](https://github.com/icssc/auth/issues/8)) would invalidate the IdP session without an ASW sheet. This repo cannot add that endpoint (no write access to `icssc/auth`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e12f900-c9f1-4dfa-8288-39d55a6a2238?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e12f900-c9f1-4dfa-8288-39d55a6a2238&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

