### PR TITLE
feat: Update No courses screen text

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/PlannerCourseLinkBanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/PlannerCourseLinkBanner.tsx
@@ -42,7 +42,8 @@ export function PlannerCourseLinkBanner({ deptValue, courseNumber }: PlannerCour
                 }}
             >
                 <span>
-                    Search for <span style={{ textDecoration: 'underline' }}>{courseLabel}</span> on AntAlmanac Planner!
+                    No sections for <span style={{ textDecoration: 'underline' }}>{courseLabel}</span> in this session.
+                    Please see class information on AntAlmanac Planner!
                 </span>
             </Alert>
         </Link>


### PR DESCRIPTION
## Summary
Changes the no courses screen text to match the image

## Test Plan

## Issues

Closes #1264

<!-- [Optional]
## Future Followup
-->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/AntAlmanac/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

